### PR TITLE
feat: implement progress tracking for media uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2485,6 +2486,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.11.5.tgz",
       "integrity": "sha512-uNp8/Rv12GrrM/dfyqzZCftA2i/5X9axmiEtUDmyQw+0S17EV5s9gudOgdIIGr849LmbAk3At2CBZMqiQJVwNw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.13",
         "@firebase/logger": "0.4.4",
@@ -2551,6 +2553,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.54.tgz",
       "integrity": "sha512-Vwf29tV/5bHEnp+VPgNWOFMbFG+RSur2ntmzZ19Plp5dJOtoo2nQS817COALLaHlebG/Xf/P5PVHyeQNcSVCqQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.11.5",
         "@firebase/component": "0.6.13",
@@ -2566,7 +2569,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.1",
@@ -3017,6 +3021,7 @@
       "integrity": "sha512-PzSrhIr++KI6y4P6C/IdgBNMkEx0Ex6554/cYd0Hm+ovyFSJtJXqb/3OSIdnBoa2cpwZT1/GW56EmRc5qEc5fQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -4126,6 +4131,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4644,6 +4650,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -5518,6 +5525,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8874,6 +8882,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9733,6 +9742,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10097,6 +10107,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -10187,6 +10198,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/js/services/storage-service.js
+++ b/src/js/services/storage-service.js
@@ -4,6 +4,7 @@
 import {
   ref,
   uploadBytes,
+  uploadBytesResumable,
   getDownloadURL,
   deleteObject,
   listAll,
@@ -32,6 +33,49 @@ export class StorageService {
       console.error('Error uploading file:', error);
       throw new Error('Failed to upload file');
     }
+  }
+
+  /**
+   * Uploads a file to Firebase Storage with progress tracking.
+   * @param {File|Blob} file - The file to upload
+   * @param {string} path - The storage path
+   * @param {Function} [onProgress] - Callback for progress (percent: number) => void
+   * @returns {Promise<string>} The download URL of the uploaded file
+   */
+  static uploadFileWithProgress(file, path, onProgress) {
+    return new Promise((resolve, reject) => {
+      try {
+        const storage = getStorageInstance();
+        const storageRef = ref(storage, path);
+        const uploadTask = uploadBytesResumable(storageRef, file);
+
+        uploadTask.on(
+          'state_changed',
+          (snapshot) => {
+            const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+            if (onProgress && typeof onProgress === 'function') {
+              onProgress(progress);
+            }
+          },
+          (error) => {
+            console.error('Error uploading file with progress:', error);
+            reject(new Error('Failed to upload file'));
+          },
+          async () => {
+            try {
+              const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
+              resolve(downloadURL);
+            } catch (error) {
+              console.error('Error getting download URL:', error);
+              reject(new Error('Failed to get download URL'));
+            }
+          },
+        );
+      } catch (error) {
+        console.error('Error initiating upload:', error);
+        reject(new Error('Failed to initiate upload'));
+      }
+    });
   }
 
   /**

--- a/src/js/utils/recipes/recipe-media-utils.js
+++ b/src/js/utils/recipes/recipe-media-utils.js
@@ -178,18 +178,8 @@ export async function uploadMediaInstructionFile(file, recipeId, userId, onProgr
       throw new Error('Unable to determine media type');
     }
 
-    // TODO: Implement progress tracking with Firebase Storage 'state_changed' listener
-    // For now, onProgress is accepted but not used (can be implemented later)
-    if (onProgress && typeof onProgress === 'function') {
-      onProgress(0);
-    }
-
-    // Upload to Firebase Storage
-    await StorageService.uploadFile(file, storagePath);
-
-    if (onProgress && typeof onProgress === 'function') {
-      onProgress(100);
-    }
+    // Upload to Firebase Storage with progress tracking
+    await StorageService.uploadFileWithProgress(file, storagePath, onProgress);
 
     // Build and return metadata
     const metadata = {

--- a/tests/common/mocks/firebase-storage.mock.js
+++ b/tests/common/mocks/firebase-storage.mock.js
@@ -18,6 +18,7 @@ jest.unstable_mockModule('firebase/storage', () => ({
   getStorage: jest.fn(() => 'mockStorage'),
   ref: jest.fn((storage, path) => ({ storage, path })),
   uploadBytes: jest.fn(),
+  uploadBytesResumable: jest.fn(),
   getDownloadURL: jest.fn(),
   deleteObject: jest.fn(),
   listAll: jest.fn(),

--- a/tests/services/storage-service.test.mjs
+++ b/tests/services/storage-service.test.mjs
@@ -7,7 +7,13 @@ import '../common/mocks/firebase-storage.mock.js';
 import '../common/mocks/firebase-service.mock.js';
 
 describe('StorageService', () => {
-  let StorageService, ref, uploadBytes, getDownloadURL, deleteObject, firebaseService;
+  let StorageService,
+    ref,
+    uploadBytes,
+    uploadBytesResumable,
+    getDownloadURL,
+    deleteObject,
+    firebaseService;
   const mockStorage = 'mockStorage';
   const mockFile = new Blob(['test content'], { type: 'text/plain' });
   const mockPath = 'uploads/test.txt';
@@ -17,7 +23,9 @@ describe('StorageService', () => {
     jest.resetModules();
     // Dynamically import after mocks are in place
     ({ StorageService } = await import('../../src/js/services/storage-service.js'));
-    ({ ref, uploadBytes, getDownloadURL, deleteObject } = await import('firebase/storage'));
+    ({ ref, uploadBytes, uploadBytesResumable, getDownloadURL, deleteObject } = await import(
+      'firebase/storage'
+    ));
     firebaseService = await import('../../src/js/services/firebase-service.js');
     firebaseService.getStorageInstance.mockReturnValue(mockStorage);
     ref.mockImplementation((storage, path) => ({ storage, path }));
@@ -43,6 +51,78 @@ describe('StorageService', () => {
       await expect(StorageService.uploadFile(mockFile, mockPath)).rejects.toThrow(
         'Failed to upload file',
       );
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('uploadFileWithProgress', () => {
+    let mockUploadTask;
+    let onStateChanged;
+    let onError;
+    let onComplete;
+
+    beforeEach(() => {
+      mockUploadTask = {
+        on: jest.fn((event, next, error, complete) => {
+          onStateChanged = next;
+          onError = error;
+          onComplete = complete;
+        }),
+        snapshot: {
+          ref: { storage: mockStorage, path: mockPath },
+          bytesTransferred: 0,
+          totalBytes: 100,
+        },
+      };
+      uploadBytesResumable.mockReturnValue(mockUploadTask);
+    });
+
+    it('uploads a file, reports progress, and returns download URL', async () => {
+      getDownloadURL.mockResolvedValue(mockUrl);
+      const onProgress = jest.fn();
+
+      const uploadPromise = StorageService.uploadFileWithProgress(mockFile, mockPath, onProgress);
+
+      // Simulate progress
+      mockUploadTask.snapshot.bytesTransferred = 50;
+      onStateChanged(mockUploadTask.snapshot);
+      expect(onProgress).toHaveBeenCalledWith(50);
+
+      // Simulate completion
+      await onComplete();
+
+      const url = await uploadPromise;
+
+      expect(firebaseService.getStorageInstance).toHaveBeenCalled();
+      expect(ref).toHaveBeenCalledWith(mockStorage, mockPath);
+      expect(uploadBytesResumable).toHaveBeenCalledWith(
+        { storage: mockStorage, path: mockPath },
+        mockFile,
+      );
+      expect(getDownloadURL).toHaveBeenCalledWith({ storage: mockStorage, path: mockPath });
+      expect(url).toBe(mockUrl);
+    });
+
+    it('handles upload errors', async () => {
+      const uploadPromise = StorageService.uploadFileWithProgress(mockFile, mockPath);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Simulate error
+      onError(new Error('Upload failed'));
+
+      await expect(uploadPromise).rejects.toThrow('Failed to upload file');
+      errorSpy.mockRestore();
+    });
+
+    it('handles getDownloadURL errors', async () => {
+      getDownloadURL.mockRejectedValue(new Error('URL failed'));
+      const uploadPromise = StorageService.uploadFileWithProgress(mockFile, mockPath);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Simulate completion
+      await onComplete();
+
+      await expect(uploadPromise).rejects.toThrow('Failed to get download URL');
       errorSpy.mockRestore();
     });
   });


### PR DESCRIPTION
- Added `uploadFileWithProgress` to `StorageService` using `uploadBytesResumable`
- Updated `uploadMediaInstructionFile` in `recipe-media-utils.js` to use the new method
- Added unit tests for `uploadFileWithProgress`
- Added mock for `uploadBytesResumable` in storage mock