### PR TITLE
⚡ Bolt: Non-blocking Component Preloading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** Firestore `getDoc` calls are not automatically deduped or cached in memory across components if not using a listener. Centralizing user data fetching in `AuthService` and listening for update events (like `recipe-favorite-changed`) significantly reduces redundant network requests.
 **Action:** Always prefer a centralized data service with caching and event listeners for frequently accessed, user-specific data that changes based on UI actions.
+
+## 2025-10-25 - [Non-blocking Component Preloading]
+
+**Learning:** `await`ing every component import in the application initialization path (e.g., in `initializeSPA`) delays the Time to Interactive (TTI) because the router waits for all components to load before rendering.
+**Action:** Separate truly critical shell components (like `navigation-script`) from supplemental ones (like Auth and Search). `await` only critical shell dependencies to avoid race conditions, but let supplemental ones load in parallel via non-blocking `Promise.all().catch()`.

--- a/src/app.js
+++ b/src/app.js
@@ -30,17 +30,17 @@ async function initializeSPA() {
   try {
     initFirebase(firebaseConfig);
 
-    // Preload critical components in parallel
-    await Promise.all([
+    // Start loading supplemental components in parallel (non-blocking for faster TTI)
+    Promise.all([
       import('./lib/auth/auth-controller.js'),
       import('./lib/auth/components/auth-avatar.js'),
       import('./lib/auth/components/auth-content.js'),
-    ]);
-
-    await Promise.all([
       import('./lib/search/header-search-bar/header-search-bar.js'),
-      import('./js/navigation-script.js'),
-    ]);
+    ]).catch((err) => console.warn('Failed to preload supplemental components:', err));
+
+    // Await components critical for the UI shell to avoid race conditions
+    // (e.g., navigation-script handles link interception which the router depends on)
+    await import('./js/navigation-script.js');
 
     const contentContainer = document.getElementById('spa-content');
     if (!contentContainer) {


### PR DESCRIPTION
💡 What: Removed `await` from the initial component imports in `src/app.js` (Auth, Search) to allow them to load in parallel with the app initialization.
🎯 Why: These imports were blocking the main `initializeSPA` function, delaying the initial render of the application shell.
📊 Impact: Improves Time to Interactive (TTI) by allowing the router and page manager to initialize immediately while background components load.
🔬 Measurement: Verified with local Playwright tests that the app still loads correctly.

---
*PR created automatically by Jules for task [2094297917836038416](https://jules.google.com/task/2094297917836038416) started by @roiguri*