### PR TITLE
⚡ Bolt: Optimize home page featured recipes query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,6 @@
 
 **Learning:** `npm install` can generate significant noise in `package-lock.json` if local environment differs from CI/CD. Also, simple `Map` caches in SPAs can leak memory if unbounded.
 **Action:** Revert `package-lock.json` if no dependencies added. Always implement LRU or size limits for in-memory caches in long-running applications.
+## 2025-10-24 - [Firestore Pagination & Limiting]
+**Learning:** In the `home-page.js`, the code was fetching all approved recipes just to display the top 3 newest ones, then sorting them client-side. This results in heavy over-fetching of unnecessary data.
+**Action:** Always use Firestore's native `orderBy` and `limit` on the query object `queryParams` whenever possible to limit results directly on the database level before fetching.

--- a/src/app/pages/home-page.js
+++ b/src/app/pages/home-page.js
@@ -68,8 +68,12 @@ export default {
     }
 
     try {
-      // Get most recent approved recipes
-      const queryParams = { where: [['approved', '==', true]] };
+      // Get most recent approved recipes (limit to 3 to prevent overfetching)
+      const queryParams = {
+        where: [['approved', '==', true]],
+        orderBy: ['creationTime', 'desc'],
+        limit: 3
+      };
       const recipes = await FirestoreService.queryDocuments('recipes', queryParams);
 
       if (!recipes.length) {
@@ -77,19 +81,9 @@ export default {
         return;
       }
 
-      // Sort by creationTime, newest first
-      recipes.sort((a, b) => {
-        const timeA = a.creationTime?.seconds || 0;
-        const timeB = b.creationTime?.seconds || 0;
-        return timeB - timeA;
-      });
-
-      // Take only first 3 recipes
-      const recentRecipes = recipes.slice(0, 3);
-
       messageContainer.remove();
 
-      recentRecipes.forEach((doc) => {
+      recipes.forEach((doc) => {
         const recipeCard = document.createElement('recipe-card');
         recipeCard.setAttribute('recipe-id', doc.id);
         recipeCard.setAttribute('layout', 'vertical');


### PR DESCRIPTION
💡 What: Updated the `loadFeaturedRecipes` method in `home-page.js` to use Firestore's native `orderBy` and `limit` operations instead of fetching all approved recipes and sorting/slicing on the client.
🎯 Why: The previous implementation fetched potentially hundreds of recipe documents from Firestore just to display the top 3 newest ones, leading to heavy network usage, wasted memory, and slow rendering times.
📊 Impact: Reduces Firestore reads from O(N) to O(1) (exactly 3 reads). Dramatically reduces payload size and eliminates client-side sorting overhead.
🔬 Measurement: Verify by checking network payload size and Firestore reads when loading the home page compared to the previous implementation.

---
*PR created automatically by Jules for task [13344464330866762840](https://jules.google.com/task/13344464330866762840) started by @roiguri*