### PR TITLE
⚡ Bolt: Debounce recipe search input in manager dashboard

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,3 +27,4 @@
 
 **Learning:** `await`ing every component import in the application initialization path (e.g., in `initializeSPA`) delays the Time to Interactive (TTI) because the router waits for all components to load before rendering.
 **Action:** Separate truly critical shell components (like `navigation-script`) from supplemental ones (like Auth and Search). `await` only critical shell dependencies to avoid race conditions, but let supplemental ones load in parallel via non-blocking `Promise.all().catch()`.
+## 2025-10-25 - [Debounce Search Inputs]\n**Learning:** Search inputs triggering filtering operations directly on every keystroke can cause performance bottlenecks. Debouncing is a simple, effective optimization.\n**Action:** Always wrap search input handlers with a debounce function (e.g., 300ms) to reduce the frequency of filtering operations and improve application responsiveness.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -27,4 +27,5 @@
 
 **Learning:** `await`ing every component import in the application initialization path (e.g., in `initializeSPA`) delays the Time to Interactive (TTI) because the router waits for all components to load before rendering.
 **Action:** Separate truly critical shell components (like `navigation-script`) from supplemental ones (like Auth and Search). `await` only critical shell dependencies to avoid race conditions, but let supplemental ones load in parallel via non-blocking `Promise.all().catch()`.
+
 ## 2025-10-25 - [Debounce Search Inputs]\n**Learning:** Search inputs triggering filtering operations directly on every keystroke can cause performance bottlenecks. Debouncing is a simple, effective optimization.\n**Action:** Always wrap search input handlers with a debounce function (e.g., 300ms) to reduce the frequency of filtering operations and improve application responsiveness.

--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -2,6 +2,7 @@ import { FirestoreService } from '../../js/services/firestore-service.js';
 import authService from '../../js/services/auth-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import { CATEGORY_MAP, deleteRecipe } from '../../js/utils/recipes/recipe-data-utils.js';
+import { debounce } from '../../js/utils/common-utils.js';
 import {
   DashboardRefreshManager,
   DASHBOARD_SECTIONS,
@@ -269,8 +270,11 @@ export default {
       this.updateRecipeList(recipes);
       this.populateFilterOptions(recipes);
 
+      // Create a debounced version of filterRecipes
+      this.debouncedFilterRecipes = debounce(() => this.filterRecipes(), 300);
+
       // Set up event listeners
-      searchInput.addEventListener('input', () => this.filterRecipes());
+      searchInput.addEventListener('input', this.debouncedFilterRecipes);
       filterSelect.addEventListener('change', () => this.filterRecipes());
     } catch (error) {
       this.handleError(error);

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -128,11 +128,7 @@ export const icons = {
   ),
 
   // Thin cross / add-to-meal (stroke-based)
-  plus: svgStroke(
-    '0 0 24 24',
-    '<path d="M12 5v14M5 12h14"/>',
-    '2',
-  ),
+  plus: svgStroke('0 0 24 24', '<path d="M12 5v14M5 12h14"/>', '2'),
 
   // Eye icon for password-visibility toggle (stroke-based, path + circle)
   eye: svgStroke(
@@ -141,42 +137,21 @@ export const icons = {
   ),
 
   // Left-pointing arrow used on RTL auth-form submit buttons
-  arrowLeft: svgStroke(
-    '0 0 16 16',
-    '<path d="M13 8H3M7 4l-4 4 4 4"/>',
-  ),
+  arrowLeft: svgStroke('0 0 16 16', '<path d="M13 8H3M7 4l-4 4 4 4"/>'),
 
   // Carousel chevrons (stroke-based, polyline)
-  chevronLeft: svgStroke(
-    '0 0 24 24',
-    '<polyline points="15 18 9 12 15 6"/>',
-    '2',
-  ),
+  chevronLeft: svgStroke('0 0 24 24', '<polyline points="15 18 9 12 15 6"/>', '2'),
 
-  chevronRight: svgStroke(
-    '0 0 24 24',
-    '<polyline points="9 18 15 12 9 6"/>',
-    '2',
-  ),
+  chevronRight: svgStroke('0 0 24 24', '<polyline points="9 18 15 12 9 6"/>', '2'),
 
   // Magnifying-glass search icon (stroke-based, circle + line)
-  search: svgStroke(
-    '0 0 16 16',
-    '<circle cx="7" cy="7" r="5"/><path d="M11 11l3 3"/>',
-  ),
+  search: svgStroke('0 0 16 16', '<circle cx="7" cy="7" r="5"/><path d="M11 11l3 3"/>'),
 
   // Floppy-disk save icon (stroke-based; original uses stroke-width 1.4)
-  floppyDisk: svgStroke(
-    '0 0 16 16',
-    '<path d="M13 2H5L2 5v9h12V2zM10 2v4H5V2M8 8v5"/>',
-    '1.4',
-  ),
+  floppyDisk: svgStroke('0 0 16 16', '<path d="M13 2H5L2 5v9h12V2zM10 2v4H5V2M8 8v5"/>', '1.4'),
 
   // Small × close/clear icon (stroke-based, two diagonal lines)
-  closeX: svgStroke(
-    '0 0 16 16',
-    '<path d="M3 3l10 10M13 3L3 13"/>',
-  ),
+  closeX: svgStroke('0 0 16 16', '<path d="M3 3l10 10M13 3L3 13"/>'),
 
   // Kitchen utensils icon used in my-meal empty state (stroke-based, multi-path)
   kitchenUtensils: svgStroke(


### PR DESCRIPTION
💡 **What:** Added a 300ms debounce to the `filterRecipes` method triggered by the recipe search input in the manager dashboard.
🎯 **Why:** Previously, the `filterRecipes` method was called on every single keystroke. This caused unnecessary and frequent filtering of the entire recipes array, leading to performance bottlenecks and UI lag, especially with a large number of recipes or on slower devices.
📊 **Impact:** Reduces the number of `filterRecipes` executions significantly while typing. For example, typing "chocolate" quickly now triggers the filter once instead of 9 times, saving CPU cycles and making the UI more responsive.
🔬 **Measurement:** Open the manager dashboard, go to the "All Recipes" section, and type quickly in the search bar. The UI should remain responsive, and the filtering will occur only after a short pause in typing.

---
*PR created automatically by Jules for task [237878229108340119](https://jules.google.com/task/237878229108340119) started by @roiguri*