### PR TITLE
refactor(styles): centralize z-index with CSS variables (closes #141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,13 @@ Tokens are in `src/styles/tokens.css` (v2, modern). Key variables to use in all 
 - **Shadows**: `--shadow-1/2/3`, `--ring` (focus ring)
 - **Motion**: `--ease`, `--ease-out`, `--dur-1` (160ms), `--dur-2` (280ms), `--dur-3` (520ms)
 - **Layout**: `--content-max` (1200px), `--gutter` (fluid)
+- **Z-Index**: token hierarchy (lowest → highest): `--z-elevated` (10) → `--z-sticky` (100) → `--z-page-overlay` (200) → `--z-nav` (1000) → `--z-backdrop` (1010) → `--z-drawer` (1020) → `--z-modal` (2000) → `--z-toast` (3000) → `--z-fullscreen` (10000) → `--z-spinner` (10010)
+
+**Z-index rules:**
+
+- Always use a token when placing an element in the application stacking context (nav, drawers, modals, backdrops, toasts, overlays).
+- Raw numeric `z-index` values are acceptable for _internal_ component layout — e.g. `z-index: 1` to lift a pseudo-element or child above a sibling within the same component. These are local, not application-level, so tokens would be semantically wrong.
+- Never use a raw number for anything that competes with application-level layers (header, drawers, modals, etc.).
 
 Never use raw hex colors or hardcoded px values for things covered by tokens. The app has Hebrew RTL content — use `dir="rtl"` on Hebrew containers.
 

--- a/src/lib/notifications/toast-notification/toast-notification.js
+++ b/src/lib/notifications/toast-notification/toast-notification.js
@@ -2,7 +2,6 @@ import alertStyles from '../../../styles/components/alerts.css?inline';
 
 // Constants
 const DEFAULT_TOAST_DURATION_MS = 3000;
-const TOAST_Z_INDEX = 10000;
 
 /**
  * Toast Notification Component
@@ -29,7 +28,7 @@ class ToastNotification extends HTMLElement {
           position: fixed;
           bottom: 24px;
           right: 24px;
-          z-index: ${TOAST_Z_INDEX};
+          z-index: var(--z-toast);
           pointer-events: none;
         }
 

--- a/src/lib/utilities/fullscreen-media-viewer/fullscreen-media-viewer.js
+++ b/src/lib/utilities/fullscreen-media-viewer/fullscreen-media-viewer.js
@@ -240,7 +240,7 @@ class FullscreenMediaViewer extends HTMLElement {
           width: 100%;
           height: 100%;
           background-color: rgba(0, 0, 0, 0.95);
-          z-index: 10000;
+          z-index: var(--z-fullscreen);
           opacity: 0;
           transition: opacity 0.3s ease;
           flex-direction: column;
@@ -270,7 +270,7 @@ class FullscreenMediaViewer extends HTMLElement {
           align-items: center;
           justify-content: center;
           transition: background-color 0.2s ease, transform 0.2s ease;
-          z-index: 10002;
+          z-index: calc(var(--z-fullscreen) + 2);
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
         }
 
@@ -290,7 +290,7 @@ class FullscreenMediaViewer extends HTMLElement {
           background: rgba(0, 0, 0, 0.5);
           padding: 8px 16px;
           border-radius: 20px;
-          z-index: 10002;
+          z-index: calc(var(--z-fullscreen) + 2);
         }
 
         .viewer-content {
@@ -347,7 +347,7 @@ class FullscreenMediaViewer extends HTMLElement {
           align-items: center;
           justify-content: center;
           transition: background-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
-          z-index: 10001;
+          z-index: calc(var(--z-fullscreen) + 1);
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
         }
 

--- a/src/lib/utilities/loading-spinner/loading-spinner.js
+++ b/src/lib/utilities/loading-spinner/loading-spinner.js
@@ -100,7 +100,7 @@ class LoadingSpinner extends HTMLElement {
         position: fixed;
         inset: 0;
         background: rgba(255,255,255,0.7);
-        z-index: 10000;
+        z-index: var(--z-spinner);
         pointer-events: all;
         border-radius: ${this.borderRadius};
       }

--- a/src/lib/utilities/modal/modal.js
+++ b/src/lib/utilities/modal/modal.js
@@ -112,7 +112,7 @@ export class Modal extends HTMLElement {
       .modal {
         display: flex;
         position: fixed;
-        z-index: 2000;
+        z-index: var(--z-modal);
         inset: 0;
         align-items: center;
         justify-content: center;

--- a/src/lib/utilities/pdf_viewer/pdf_viewer.js
+++ b/src/lib/utilities/pdf_viewer/pdf_viewer.js
@@ -107,7 +107,7 @@ class PDFViewer extends HTMLElement {
                     left: 0;
                     width: 100vw;
                     height: 100vh;
-                    z-index: 10000;
+                    z-index: var(--z-fullscreen);
                     border-radius: 0;
                     margin: 0;
                 }
@@ -228,7 +228,7 @@ class PDFViewer extends HTMLElement {
                     color: white;
                     border: none;
                     cursor: pointer;
-                    z-index: 10001;
+                    z-index: calc(var(--z-fullscreen) + 1);
                     transition: background var(--dur-1, 160ms);
                 }
 

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -61,7 +61,7 @@ header.app-loading::before {
   background: linear-gradient(90deg, #eef3e1 25%, #dcebc1 50%, #eef3e1 75%);
   background-size: 200% 100%;
   animation: nav-shimmer 1.5s infinite linear;
-  z-index: 10;
+  z-index: var(--z-elevated);
 }
 
 @keyframes nav-shimmer {
@@ -303,7 +303,7 @@ header .hamburger::after {
 
   header .nav-toggle {
     display: flex;
-    z-index: 1002;
+    z-index: var(--z-nav);
     position: relative;
     width: 30px;
     height: 30px;
@@ -408,7 +408,7 @@ header .hamburger::after {
     border-left: 1px solid var(--hairline);
     transform: translate3d(100%, 0, 0);
     transition: transform var(--dur-3) var(--ease-out);
-    z-index: 1001;
+    z-index: var(--z-drawer);
     box-shadow: 24px 0 64px -24px rgba(31, 29, 24, 0.35);
     overflow: hidden;
     display: flex;
@@ -424,7 +424,7 @@ header .hamburger::after {
     bottom: 0;
     width: 1px;
     background: rgba(188, 71, 73, 0.25);
-    z-index: 0;
+    z-index: var(--z-base);
   }
 
   .mobile-nav-drawer.active {
@@ -644,7 +644,7 @@ header .hamburger::after {
     opacity: 0;
     visibility: hidden;
     transition: all var(--dur-3) var(--ease-out);
-    z-index: 1000;
+    z-index: var(--z-backdrop);
   }
 
   .mobile-nav-backdrop.active {

--- a/src/styles/components/spa.css
+++ b/src/styles/components/spa.css
@@ -62,7 +62,7 @@ footer {
   align-items: center;
   justify-content: center;
   background: rgba(250, 246, 236, 0.9);
-  z-index: 2000;
+  z-index: var(--z-modal);
   transition: opacity 0.15s ease;
 }
 

--- a/src/styles/pages/categories-spa.css
+++ b/src/styles/pages/categories-spa.css
@@ -33,7 +33,7 @@
 .spa-content .categories-page unified-recipe-filter {
   position: sticky;
   top: 0;
-  z-index: 40;
+  z-index: var(--z-sticky);
   background: var(--surface-0, #faf6ec);
   border-top: 1px solid var(--hairline, rgba(31, 29, 24, 0.12));
   border-bottom: 1px solid var(--hairline, rgba(31, 29, 24, 0.12));

--- a/src/styles/pages/my-meal-page.css
+++ b/src/styles/pages/my-meal-page.css
@@ -10,7 +10,7 @@
 .spa-content .my-meal-page .meal-header {
   position: sticky;
   top: 0;
-  z-index: var(--z-elevated);
+  z-index: var(--z-sticky);
   background: var(--surface-1);
   border-bottom: 1px solid var(--hairline-strong);
   display: flex;

--- a/src/styles/pages/my-meal-page.css
+++ b/src/styles/pages/my-meal-page.css
@@ -10,7 +10,7 @@
 .spa-content .my-meal-page .meal-header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: var(--z-elevated);
   background: var(--surface-1);
   border-bottom: 1px solid var(--hairline-strong);
   display: flex;
@@ -152,7 +152,7 @@
   height: 100%;
   background: var(--surface-1);
   box-shadow: -4px 0 24px rgba(31, 29, 24, 0.12);
-  z-index: 1100;
+  z-index: var(--z-drawer);
   transform: translateX(100%);
   transition: transform var(--dur-2, 260ms) var(--ease-out, ease);
   display: flex;
@@ -402,7 +402,7 @@
   width: 100%;
   height: 100%;
   background: rgba(31, 29, 24, 0.45);
-  z-index: 1090;
+  z-index: var(--z-backdrop);
   display: none;
 }
 

--- a/src/styles/pages/propose-recipe-spa.css
+++ b/src/styles/pages/propose-recipe-spa.css
@@ -52,7 +52,7 @@
 .spa-content .propose-action-bar {
   position: sticky;
   bottom: 0;
-  z-index: 100;
+  z-index: var(--z-sticky);
   background: var(--surface-1, #fff);
   border-top: 1px solid var(--hairline, rgba(31, 29, 24, 0.12));
   box-shadow: 0 -4px 24px rgba(31, 29, 24, 0.08);

--- a/src/styles/pages/recipe-detail-spa.css
+++ b/src/styles/pages/recipe-detail-spa.css
@@ -20,7 +20,7 @@
   position: absolute;
   top: 14px;
   left: 14px;
-  z-index: 100;
+  z-index: var(--z-sticky);
 }
 
 .spa-content .recipe-detail .recipe-menu-button {
@@ -60,7 +60,7 @@
   min-width: 200px;
   overflow: hidden;
   display: none;
-  z-index: 1000;
+  z-index: var(--z-page-overlay);
 }
 
 .spa-content .recipe-detail .recipe-menu-dropdown.open {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -105,6 +105,28 @@
   /* ---- Layout ---- */
   --content-max: 1200px;
   --gutter: clamp(20px, 4vw, 48px);
+
+  /* ---- Z-Index Architecture ---- */
+  --z-hide: -1;
+  --z-base: 0;
+
+  /* Page & Component Level */
+  --z-elevated: 10; /* Hover states, local card stacking */
+  --z-sticky: 100; /* Sticky headers within pages, FABs */
+  --z-page-overlay: 200; /* In-page dropdowns, tooltips */
+
+  /* Application Layout Level */
+  --z-backdrop: 1000; /* Dimming backdrops for drawers/modals */
+  --z-drawer: 1010; /* Mobile navigation drawer */
+  --z-nav: 1020; /* Top navigation bar, hamburger menu */
+
+  /* Global Overlays Level */
+  --z-modal: 2000; /* Modals, Dialogs (Must be > nav) */
+  --z-toast: 3000; /* Toast notifications */
+
+  /* System Level */
+  --z-fullscreen: 10000; /* Fullscreen media viewers, PDF viewers */
+  --z-spinner: 10010; /* Global loading spinners */
 }
 
 * {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -116,9 +116,9 @@
   --z-page-overlay: 200; /* In-page dropdowns, tooltips */
 
   /* Application Layout Level */
-  --z-backdrop: 1000; /* Dimming backdrops for drawers/modals */
-  --z-drawer: 1010; /* Mobile navigation drawer */
-  --z-nav: 1020; /* Top navigation bar, hamburger menu */
+  --z-nav: 1000; /* Top navigation bar — above page content, below overlays */
+  --z-backdrop: 1010; /* Dimming backdrops — covers nav when drawers/modals open */
+  --z-drawer: 1020; /* Drawers and side panels */
 
   /* Global Overlays Level */
   --z-modal: 2000; /* Modals, Dialogs (Must be > nav) */


### PR DESCRIPTION
Introduces a semantic --z-* ladder in tokens.css and replaces all hardcoded z-index magic numbers across CSS and JS files.

- tokens.css: add --z-hide/base/elevated/sticky/page-overlay/backdrop/ drawer/nav/modal/toast/fullscreen/spinner variables
- header.css: nav-toggle → --z-nav, drawer → --z-drawer, backdrop → --z-backdrop, shimmer → --z-elevated, rule line → --z-base
- spa.css: page-loading overlay → --z-modal
- modal.js: modal overlay → --z-modal
- loading-spinner.js: global spinner overlay → --z-spinner
- toast-notification.js: replace JS constant with var(--z-toast)
- my-meal-page.css: meal-header → --z-elevated, ingredients-drawer → --z-drawer, drawer-backdrop → --z-backdrop
- categories-spa.css: sticky filter bar → --z-sticky
- recipe-detail-spa.css: recipe-menu → --z-sticky, dropdown → --z-page-overlay
- propose-recipe-spa.css: action bar → --z-sticky
- fullscreen-media-viewer.js: overlay → --z-fullscreen + calc offsets
- pdf_viewer.js: full-page mode → --z-fullscreen + calc offset