### PR TITLE
Fix mobile auto-zoom on inputs

### DIFF
--- a/src/lib/auth/components/forgot-password.js
+++ b/src/lib/auth/components/forgot-password.js
@@ -100,6 +100,7 @@ class ForgotPassword extends HTMLElement {
         .back:hover { border-color: var(--primary, #6a994e); }
 
         @media (max-width: 560px) {
+          .field input { font-size: 16px; }
           .body { padding-left: 22px; padding-right: 22px; }
         }
       </style>

--- a/src/lib/auth/components/login-form.js
+++ b/src/lib/auth/components/login-form.js
@@ -152,6 +152,7 @@ class LoginForm extends HTMLElement {
         }
 
         @media (max-width: 560px) {
+          .field input { font-size: 16px; }
           .stack { padding-left: 22px; padding-right: 22px; }
         }
       </style>

--- a/src/lib/auth/components/signup-form.js
+++ b/src/lib/auth/components/signup-form.js
@@ -131,6 +131,7 @@ class SignupForm extends HTMLElement {
         }
 
         @media (max-width: 560px) {
+          .field input { font-size: 16px; }
           .stack { padding-left: 22px; padding-right: 22px; }
           .grid2 { grid-template-columns: 1fr; }
         }

--- a/src/lib/auth/components/user-profile.js
+++ b/src/lib/auth/components/user-profile.js
@@ -215,6 +215,7 @@ class UserProfile extends HTMLElement {
         }
 
         @media (max-width: 560px) {
+          .field input { font-size: 16px; }
           .profile-body { padding-left: 22px; padding-right: 22px; }
           .profile-foot { padding: 14px 22px; }
           .avatar-grid { grid-template-columns: repeat(4, 1fr); }

--- a/src/styles/components/fields.css
+++ b/src/styles/components/fields.css
@@ -174,3 +174,13 @@
 .fields-grid .field--full {
   grid-column: span 2;
 }
+
+/* ---- Mobile optimizations to prevent auto-zoom ---- */
+@media (max-width: 768px) {
+  .field__input,
+  .field input,
+  .field textarea,
+  .field select {
+    font-size: 16px;
+  }
+}

--- a/src/styles/components/search_bar.css
+++ b/src/styles/components/search_bar.css
@@ -32,3 +32,9 @@
   align-items: center;
   justify-content: center;
 }
+
+@media (max-width: 768px) {
+  .search-form .search-input {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
Modified `fields.css`, `search_bar.css`, and authentication web components (`login-form`, `signup-form`, `forgot-password`, `user-profile`) to ensure inputs, textareas, and selects have a font size of 16px on screens under 768px. This resolves an issue where iOS Safari automatically zooms in when an input with a smaller font size is focused.

---
*PR created automatically by Jules for task [16392675165077846776](https://jules.google.com/task/16392675165077846776) started by @roiguri*