### PR TITLE
Disable double-tap zoom globally

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18,6 +18,10 @@
 @import 'components/lazy-loading.css';
 
 /* ---- Global resets ---- */
+* {
+  touch-action: manipulation;
+}
+
 html {
   scrollbar-gutter: stable;
 }


### PR DESCRIPTION
Adds global CSS to block double-tap to zoom behavior on mobile devices for a more native app feel.

---
*PR created automatically by Jules for task [10056552387385065947](https://jules.google.com/task/10056552387385065947) started by @roiguri*