### PR TITLE
Add preview mode to recipe proposal form

### DIFF
--- a/src/app/pages/propose-recipe-page.html
+++ b/src/app/pages/propose-recipe-page.html
@@ -4,29 +4,43 @@
     <p class="propose-hero__dek">כתוב אותו כפי שהיית מספר אותו לחבר.</p>
   </section>
 
-  <section class="propose-form">
+  <section class="propose-form" id="propose-form-section">
     <propose-recipe-component></propose-recipe-component>
+  </section>
+
+  <section class="propose-preview" id="propose-preview-section" style="display: none;">
+    <recipe-component id="recipe-preview"></recipe-component>
   </section>
 </div>
 
 <div class="propose-action-bar" id="propose-action-bar" style="display: none">
   <div class="propose-action-bar__inner">
-    <button
-      class="propose-action-bar__btn propose-action-bar__btn--import"
-      id="action-import"
-      aria-label="ייבא מתכון"
-    >
-      <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-        <path
-          d="M8 2v7M5 6l3 3 3-3M3 13h10"
-          stroke="currentColor"
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-      <span class="propose-action-bar__label">ייבא מתכון</span>
-    </button>
+    <div class="propose-action-bar__toggles">
+      <button
+        class="propose-action-bar__btn propose-action-bar__btn--preview"
+        id="action-preview"
+        aria-label="תצוגה מקדימה"
+      >
+        <span class="propose-action-bar__icon" id="preview-icon"></span>
+        <span class="propose-action-bar__label" id="preview-label">תצוגה מקדימה</span>
+      </button>
+      <button
+        class="propose-action-bar__btn propose-action-bar__btn--import"
+        id="action-import"
+        aria-label="ייבא מתכון"
+      >
+        <svg width="15" height="15" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M8 2v7M5 6l3 3 3-3M3 13h10"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <span class="propose-action-bar__label">ייבא מתכון</span>
+      </button>
+    </div>
     <div class="propose-action-bar__actions">
       <button
         class="propose-action-bar__btn propose-action-bar__btn--clear"

--- a/src/app/pages/propose-recipe-page.html
+++ b/src/app/pages/propose-recipe-page.html
@@ -8,7 +8,7 @@
     <propose-recipe-component></propose-recipe-component>
   </section>
 
-  <section class="propose-preview" id="propose-preview-section" style="display: none;">
+  <section class="propose-preview" id="propose-preview-section" style="display: none">
     <recipe-component id="recipe-preview"></recipe-component>
   </section>
 </div>

--- a/src/app/pages/propose-recipe-page.js
+++ b/src/app/pages/propose-recipe-page.js
@@ -225,6 +225,8 @@ export default {
     const submitBtn = document.querySelector('#action-submit');
     const clearBtn = document.querySelector('#action-clear');
     const importBtn = document.querySelector('#action-import');
+    const heroTitle = document.querySelector('.propose-hero__title');
+    const heroDek = document.querySelector('.propose-hero__dek');
 
     if (this.isPreviewMode) {
       // Switching to Preview mode
@@ -243,6 +245,9 @@ export default {
       if (clearBtn) clearBtn.disabled = true;
       if (importBtn) importBtn.disabled = true;
 
+      if (heroTitle) heroTitle.innerHTML = 'כך ייראה <em>המתכון שלך</em>';
+      if (heroDek) heroDek.textContent = 'כפי שיופיע לאחר הפרסום';
+
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } else {
       // Switching back to Edit mode
@@ -252,6 +257,9 @@ export default {
       if (submitBtn) submitBtn.disabled = false;
       if (clearBtn) clearBtn.disabled = false;
       if (importBtn) importBtn.disabled = false;
+
+      if (heroTitle) heroTitle.innerHTML = 'הצע <em>מתכון</em> לספר.';
+      if (heroDek) heroDek.textContent = 'כתוב אותו כפי שהיית מספר אותו לחבר.';
     }
 
     this.updatePreviewButton();

--- a/src/app/pages/propose-recipe-page.js
+++ b/src/app/pages/propose-recipe-page.js
@@ -1,5 +1,7 @@
 import authService from '../../js/services/auth-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
+import { icons } from '../../js/icons.js';
+import { collectRecipeFormData } from '../../js/utils/form/form-data-collector.js';
 import '../../styles/pages/propose-recipe-spa.css';
 
 export default {
@@ -18,11 +20,13 @@ export default {
 
   async mount(container, params) {
     try {
+      this.isPreviewMode = false;
       await this.importComponents();
 
       await this.setupAuthentication(container);
 
       this.setupEventListeners();
+      this.updatePreviewButton();
     } catch (error) {
       console.error('Error mounting propose recipe page:', error);
       this.handleError(error, 'mount');
@@ -55,6 +59,7 @@ export default {
     try {
       await Promise.all([
         import('../../lib/recipes/recipe_form_component/propose_recipe_component.js'),
+        import('../../lib/recipes/recipe_component/recipe_component.js'),
         import('../../lib/modals/message-modal/message-modal.js'),
       ]);
     } catch (error) {
@@ -129,6 +134,9 @@ export default {
 
   setupEventListeners() {
     this.recipeProposedHandler = () => {
+      if (this.isPreviewMode) {
+        this.togglePreviewMode();
+      }
       window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
@@ -137,6 +145,7 @@ export default {
     const submitBtn = document.querySelector('#action-submit');
     const clearBtn = document.querySelector('#action-clear');
     const importBtn = document.querySelector('#action-import');
+    const previewBtn = document.querySelector('#action-preview');
 
     if (submitBtn) {
       this.actionSubmitHandler = () => {
@@ -157,6 +166,13 @@ export default {
         if (this.proposeRecipeForm) this.proposeRecipeForm.openImportModal();
       };
       importBtn.addEventListener('click', this.actionImportHandler);
+    }
+
+    if (previewBtn) {
+      this.actionPreviewHandler = () => {
+        this.togglePreviewMode();
+      };
+      previewBtn.addEventListener('click', this.actionPreviewHandler);
     }
 
     if (this.loginPromptModal) {
@@ -180,12 +196,15 @@ export default {
     const submitBtn = document.querySelector('#action-submit');
     const clearBtn = document.querySelector('#action-clear');
     const importBtn = document.querySelector('#action-import');
+    const previewBtn = document.querySelector('#action-preview');
     if (submitBtn && this.actionSubmitHandler)
       submitBtn.removeEventListener('click', this.actionSubmitHandler);
     if (clearBtn && this.actionClearHandler)
       clearBtn.removeEventListener('click', this.actionClearHandler);
     if (importBtn && this.actionImportHandler)
       importBtn.removeEventListener('click', this.actionImportHandler);
+    if (previewBtn && this.actionPreviewHandler)
+      previewBtn.removeEventListener('click', this.actionPreviewHandler);
 
     if (this.loginPromptModal && this.modalClosedHandler) {
       this.loginPromptModal.removeEventListener('modal-closed-by-user', this.modalClosedHandler);
@@ -197,6 +216,61 @@ export default {
     if (this.authStateUnsubscribe) {
       this.authStateUnsubscribe();
       this.authStateUnsubscribe = null;
+    }
+  },
+
+  togglePreviewMode() {
+    this.isPreviewMode = !this.isPreviewMode;
+
+    const formSection = document.querySelector('#propose-form-section');
+    const previewSection = document.querySelector('#propose-preview-section');
+    const previewComponent = document.querySelector('#recipe-preview');
+    const submitBtn = document.querySelector('#action-submit');
+    const clearBtn = document.querySelector('#action-clear');
+    const importBtn = document.querySelector('#action-import');
+
+    if (this.isPreviewMode) {
+      // Switching to Preview mode
+      const formComponent = this.proposeRecipeForm.shadowRoot.querySelector('recipe-form-component');
+      const recipeData = collectRecipeFormData(formComponent.shadowRoot);
+
+      if (previewComponent) {
+        previewComponent.setData(recipeData);
+      }
+
+      formSection.style.display = 'none';
+      previewSection.style.display = 'block';
+
+      if (submitBtn) submitBtn.disabled = true;
+      if (clearBtn) clearBtn.disabled = true;
+      if (importBtn) importBtn.disabled = true;
+
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      // Switching back to Edit mode
+      formSection.style.display = 'block';
+      previewSection.style.display = 'none';
+
+      if (submitBtn) submitBtn.disabled = false;
+      if (clearBtn) clearBtn.disabled = false;
+      if (importBtn) importBtn.disabled = false;
+    }
+
+    this.updatePreviewButton();
+  },
+
+  updatePreviewButton() {
+    const iconContainer = document.querySelector('#preview-icon');
+    const labelContainer = document.querySelector('#preview-label');
+
+    if (iconContainer && labelContainer) {
+      if (this.isPreviewMode) {
+        iconContainer.innerHTML = icons.pencilAlt;
+        labelContainer.textContent = 'חזור לעריכה';
+      } else {
+        iconContainer.innerHTML = icons.eye;
+        labelContainer.textContent = 'תצוגה מקדימה';
+      }
     }
   },
 

--- a/src/app/pages/propose-recipe-page.js
+++ b/src/app/pages/propose-recipe-page.js
@@ -134,9 +134,6 @@ export default {
 
   setupEventListeners() {
     this.recipeProposedHandler = () => {
-      if (this.isPreviewMode) {
-        this.togglePreviewMode();
-      }
       window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
@@ -231,7 +228,8 @@ export default {
 
     if (this.isPreviewMode) {
       // Switching to Preview mode
-      const formComponent = this.proposeRecipeForm.shadowRoot.querySelector('recipe-form-component');
+      const formComponent =
+        this.proposeRecipeForm.shadowRoot.querySelector('recipe-form-component');
       const recipeData = collectRecipeFormData(formComponent.shadowRoot);
 
       if (previewComponent) {

--- a/src/js/utils/form/form-data-collector.js
+++ b/src/js/utils/form/form-data-collector.js
@@ -140,6 +140,7 @@ function collectImages(shadowRoot) {
       // New image to upload
       return {
         file: img.file,
+        preview: img.preview,
         isPrimary: img.isPrimary ?? false, // Default to false if undefined
         access: 'public',
         uploadedBy: authService.getCurrentUser()?.uid || 'anonymous',
@@ -179,25 +180,25 @@ function collectMediaInstructions(shadowRoot) {
     return null;
   }
 
-  if (typeof mediaEditor.getMediaInstructionsData !== 'function') {
-    console.warn('Media instructions editor missing getMediaInstructionsData method');
+  if (typeof mediaEditor.getAllMediaInOrder !== 'function') {
+    console.warn('Media instructions editor missing getAllMediaInOrder method');
     return null;
   }
 
-  const data = mediaEditor.getMediaInstructionsData();
-  const mediaInstructions = data.mediaInstructions || [];
-  const hasPendingFiles = data.pendingFiles && data.pendingFiles.length > 0;
+  const allMedia = mediaEditor.getAllMediaInOrder();
 
-  // Return combined state - important for dirty checking
-  // If there are pending files, include them in the structure
-  if (hasPendingFiles) {
-    return [
-      ...mediaInstructions,
-      ...data.pendingFiles.map((p) => ({ pending: true, caption: p.caption })),
-    ];
+  if (allMedia.length === 0) {
+    return null;
   }
 
-  return mediaInstructions.length > 0 ? mediaInstructions : null;
+  return allMedia.map((item) => ({
+    id: item.id,
+    path: item.path || item.preview, // Use preview for local unsaved items
+    caption: item.caption,
+    type: item.type,
+    order: item.position,
+    pending: !!item.file,
+  }));
 }
 
 /**

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -175,7 +175,12 @@ export function getPlaceholderImageUrl() {
  * @returns {Promise<string>} Download URL
  */
 export async function getOptimizedImageUrl(image, size = '400x400') {
-  if (!image || !image.full) return getPlaceholderImageUrl();
+  if (!image) return getPlaceholderImageUrl();
+
+  // 0. Use local preview if available (for form preview mode)
+  if (image.preview) return image.preview;
+
+  if (!image.full) return getPlaceholderImageUrl();
 
   // 1. Try Optimized version (New)
   // Extension appends suffix like _400x400.webp

--- a/src/js/utils/recipes/recipe-media-utils.js
+++ b/src/js/utils/recipes/recipe-media-utils.js
@@ -270,6 +270,13 @@ export async function deleteMediaInstructionFiles(filePaths) {
  * @returns {Promise<string>} The download URL
  */
 export async function getMediaInstructionUrl(storagePath) {
+  if (!storagePath) return '';
+
+  // If it's already a URL (blob or data), return it directly
+  if (storagePath.startsWith('blob:') || storagePath.startsWith('data:')) {
+    return storagePath;
+  }
+
   try {
     return await StorageService.getFileUrl(storagePath);
   } catch (error) {

--- a/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
@@ -869,18 +869,6 @@ class MediaInstructionsEditor extends HTMLElement {
   }
 
   /**
-   * Gets media instructions data for form collection
-   * Provides consistent method-based API for accessing media state
-   * @returns {Object} { mediaInstructions: Array, pendingFiles: Array }
-   */
-  getMediaInstructionsData() {
-    return {
-      mediaInstructions: this.mediaInstructions,
-      pendingFiles: this.pendingFiles,
-    };
-  }
-
-  /**
    * Clears all media instructions and pending files
    * Used when resetting the form
    */

--- a/src/lib/recipes/recipe_component/recipe_component.js
+++ b/src/lib/recipes/recipe_component/recipe_component.js
@@ -168,6 +168,11 @@ class RecipeComponent extends HTMLElement {
 
   styles() {
     return `
+    :host {
+      display: block;
+      width: 100%;
+    }
+
     .Recipe_component {
       display: flex;
       flex-direction: column;

--- a/src/lib/recipes/recipe_component/recipe_component.js
+++ b/src/lib/recipes/recipe_component/recipe_component.js
@@ -68,7 +68,9 @@ class RecipeComponent extends HTMLElement {
   connectedCallback() {
     this.render();
     this.recipeId = this.getAttribute('recipe-id');
-    this.fetchAndPopulateRecipeData();
+    if (this.recipeId) {
+      this.fetchAndPopulateRecipeData();
+    }
   }
 
   disconnectedCallback() {
@@ -842,24 +844,42 @@ class RecipeComponent extends HTMLElement {
     }
   }
 
+  /**
+   * Public API: Directly set recipe data to display (e.g., for preview mode)
+   * @param {Object} recipe - Formatted recipe data object
+   */
+  async setData(recipe) {
+    if (!recipe) return;
+
+    try {
+      this.updatePageTitle(recipe.name);
+      this.populateRecipeDetails(recipe);
+      await this.setRecipeImage(recipe);
+      this.populateIngredientsList(recipe);
+      this.populateInstructions(recipe);
+      this.populateCommentList(recipe);
+      this.populateRelatedRecipes(recipe).catch((err) => {
+        console.error('Error loading related recipes:', err);
+      });
+      this.setupServingsAdjuster(recipe);
+      this.displayMediaInstructions(recipe).catch((err) => {
+        console.error('Error loading media instructions:', err);
+      });
+      this._originalIngredients = recipe.ingredientSections || recipe.ingredients;
+    } catch (error) {
+      console.error('Error setting recipe data:', error);
+    } finally {
+      this.dispatchEvent(new CustomEvent('recipe-data-loaded', { bubbles: false, composed: true }));
+    }
+  }
+
   async fetchAndPopulateRecipeData() {
+    if (!this.recipeId) return;
+
     try {
       const recipe = await getRecipeById(this.recipeId);
       if (recipe) {
-        this.updatePageTitle(recipe.name);
-        this.populateRecipeDetails(recipe);
-        await this.setRecipeImage(recipe);
-        this.populateIngredientsList(recipe);
-        this.populateInstructions(recipe);
-        this.populateCommentList(recipe);
-        this.populateRelatedRecipes(recipe).catch((err) => {
-          console.error('Error loading related recipes:', err);
-        });
-        this.setupServingsAdjuster(recipe);
-        this.displayMediaInstructions(recipe).catch((err) => {
-          console.error('Error loading media instructions:', err);
-        });
-        this._originalIngredients = recipe.ingredients;
+        await this.setData(recipe);
       } else {
         console.warn('No such document!');
         // TODO: Handle the case where the recipe doesn't exist

--- a/src/lib/recipes/recipe_component/recipe_component.js
+++ b/src/lib/recipes/recipe_component/recipe_component.js
@@ -852,7 +852,6 @@ class RecipeComponent extends HTMLElement {
     if (!recipe) return;
 
     try {
-      this.updatePageTitle(recipe.name);
       this.populateRecipeDetails(recipe);
       await this.setRecipeImage(recipe);
       this.populateIngredientsList(recipe);
@@ -879,6 +878,7 @@ class RecipeComponent extends HTMLElement {
     try {
       const recipe = await getRecipeById(this.recipeId);
       if (recipe) {
+        this.updatePageTitle(recipe.name);
         await this.setData(recipe);
       } else {
         console.warn('No such document!');

--- a/src/lib/utilities/image-carousel/image-carousel.js
+++ b/src/lib/utilities/image-carousel/image-carousel.js
@@ -79,7 +79,7 @@ class ImageCarousel extends HTMLElement {
 
         let src = null;
         // Check if the image is a RecipeImage object or a Firebase path string
-        if (typeof image === 'object' && image !== null && image.full) {
+        if (typeof image === 'object' && image !== null && (image.full || image.preview)) {
           try {
             src = await getOptimizedImageUrl(image, '1080x1080');
           } catch (error) {

--- a/src/styles/components/spa.css
+++ b/src/styles/components/spa.css
@@ -17,6 +17,8 @@
   width: 100%;
   min-height: 0;
   position: relative;
+  display: flex;
+  flex-direction: column;
   background:
     radial-gradient(1200px 600px at 100% -10%, rgba(167, 201, 87, 0.1), transparent 60%),
     radial-gradient(900px 500px at -10% 110%, rgba(188, 71, 73, 0.06), transparent 60%), var(--bg);

--- a/src/styles/pages/propose-recipe-spa.css
+++ b/src/styles/pages/propose-recipe-spa.css
@@ -87,7 +87,14 @@
   cursor: pointer;
   transition:
     background var(--dur-1, 160ms) var(--ease, ease),
-    border-color var(--dur-1, 160ms) var(--ease, ease);
+    border-color var(--dur-1, 160ms) var(--ease, ease),
+    opacity var(--dur-1, 160ms) var(--ease, ease);
+}
+
+.spa-content .propose-action-bar__btn:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 .spa-content .propose-action-bar__btn--submit {
@@ -110,7 +117,14 @@
   background: var(--surface-2, #f2e8cf);
 }
 
-.spa-content .propose-action-bar__btn--import {
+.spa-content .propose-action-bar__toggles {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.spa-content .propose-action-bar__btn--import,
+.spa-content .propose-action-bar__btn--preview {
   background: transparent;
   color: var(--ink-3, #7c7562);
   border: 1px solid var(--hairline, rgba(31, 29, 24, 0.12));
@@ -119,10 +133,33 @@
   padding: 10px 18px;
 }
 
-.spa-content .propose-action-bar__btn--import:hover {
+.spa-content .propose-action-bar__btn--import:hover,
+.spa-content .propose-action-bar__btn--preview:hover {
   background: var(--surface-2, #f2e8cf);
   border-color: var(--primary, #6a994e);
   color: var(--primary-dark, #386641);
+}
+
+.spa-content .propose-action-bar__icon svg {
+  display: block;
+  width: 15px;
+  height: 15px;
+}
+
+.spa-content .propose-preview {
+  padding: 24px 0;
+  animation: fadeIn 0.4s ease forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ---- Mobile ---- */

--- a/src/styles/pages/propose-recipe-spa.css
+++ b/src/styles/pages/propose-recipe-spa.css
@@ -5,6 +5,7 @@
   margin: 0 auto;
   padding: 0 var(--gutter, 2rem) var(--sp-2xl, 4rem);
   direction: rtl;
+  flex: 1;
 }
 
 /* ---- Hero / title block ---- */
@@ -57,6 +58,7 @@
   border-top: 1px solid var(--hairline, rgba(31, 29, 24, 0.12));
   box-shadow: 0 -4px 24px rgba(31, 29, 24, 0.08);
   padding: 12px var(--gutter, 2rem);
+  margin-top: auto;
 }
 
 .spa-content .propose-action-bar__inner {

--- a/src/styles/pages/propose-recipe-spa.css
+++ b/src/styles/pages/propose-recipe-spa.css
@@ -1,6 +1,7 @@
 /* Propose Recipe Page — v2 */
 
 .spa-content .propose-recipe {
+  width: 100%;
   max-width: var(--content-max, 1200px);
   margin: 0 auto;
   padding: 0 var(--gutter, 2rem) var(--sp-2xl, 4rem);


### PR DESCRIPTION
The recipe proposal page now includes a "Preview" mode, allowing users to visualize how their recipe will look on the site before final submission.

Key changes:
- **`RecipeComponent`**: Added a public `setData(recipeData)` method that allows the component to be rendered using a provided data object instead of fetching from Firestore.
- **Utilities**: Updated `recipe-image-utils.js` and `recipe-media-utils.js` to correctly resolve local blob/data URLs, enabling previews of newly added images and media instructions.
- **Form Data Collection**: `collectRecipeFormData` now preserves local preview URLs for the preview flow.
- **Propose Page**: Integrated the preview toggle in the sticky action bar. The toggle switches between the form and a live preview of the recipe.
- **UX**: When in preview mode, potentially destructive or final actions (Submit, Clear, Import) are disabled to prevent accidental data loss or out-of-sync submissions.
- **Styles**: Added a fade-in animation for the preview mode and ensured the new toggle button matches the project's design language, including icon-only behavior on mobile.

Fixes #146

---
*PR created automatically by Jules for task [831809358200681426](https://jules.google.com/task/831809358200681426) started by @roiguri*