### PR TITLE
Replace native confirm() with custom modal in My Meal page

### DIFF
--- a/src/app/pages/my-meal-page.html
+++ b/src/app/pages/my-meal-page.html
@@ -100,4 +100,5 @@
     </div>
   </div>
   <div id="drawer-backdrop" class="drawer-backdrop"></div>
+  <confirmation-modal id="confirmation-modal"></confirmation-modal>
 </div>

--- a/src/app/pages/my-meal-page.js
+++ b/src/app/pages/my-meal-page.js
@@ -12,6 +12,7 @@ import { onSnapshot, doc, setDoc, serverTimestamp } from 'firebase/firestore';
 import { getFirestoreInstance } from '../../js/services/firebase-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import { icons } from '../../js/icons.js';
+import '../../lib/modals/confirmation_modal/confirmation_modal.js';
 import '../../styles/pages/my-meal-page.css';
 
 export default {
@@ -212,7 +213,10 @@ export default {
 
   async handleRemoveRecipe(e, recipeId, ActiveMealUtils) {
     e.stopPropagation();
-    if (!confirm('האם להסיר את המתכון מהארוחה?')) return;
+    const confirmed = await this.container
+      .querySelector('#confirmation-modal')
+      .confirm('האם להסיר את המתכון מהארוחה?');
+    if (!confirmed) return;
 
     // Detect if we need to switch tabs
     if (this.state.activeTabId === recipeId) {
@@ -238,7 +242,10 @@ export default {
   },
 
   async handleClearMeal(ActiveMealUtils) {
-    if (!confirm('האם לנקות את כל הארוחה? פעולה זו תסיר את כל המתכונים.')) return;
+    const confirmed = await this.container
+      .querySelector('#confirmation-modal')
+      .confirm('האם לנקות את כל הארוחה? פעולה זו תסיר את כל המתכונים.');
+    if (!confirmed) return;
 
     await ActiveMealUtils.clearMeal(this.currentUser.uid);
     // UI update will happen automatically via onSnapshot

--- a/src/lib/modals/confirmation_modal/confirmation_modal.js
+++ b/src/lib/modals/confirmation_modal/confirmation_modal.js
@@ -144,6 +144,36 @@ class ConfirmationModal extends Modal {
     `;
   }
 
+  setupEventListeners() {
+    super.setupEventListeners();
+
+    const approveButton = this.shadowRoot.getElementById('modal-approve-button');
+    const rejectButton = this.shadowRoot.getElementById('modal-reject-button');
+
+    approveButton.addEventListener('click', () => {
+      const resolve = this._resolveConfirm;
+      this._resolveConfirm = null;
+      this.close();
+      this.dispatchEvent(new CustomEvent('confirm-approved'));
+      if (resolve) resolve(true);
+    });
+
+    rejectButton.addEventListener('click', () => {
+      const resolve = this._resolveConfirm;
+      this._resolveConfirm = null;
+      this.close();
+      this.dispatchEvent(new CustomEvent('confirm-rejected'));
+      if (resolve) resolve(false);
+    });
+
+    this.addEventListener('modal-closed', () => {
+      if (this._resolveConfirm) {
+        this._resolveConfirm(false);
+        this._resolveConfirm = null;
+      }
+    });
+  }
+
   confirm(
     message = 'האם אתה בטוח?',
     title = '',
@@ -163,20 +193,11 @@ class ConfirmationModal extends Modal {
     this.shadowRoot.getElementById('modal-approve-button').textContent = approveButtonText;
     this.shadowRoot.getElementById('modal-reject-button').textContent = rejectButtonText;
 
-    const approveButton = this.shadowRoot.getElementById('modal-approve-button');
-    const rejectButton = this.shadowRoot.getElementById('modal-reject-button');
-
-    approveButton.addEventListener('click', () => {
-      this.close();
-      this.dispatchEvent(new CustomEvent('confirm-approved'));
-    });
-
-    rejectButton.addEventListener('click', () => {
-      this.close();
-      this.dispatchEvent(new CustomEvent('confirm-rejected'));
-    });
-
     this.open();
+
+    return new Promise((resolve) => {
+      this._resolveConfirm = resolve;
+    });
   }
 }
 


### PR DESCRIPTION
This change replaces the browser-native confirm() dialogs in the My Meal page with the application's custom <confirmation-modal> component. 

Key changes:
1. Refactored `ConfirmationModal` in `src/lib/modals/confirmation_modal/confirmation_modal.js` to:
   - Move event listener attachment to `setupEventListeners`, preventing redundant listeners on each `confirm()` call.
   - Return a Promise from `confirm()` that resolves to `true` on approval and `false` on rejection.
   - Maintain backward compatibility by still dispatching `confirm-approved` and `confirm-rejected` events.
   - Properly handle promise resolution when the modal is closed via backdrop or close button.
2. Updated `src/app/pages/my-meal-page.html` to include the `<confirmation-modal>` element.
3. Updated `src/app/pages/my-meal-page.js` to:
   - Import the `ConfirmationModal` component.
   - Replace native `confirm()` in `handleRemoveRecipe` and `handleClearMeal` with the new Promise-based modal API.
   - Use correct Hebrew messages as requested.

All tests passed, and the code follows the project's architecture and design tokens.

Fixes #120

---
*PR created automatically by Jules for task [12574088423174835973](https://jules.google.com/task/12574088423174835973) started by @roiguri*