### PR TITLE
Remove legacy compressed image fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ Unit tests use Jest with jsdom in `tests/`. Firebase is mocked via `tests/common
 
 ### Cloud Functions
 
-`functions/index.js` handles image compression via Sharp, Gemini AI recipe extraction from images/URLs, and batch recipe imports. Triggered by Pub/Sub and Firestore events.
+`functions/index.js` handles Gemini AI recipe extraction from images/URLs, and batch recipe imports. Triggered by Pub/Sub and Firestore events. (Legacy image compression via Sharp was removed in favor of automated Storage-triggered WebP resizing).
 
 ### Design System
 

--- a/docs/FIREBASE_IMAGE_OPTIMIZATION.md
+++ b/docs/FIREBASE_IMAGE_OPTIMIZATION.md
@@ -50,10 +50,9 @@ The application is built to handle the asynchronous nature of server-side resizi
 When a component requests an image, the `getOptimizedImageUrl` utility follows this sequence:
 
 1.  **Optimized Attempt:** Tries to fetch the WebP variant (`_400x400.webp` or `_1080x1080.webp`).
-2.  **Legacy Fallback:** If the WebP is missing, it tries the legacy `compressed` path (for very old documents).
-3.  **Latency Fallback:** If still missing, it fetches the original `full` image (ensuring the user sees something immediately after upload).
-4.  **UI Placeholder:** If all Storage paths fail, it returns `null`, and the component renders a CSS-based SVG placeholder.
+2.  **Latency Fallback:** If missing, it fetches the original `full` image (ensuring the user sees something immediately after upload).
+3.  **UI Placeholder:** If Storage paths fail, it returns `null`, and the component renders a CSS-based SVG placeholder.
 
 ### Clean Deletion
 
-When a recipe or image is deleted via the app, the logic in `recipe-image-utils.js` automatically cleans up all associated files: the original, the 400px WebP, the 1080px WebP, and any legacy compressed files.
+When a recipe or image is deleted via the app, the logic in `recipe-image-utils.js` automatically cleans up all associated files: the original, the 400px WebP, and the 1080px WebP.

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,7 +3,6 @@ const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const { initializeApp } = require('firebase-admin/app');
 const { getFirestore, FieldValue, Timestamp } = require('firebase-admin/firestore');
 const { getStorage } = require('firebase-admin/storage');
-const sharp = require('sharp');
 const { extractRecipeFromImage, extractRecipeFromUrl } = require('./utils/gemini-service');
 
 // Initialize Firebase Admin
@@ -54,45 +53,9 @@ async function processRecipeImages(recipeId, images, category, originalUserId) {
 
       console.log(`Uploaded full image to: ${fullPath}`);
 
-      // Create compressed version
-      let compressedBuffer;
-      try {
-        compressedBuffer = await sharp(buffer)
-          .resize(800, 600, {
-            fit: 'inside',
-            withoutEnlargement: true,
-          })
-          .jpeg({ quality: 80 })
-          .toBuffer();
-      } catch (compressionError) {
-        console.warn(
-          `Compression failed for ${fileName}, using original:`,
-          compressionError.message,
-        );
-        compressedBuffer = buffer;
-      }
-
-      // Upload compressed image
-      const compressedPath = `img/recipes/compressed/${category}/${recipeId}/${fileName}`;
-      const compressedFile = bucket.file(compressedPath);
-
-      await compressedFile.save(compressedBuffer, {
-        metadata: {
-          contentType: 'image/jpeg',
-          metadata: {
-            originalSource: 'recipe-reader-transfer',
-            transferredAt: new Date().toISOString(),
-            compressed: true,
-          },
-        },
-      });
-
-      console.log(`Uploaded compressed image to: ${compressedPath}`);
-
       // Create Firestore image object
       const firestoreImage = {
         access: 'public',
-        compressed: compressedPath,
         fileName: fileName,
         full: fullPath,
         id: imageId,

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@google/genai": "^1.35.0",
     "firebase-admin": "^12.7.0",
-    "firebase-functions": "^6.3.2",
-    "sharp": "^0.34.3"
+    "firebase-functions": "^6.3.2"
   },
   "devDependencies": {
     "eslint": "^8.15.0",

--- a/scripts/backfill/remove-compressed-field.js
+++ b/scripts/backfill/remove-compressed-field.js
@@ -1,0 +1,86 @@
+/**
+ * remove-compressed-field.js
+ *
+ * BACKFILL SCRIPT
+ * This script removes the legacy 'compressed' field from all recipe images in Firestore.
+ *
+ * Usage in Cloud Shell:
+ * 1. node remove-compressed-field.js
+ */
+
+const admin = require('firebase-admin');
+
+// Initialize
+admin.initializeApp();
+
+const db = admin.firestore();
+
+async function backfillRemoveCompressed() {
+  console.log('--- Starting Backfill: Removing Legacy "compressed" Fields ---');
+
+  const recipesSnapshot = await db.collection('recipes').get();
+  console.log(`Scanning ${recipesSnapshot.size} recipes...`);
+
+  let batch = db.batch();
+  let count = 0;
+  let totalUpdatedDocs = 0;
+  let totalImagesCleaned = 0;
+
+  for (const doc of recipesSnapshot.docs) {
+    const recipe = doc.data();
+    let hasChanges = false;
+
+    // Helper to clean image arrays
+    const cleanImages = (imgArray) => {
+      if (!Array.isArray(imgArray)) return imgArray;
+      return imgArray.map((img) => {
+        if (img.compressed) {
+          const { compressed, ...rest } = img;
+          hasChanges = true;
+          totalImagesCleaned++;
+          return rest;
+        }
+        return img;
+      });
+    };
+
+    const updatedImages = cleanImages(recipe.images);
+    const updatedPendingImages = cleanImages(recipe.pendingImages);
+
+    if (hasChanges) {
+      const updateData = {};
+      if (recipe.images !== undefined) updateData.images = updatedImages;
+      if (recipe.pendingImages !== undefined) updateData.pendingImages = updatedPendingImages;
+
+      batch.update(doc.ref, updateData);
+
+      count++;
+      totalUpdatedDocs++;
+
+      // Commit batch every 500 documents
+      if (count === 500) {
+        console.log(`Committing batch of 500 updates...`);
+        await batch.commit();
+        batch = db.batch();
+        count = 0;
+      }
+    }
+  }
+
+  // Commit remaining
+  if (count > 0) {
+    console.log(`Committing final batch of ${count} updates...`);
+    await batch.commit();
+  }
+
+  console.log('\n--- Backfill Summary ---');
+  console.log(`Total Recipes Scanned: ${recipesSnapshot.size}`);
+  console.log(`Total Recipes Updated: ${totalUpdatedDocs}`);
+  console.log(`Total Image Objects Cleaned: ${totalImagesCleaned}`);
+  console.log('\nSUCCESS: Legacy "compressed" fields have been removed from Firestore.');
+}
+
+backfillRemoveCompressed().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -13,7 +13,7 @@
  *   - generateImageId(): Generate a unique image ID.
  *
  * Image File Deletion:
- *   - deleteImageFiles(image): Delete all storage files for an image (full + WebP variants + legacy compressed).
+ *   - deleteImageFiles(image): Delete all storage files for an image (full + WebP variants).
  *
  * Multi Pending Images:
  *   - addPendingImages(recipeId, files, category, uploader): Upload multiple pending images.
@@ -102,19 +102,18 @@ export function generateImageId() {
 
 // --- Image File Deletion ---
 /**
- * Deletes all storage files for an image: full original, WebP variants, and optional legacy compressed.
+ * Deletes all storage files for an image: full original and WebP variants.
  * The full-size deletion propagates errors; variant deletions are best-effort.
- * @param {Object} image - Image object with `full` path and optional `compressed` path
+ * @param {Object} image - Image object with `full` path
  * @returns {Promise<void>}
  */
-export async function deleteImageFiles({ full, compressed }) {
+export async function deleteImageFiles({ full }) {
   const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
   const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
   await StorageService.deleteFile(full);
   await Promise.all([
     StorageService.deleteFile(optimized400).catch(() => {}),
     StorageService.deleteFile(optimized1080).catch(() => {}),
-    ...(compressed ? [StorageService.deleteFile(compressed).catch(() => {})] : []),
   ]);
 }
 
@@ -311,18 +310,10 @@ export async function migrateImageToCategory(image, recipeId, oldCategory, newCa
       }
     }
 
-    // If there was a legacy compressed version, delete it too
-    if (image.compressed) {
-      await StorageService.deleteFile(image.compressed).catch(() => {});
-    }
-
-    const updatedImage = {
+    return {
       ...image,
       full: newFullPath,
     };
-    delete updatedImage.compressed;
-
-    return updatedImage;
   } catch (error) {
     console.error(
       `Failed to migrate image ${image.id} from ${oldCategory} to ${newCategory}:`,

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -79,7 +79,6 @@ export function validateImageFile(file) {
 
 // --- Storage Path Helpers ---
 export function getImageStoragePath(recipeId, category, fileName, type = 'full') {
-  // type: 'full' | 'compressed'
   const base = `img/recipes/${type}/${category}/${recipeId}`;
   return `${base}/${fileName}`;
 }
@@ -189,21 +188,11 @@ export async function getOptimizedImageUrl(image, size = '400x400') {
   try {
     return await StorageService.getFileUrl(optimizedPath);
   } catch (error) {
-    // 2. Fallback to Legacy Compressed (if it exists in old docs)
-    // TODO: Remove after migration period — https://github.com/roiguri/My-Cook-Book/issues/142
-    if (image.compressed) {
-      try {
-        return await StorageService.getFileUrl(image.compressed);
-      } catch (innerError) {
-        // Fall through
-      }
-    }
-
-    // 3. Fallback to Full Original (Latency or Legacy)
+    // 2. Fallback to Full Original (Latency or Legacy)
     try {
       return await StorageService.getFileUrl(image.full);
     } catch (finalError) {
-      // 4. Ultimate Fallback
+      // 3. Ultimate Fallback
       return getPlaceholderImageUrl();
     }
   }

--- a/src/lib/recipes/recipe_form_component/edit_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/edit_recipe_component.js
@@ -205,32 +205,6 @@ class EditRecipeComponent extends HTMLElement {
     await FirestoreService.updateDocument('recipes', recipeId, recipeDataWithoutImage);
   }
 
-  async uploadImage(imageFile, category, imageName, oldImageName = null) {
-    // Remove old image if it exists and has changed
-    if (oldImageName && oldImageName !== imageName) {
-      try {
-        const oldFullPath = getImageStoragePath(this.recipeId, category, oldImageName, 'full');
-        const oldCompressedPath = getImageStoragePath(
-          this.recipeId,
-          category,
-          oldImageName,
-          'compressed',
-        );
-        await StorageService.deleteFile(oldFullPath);
-        // Catch deletion of compressed path in case it doesn't exist (legacy)
-        await StorageService.deleteFile(oldCompressedPath).catch(() => {});
-      } catch (error) {
-        console.error('Error removing old images:', error);
-      }
-    }
-    // Upload new image (full only)
-    try {
-      const fullPath = getImageStoragePath(this.recipeId, category, imageName, 'full');
-      await StorageService.uploadFile(imageFile, fullPath);
-    } catch (error) {
-      console.error('Error uploading new image:', error);
-    }
-  }
 
   showSuccessMessage(message) {
     const editRecipeModal = this.shadowRoot.querySelector('message-modal');

--- a/src/lib/recipes/recipe_form_component/edit_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/edit_recipe_component.js
@@ -205,7 +205,6 @@ class EditRecipeComponent extends HTMLElement {
     await FirestoreService.updateDocument('recipes', recipeId, recipeDataWithoutImage);
   }
 
-
   showSuccessMessage(message) {
     const editRecipeModal = this.shadowRoot.querySelector('message-modal');
 

--- a/tests/common/mocks/firestore-service.browser.js
+++ b/tests/common/mocks/firestore-service.browser.js
@@ -15,9 +15,7 @@ export const MOCK_RECIPES = [
     prepTime: 10,
     waitTime: 5,
     difficulty: 'Easy',
-    images: [
-      { id: 'img-1', full: IMG_RED, compressed: IMG_RED, isPrimary: true, access: 'public' },
-    ],
+    images: [{ id: 'img-1', full: IMG_RED, isPrimary: true, access: 'public' }],
     approved: true,
     creationTime: { seconds: 1700000003 },
   },
@@ -29,9 +27,7 @@ export const MOCK_RECIPES = [
     prepTime: 15,
     waitTime: 0,
     difficulty: 'Medium',
-    images: [
-      { id: 'img-2', full: IMG_GREEN, compressed: IMG_GREEN, isPrimary: true, access: 'public' },
-    ],
+    images: [{ id: 'img-2', full: IMG_GREEN, isPrimary: true, access: 'public' }],
     approved: true,
     creationTime: { seconds: 1700000002 },
   },
@@ -43,9 +39,7 @@ export const MOCK_RECIPES = [
     prepTime: 15,
     waitTime: 0,
     difficulty: 'Easy',
-    images: [
-      { id: 'img-3', full: IMG_BLUE, compressed: IMG_BLUE, isPrimary: true, access: 'public' },
-    ],
+    images: [{ id: 'img-3', full: IMG_BLUE, isPrimary: true, access: 'public' }],
     approved: true,
     creationTime: { seconds: 1700000001 },
   },
@@ -57,9 +51,7 @@ export const MOCK_RECIPES = [
     prepTime: 10,
     waitTime: 0,
     difficulty: 'Easy',
-    images: [
-      { id: 'img-4', full: IMG_RED, compressed: IMG_RED, isPrimary: true, access: 'public' },
-    ],
+    images: [{ id: 'img-4', full: IMG_RED, isPrimary: true, access: 'public' }],
     approved: true,
     creationTime: { seconds: 1700000000 },
   },

--- a/tests/js/utils/form/form-data-collector.test.mjs
+++ b/tests/js/utils/form/form-data-collector.test.mjs
@@ -73,7 +73,6 @@ describe('form-data-collector', () => {
           id: 'existing-1',
           isPrimary: false,
           full: 'path/to/full.jpg',
-          compressed: 'path/to/compressed.jpg',
           access: 'public',
           uploadedBy: 'user123',
           fileName: 'existing.jpg',
@@ -302,7 +301,7 @@ describe('form-data-collector', () => {
         source: 'new',
       });
 
-      // Existing image (compressed field is intentionally not collected — WebP migration)
+      // Existing image (collected as part of the images array)
       expect(result.images[1]).toEqual({
         id: 'existing-1',
         isPrimary: false,

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -105,11 +105,6 @@ describe('recipe-image-utils', () => {
         'img/recipes/full/cat/id1/file.jpg',
       );
     });
-    it('generates correct path for compressed', () => {
-      expect(getImageStoragePath('id2', 'cat2', 'file2.jpg', 'compressed')).toBe(
-        'img/recipes/compressed/cat2/id2/file2.jpg',
-      );
-    });
   });
 
   describe('deleteImageFiles', () => {
@@ -205,19 +200,7 @@ describe('recipe-image-utils', () => {
       expect(getFileUrlMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
       expect(result).toBe('webp-url');
     });
-    it('falls back to compressed when WebP is missing', async () => {
-      getFileUrlMock
-        .mockRejectedValueOnce(new Error('not found')) // WebP fails
-        .mockResolvedValueOnce('compressed-url'); // compressed works
-      const image = {
-        id: '1',
-        full: 'img/recipes/full/cat/rid/image.jpg',
-        compressed: 'img/recipes/compressed/cat/rid/image.jpg',
-      };
-      const result = await getOptimizedImageUrl(image, '400x400');
-      expect(result).toBe('compressed-url');
-    });
-    it('falls back to full when WebP and compressed are missing', async () => {
+    it('falls back to full when WebP variant is missing', async () => {
       getFileUrlMock
         .mockRejectedValueOnce(new Error('not found')) // WebP fails
         .mockResolvedValueOnce('full-url'); // full works

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -114,13 +114,6 @@ describe('recipe-image-utils', () => {
       expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
       expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_1080x1080.webp');
     });
-    it('deletes legacy compressed when provided', async () => {
-      await deleteImageFiles({
-        full: 'img/recipes/full/cat/rid/image.jpg',
-        compressed: 'img/recipes/compressed/cat/rid/image.jpg',
-      });
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/compressed/cat/rid/image.jpg');
-    });
     it('silently ignores errors on variant deletion', async () => {
       deleteFileMock
         .mockResolvedValueOnce(undefined) // full OK
@@ -219,7 +212,7 @@ describe('recipe-image-utils', () => {
       expect(getFileUrlMock).not.toHaveBeenCalled();
     });
     it('returns null for image without full path', async () => {
-      expect(await getOptimizedImageUrl({ id: '1', compressed: 'c' }, '400x400')).toBeNull();
+      expect(await getOptimizedImageUrl({ id: '1' }, '400x400')).toBeNull();
       expect(getFileUrlMock).not.toHaveBeenCalled();
     });
     it('uses provided size suffix', async () => {
@@ -276,11 +269,11 @@ describe('recipe-image-utils', () => {
     it('removes all approved and pending images and updates Firestore', async () => {
       getDocumentMock.mockResolvedValue({
         images: [
-          { id: 'a', full: 'img/recipes/full/cat/rid/a.jpg', compressed: 'c1' },
+          { id: 'a', full: 'img/recipes/full/cat/rid/a.jpg' },
           { id: 'b', full: 'img/recipes/full/cat/rid/b.jpg' },
         ],
         pendingImages: [
-          { id: 'p1', full: 'img/recipes/full/cat/rid/p1.jpg', compressed: 'pc1' },
+          { id: 'p1', full: 'img/recipes/full/cat/rid/p1.jpg' },
           { id: 'p2', full: 'img/recipes/full/cat/rid/p2.jpg' },
         ],
       });
@@ -331,7 +324,6 @@ describe('recipe-image-utils', () => {
       expect(uploadFileMock).toHaveBeenCalledTimes(1);
       expect(meta).toHaveProperty('id');
       expect(meta.full).toContain('img/recipes/full/cat/rid/');
-      expect(meta).not.toHaveProperty('compressed');
       expect(meta.fileName).toBe('primary.jpg');
       expect(meta.isPrimary).toBe(true);
       expect(meta.uploadedBy).toBe('user1');
@@ -370,7 +362,6 @@ describe('recipe-image-utils', () => {
       expect(result.length).toBe(2);
       expect(result[0]).toHaveProperty('id');
       expect(result[1]).toHaveProperty('id');
-      expect(result[0]).not.toHaveProperty('compressed');
     });
     it('returns [] if no files', async () => {
       getDocumentMock.mockResolvedValue({ pendingImages: [] });
@@ -409,14 +400,13 @@ describe('recipe-image-utils', () => {
 
   describe('rejectPendingImageById', () => {
     it('deletes all files and removes the pending image from the array', async () => {
-      const pending = { id: 'pid', full: 'img/recipes/full/cat/rid/image.jpg', compressed: 'c' };
+      const pending = { id: 'pid', full: 'img/recipes/full/cat/rid/image.jpg' };
       getDocumentMock.mockResolvedValue({ pendingImages: [pending, { id: 'other' }] });
       updateDocumentMock.mockResolvedValue();
       await rejectPendingImageById('rid', 'pid');
       expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
       expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
       expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_1080x1080.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('c');
       expect(updateDocumentMock).toHaveBeenCalledWith(
         'recipes',
         'rid',

--- a/tests/lib/recipes/recipe-card/recipe-card.test.mjs
+++ b/tests/lib/recipes/recipe-card/recipe-card.test.mjs
@@ -37,7 +37,7 @@ const mockRecipeData = {
   prepTime: 10,
   waitTime: 20,
   difficulty: 'קלה',
-  images: [{ id: 'img1', isPrimary: true, compressed: 'path/to/img.jpg' }],
+  images: [{ id: 'img1', isPrimary: true }],
 };
 
 const mockUser = {


### PR DESCRIPTION
This change removes the second tier of the image fallback system (legacy compressed images) from the `getOptimizedImageUrl` utility. Now that the migration period is over and all existing images have been processed by the Firebase "Resize Images" extension, this fallback is no longer needed. The system now correctly follows a 2-tier fallback:
1. WebP variant (_400x400.webp / _1080x1080.webp)
2. Full Original image (kept for new uploads or latency)

Dead code in `edit_recipe_component.js` (`uploadImage` method) was also removed as it was unused and contained legacy logic.

Fixes #142

---
*PR created automatically by Jules for task [15218602841228954289](https://jules.google.com/task/15218602841228954289) started by @roiguri*