### PR TITLE
Fix Categories Dropdown RTL on Mobile

### DIFF
--- a/src/lib/collections/category-navigation/category-navigation-styles.js
+++ b/src/lib/collections/category-navigation/category-navigation-styles.js
@@ -57,11 +57,15 @@ export const styles = `
   }
 
   /* RTL support */
+  :host([dir="rtl"]) {
+    direction: rtl;
+  }
+
   :host([dir="rtl"]) .category-tabs {
     direction: rtl;
   }
 
-  :host([dir="rtl"]) .select-ctrl {
+  :host([dir="rtl"]) .category-dropdown {
     direction: rtl;
   }
 `;

--- a/src/lib/collections/category-navigation/category-navigation.html
+++ b/src/lib/collections/category-navigation/category-navigation.html
@@ -1,12 +1,12 @@
 <div class="category-navigation">
-  <nav dir="rtl" class="category-tabs">
+  <nav class="category-tabs">
     <ul class="category-tabs-list">
       <!-- Category tabs will be dynamically inserted here -->
     </ul>
   </nav>
 
   <div class="category-dropdown">
-    <select dir="rtl" class="select-ctrl">
+    <select class="select-ctrl">
       <!-- Category options will be dynamically inserted here -->
     </select>
   </div>

--- a/src/styles/components/fields.css
+++ b/src/styles/components/fields.css
@@ -118,7 +118,7 @@
   display: inline-flex;
   align-items: center;
   height: 38px;
-  padding: 0 14px 0 32px; /* extra left space for chevron (LTR) */
+  padding: 0 32px 0 14px; /* extra space for chevron (right in LTR, left in RTL) */
   font-family: var(--font-ui);
   font-size: 13px;
   font-weight: 500;
@@ -134,7 +134,7 @@
   box-sizing: border-box;
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%237c7562' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m6 8 4 4 4-4'/%3e%3c/svg%3e");
   background-repeat: no-repeat;
-  background-position: left 10px center; /* LTR: chevron on right; override for RTL below */
+  background-position: right 10px center;
   background-size: 16px;
   transition:
     border-color var(--dur-1) var(--ease),
@@ -143,9 +143,10 @@
 
 /* RTL: flip padding + chevron to the left */
 [dir='rtl'] .select-ctrl,
+.select-ctrl[dir='rtl'],
 .select-ctrl:dir(rtl) {
-  padding: 0 32px 0 14px;
-  background-position: right 10px center;
+  padding: 0 14px 0 32px;
+  background-position: left 10px center;
 }
 
 .select-ctrl:hover {


### PR DESCRIPTION
The categories dropdown on mobile was displaying in LTR (Left-To-Right) even for Hebrew. This was due to inverted logic in the global `fields.css` stylesheet and hardcoded directionality in the component template. This PR corrects the global styles, enhances the component's direction-awareness, and ensures a proper RTL display on mobile.

Fixes #132

---
*PR created automatically by Jules for task [5256162905994525454](https://jules.google.com/task/5256162905994525454) started by @roiguri*