### PR TITLE
Wire mobile nav search bar to categories filter

### DIFF
--- a/src/app/pages/categories-page.js
+++ b/src/app/pages/categories-page.js
@@ -311,6 +311,9 @@ export default {
 
     document.addEventListener('recipe-favorite-changed', this._boundFavoriteChanged);
 
+    this._boundHeaderSearch = this.handleHeaderSearchInput.bind(this);
+    window.addEventListener('search-input', this._boundHeaderSearch);
+
     this.setupNavigationInterception();
   },
 
@@ -319,11 +322,22 @@ export default {
     if (this._boundFavoriteChanged) {
       document.removeEventListener('recipe-favorite-changed', this._boundFavoriteChanged);
     }
+    if (this._boundHeaderSearch) {
+      window.removeEventListener('search-input', this._boundHeaderSearch);
+    }
   },
 
   updateUI() {
     this.updateUnifiedFilter();
     this.updatePageTitle();
+    this.updateHeaderSearch();
+  },
+
+  updateHeaderSearch() {
+    const headerSearch = document.querySelector('header-search-bar');
+    if (headerSearch && headerSearch.getSearchText() !== this.currentSearchQuery) {
+      headerSearch.setSearchText(this.currentSearchQuery);
+    }
   },
 
   updateUnifiedFilter() {
@@ -453,6 +467,15 @@ export default {
     recipePresentationGrid.setRecipes(this.displayedRecipes, false);
   },
 
+  handleHeaderSearchInput(event) {
+    if (event.target.tagName === 'HEADER-SEARCH-BAR' && window.innerWidth <= 768) {
+      const unifiedFilter = document.getElementById('unified-filter');
+      if (unifiedFilter) {
+        unifiedFilter.setSearchQuery(event.detail.searchText);
+      }
+    }
+  },
+
   handleRecipeSelected(event) {
     const { recipeId } = event.detail;
     if (window.spa?.router) {
@@ -478,6 +501,9 @@ export default {
       this.currentPage = 1;
       this.updateUI();
       await this.displayCurrentPageRecipes();
+
+      // Ensure header search bar is in sync (useful on desktop)
+      this.updateHeaderSearch();
 
       this.updateURL(true);
     }

--- a/src/lib/search/header-search-bar/header-search-bar.js
+++ b/src/lib/search/header-search-bar/header-search-bar.js
@@ -158,6 +158,12 @@ class HeaderSearchBar extends HTMLElement {
   async navigateToSearch(searchText) {
     if (!searchText.trim()) return;
 
+    // If on categories page and on mobile, don't perform full search navigation
+    // as it will be handled by real-time filtering in categories-page.js
+    if (window.innerWidth <= 768 && window.spa?.router?.getCurrentRoute() === '/categories') {
+      return;
+    }
+
     try {
       // Load all approved recipes from Firestore
       const recipes = await FirestoreService.queryDocuments('recipes', {


### PR DESCRIPTION
This change connects the header navigation search bar to the recipe filtering system on the categories page for mobile users. Since the local categories search bar is hidden on mobile to save space, the header search bar now fulfills its role by forwarding input events to the unified recipe filter in real-time. It also ensures that the search bar state remains in sync with the page's current filters and prevents unnecessary page reloads when searching while already on the categories page.

Fixes #114

---
*PR created automatically by Jules for task [160571221734818864](https://jules.google.com/task/160571221734818864) started by @roiguri*