### PR TITLE
feat(notifications): add manager push notifications for pending recipes

### DIFF
--- a/docs/code-review-2026-05.md
+++ b/docs/code-review-2026-05.md
@@ -1,0 +1,249 @@
+# Deep Code Review — May 2026
+
+> Expert review across architecture, performance, and security for the My-Cook-Book vanilla JS SPA. Findings are prioritized P0 → P4 with file:line references and concrete fixes. Nothing in this document has been implemented yet.
+
+## Scope
+
+Three dimensions reviewed in parallel:
+
+1. **Architecture** — router, page lifecycle, components, services, state
+2. **Performance** — bundling, initial load, queries, rendering, Cloud Functions
+3. **Security** — Firestore/Storage rules, XSS, Cloud Functions, auth flow
+
+All findings were spot-checked against the actual code. Two initially flagged "leaks" turned out to be false positives and were removed:
+
+- recipe-detail-page `_menuCleanup` IS cleaned up at [recipe-detail-page.js:207](../src/app/pages/recipe-detail-page.js#L207)
+- my-meal-page DOES define `unmount()` at [my-meal-page.js:905](../src/app/pages/my-meal-page.js#L905)
+
+---
+
+## P0 — Critical Security (Fix First)
+
+### S1. Storage: any authenticated user can delete any recipe image
+
+- **Where:** [storage.rules:22](../storage.rules#L22), [storage.rules:45](../storage.rules#L45)
+- **Issue:** `allow delete: if isAuthenticated();` — no owner check. Any signed-in user can wipe another user's images and media instructions.
+- **Fix:** Restrict delete to manager only. `isManager()` helper would need to be added to storage.rules (Firestore-style `firestore.get()` cross-service is supported).
+- **Verification:** Add a Storage Rules unit test (`@firebase/rules-unit-testing`) attempting delete as a non-manager — must fail.
+
+### S2. Cloud Function SSRF in `extractRecipeFromUrl`
+
+- **Where:** [functions/index.js:529-583](../functions/index.js#L529)
+- **Issue:** Function fetches arbitrary user-supplied URLs server-side. Validation is only `new URL(url)`. Approved/manager role gating helps but does not prevent insider abuse or compromised accounts probing internal Google Cloud metadata (`169.254.169.254`), private IPs, or `file://`.
+- **Fix:** Block private/loopback/link-local IPs, restrict scheme to `http(s)`, follow redirects with re-validation, and consider a domain allowlist if practical.
+- **Verification:** Manual call from Firebase Emulator with `http://169.254.169.254/...` — must reject with `invalid-argument`.
+
+### S3. Cloud Function unbounded image buffer
+
+- **Where:** [functions/index.js:13-78](../functions/index.js#L13) (`processRecipeImages`)
+- **Issue:** `await response.arrayBuffer()` with no Content-Length check. Storage rules cap uploads at 50MB but `downloadUrl` is fetched fresh on the server and could be redirected.
+- **Fix:** Inspect `response.headers.get('content-length')` before buffering; reject >50MB.
+
+### S4. Pub/Sub trigger lacks origin validation
+
+- **Where:** `processRecipeTransfer` in [functions/index.js](../functions/index.js)
+- **Issue:** No payload signature/source check. Relies entirely on IAM. Defense-in-depth gap.
+- **Fix:** Validate the message envelope shape and the publisher service account; fail closed on unexpected origin.
+
+---
+
+## P1 — High-Priority Bugs & Memory Leaks
+
+### B1. `manager-dashboard-page` document listener never removed
+
+- **Where:** [manager-dashboard-page.js:162](../src/app/pages/manager-dashboard-page.js#L162)
+- **Issue:** `document.addEventListener('recipe-updated', ...)` registered in `setupEditRecipeListener()` with no removal in `unmount()` at line 46. Each visit to the dashboard adds a new listener; navigation cycles cause duplicate `refreshRecipes()` calls.
+- **Fix:** Store the bound handler on `this._onRecipeUpdated`, attach with that reference, remove in `unmount()`.
+
+### B2. PageManager `isLoading` flag can stick
+
+- **Where:** [page-manager.js:14-47](../src/app/core/page-manager.js#L14)
+- **Issue:** If `unmountCurrentPage()` or `render()` throws, `isLoading` never resets and all subsequent navigation is silently dropped.
+- **Fix:** Wrap navigation logic in `try { ... } finally { this.isLoading = false; }`.
+
+### B3. No AbortController on page-scoped data fetches
+
+- **Where:** [home-page.js:56](../src/app/pages/home-page.js#L56), [categories-page.js:48](../src/app/pages/categories-page.js#L48), [manager-dashboard-page.js:259](../src/app/pages/manager-dashboard-page.js#L259)
+- **Issue:** Rapid navigation (e.g., back-button spam) lets stale fetches resolve into a detached page, sometimes throwing on null DOM refs, sometimes corrupting cached state.
+- **Fix:** Either (a) add an `AbortController` per page mount and pass `signal` into Firestore wrappers, or (b) tag each mount with a monotonically increasing `mountId` and discard responses whose id ≠ current.
+
+### B4. Auth observer cleanup inconsistent across pages
+
+- **Where:** Various pages register `onAuthStateChanged` listeners but only some call `authUnsubscribe()` in unmount. Mostly correct in newer pages but not enforced.
+- **Fix:** Architectural — see R2 (base page class). Stopgap: audit each page module and ensure unsubscribe is called.
+
+### B5. `categories-page` listener possibly re-attached
+
+- **Where:** [categories-page.js:312](../src/app/pages/categories-page.js#L312)
+- **Issue:** `setupEventListeners()` may be invoked more than once on `handleRouteChange` paths; `_boundFavoriteChanged` is bound once but re-attached without dedup.
+- **Fix:** Guard with `if (this._listenersAttached) return;` or remove-then-add pattern.
+
+---
+
+## P2 — Performance Wins
+
+### P1. Firebase SDK loaded synchronously at startup
+
+- **Where:** [src/app.js:15-16](../src/app.js#L15)
+- **Impact:** ~88KB modular Firebase blocks first paint; impacts unauthenticated home-page LCP.
+- **Fix:** Defer `initFirebase()` until first auth/data call. Wrap as lazy singleton in `firebase-config.js`. Header avatar already needs auth, so initialize there.
+
+### P2. Categories page loads ALL recipes client-side
+
+- **Where:** [categories-page.js:211-217](../src/app/pages/categories-page.js#L211)
+- **Impact:** No `limit()` and no server-side pagination. Cost grows linearly with collection size; UI does client-side filtering on the full set.
+- **Fix:** Use Firestore `limit(20)` + cursor (`startAfter`) pagination per category. Server-side `where('category', '==', X)` query with `orderBy('creationTime', 'desc')` — add the matching composite index in `firestore.indexes.json`.
+
+### P3. Manager dashboard loads entire `users` collection
+
+- **Where:** [manager-dashboard-page.js:184](../src/app/pages/manager-dashboard-page.js#L184)
+- **Impact:** Quadratic Firestore reads as users grow.
+- **Fix:** Paginate (`limit(50)` + cursor); add server-side search by email/name with `where('email', '>=', ...)`. If full export needed, use a Cloud Function with admin SDK.
+
+### P4. No responsive images / no `srcset`
+
+- **Where:** Recipe cards and detail pages
+- **Impact:** Full-resolution Storage URLs served to thumbnails (~1MB images for ~150px slots).
+- **Fix:** Use the auto-generated WebP variants from the Storage-triggered resize (per CLAUDE.md, already deployed). Wire `<img srcset="<thumb> 400w, <medium> 800w, <full> 1600w" sizes="...">`.
+
+### P5. Component renders use full `shadowRoot.innerHTML` rewrites
+
+- **Where:** [recipe_component.js:88](../src/lib/recipes/recipe_component/recipe_component.js#L88), recipe-card, image-handler
+- **Impact:** Destroys listeners on every render; FOUC; expensive in grids.
+- **Fix:** Render-once + delegate updates via attribute observation; or use a tiny diff library scoped to the component. Lower priority — measure first with DevTools Performance tab.
+
+### P6. ImageHandler preview uses base64 data: URLs
+
+- **Where:** [image-handler.js:498](../src/lib/images/image-handler.js#L498)
+- **Impact:** 5 × 3MB images = 15MB+ base64 strings held in DOM/JS memory simultaneously.
+- **Fix:** Use `URL.createObjectURL(file)` for previews; revoke with `URL.revokeObjectURL()` on remove.
+
+### P7. Cloud Function image processing is sequential
+
+- **Where:** [functions/index.js:18-28](../functions/index.js#L18)
+- **Fix:** `await Promise.all(images.map(processOne))`. ~5× speedup on multi-image recipes.
+
+### P8. No CSS code-splitting
+
+- **Where:** [src/styles/main.css](../src/styles/main.css)
+- **Impact:** All page styles ship on first load.
+- **Fix:** Move per-page CSS into the page module via dynamic `import('./page.css')`. Lower priority unless CSS bundle exceeds ~50KB.
+
+---
+
+## P3 — Lower-Severity Security
+
+### S5. Recipes are publicly readable including unapproved
+
+- **Where:** [firestore.rules:80](../firestore.rules#L80) (`allow read: if true;`)
+- **Risk:** Pending user submissions exposed to scrapers/bots.
+- **Fix:** `allow read: if resource.data.approved == true || isOwner(resource.data.userId) || isManager();` — verify all read paths first (categories page filters client-side; this would push that filter to the server).
+
+### S6. Manager dashboard uses `innerHTML` with template interpolation
+
+- **Where:** [manager-dashboard-page.js:687](../src/app/pages/manager-dashboard-page.js#L687) (`countChip.innerHTML = \`${item.count}<span>...</span>\``)
+- **Severity:** LOW (`item.count` is a server-aggregated number, not user-controlled). Still a hygiene fix and prevents future regressions if the field is ever repurposed.
+- **Fix:** Use `textContent` for the dynamic part; build the `<span>` via `createElement`.
+
+### S7. No rate limiting on Firestore writes
+
+- **Where:** firestore.rules
+- **Impact:** Abuse vector for recipe spam.
+- **Fix:** Add custom claims with last-write timestamp, or move sensitive writes through Callable Functions with a per-uid token bucket.
+
+### S8. Avatar storage allows public read with no delete restriction
+
+- **Where:** [storage.rules:28-30](../storage.rules#L28)
+- **Fix:** Restrict delete to owner via path-based UID check; consider authenticated-only read.
+
+---
+
+## P4 — Architectural Refactors (Larger Investments)
+
+### R1. Centralized event bus with auto-deregistration
+
+- **Why:** Cross-component communication is currently `document.addEventListener('recipe-updated', ...)` etc. — listeners accumulate, cleanup is manual and inconsistent (see B1).
+- **Proposal:** Tiny singleton `events.js` exposing `on(name, handler)` returning an unsubscriber. Pages collect unsubscribers in an array and flush in `unmount()`.
+- **Files affected:** New `src/app/core/events.js`; refactor [manager-dashboard-page.js:162](../src/app/pages/manager-dashboard-page.js#L162), [categories-page.js:312](../src/app/pages/categories-page.js#L312), [recipe-detail-page.js:109](../src/app/pages/recipe-detail-page.js#L109), and any other `document.addEventListener` site.
+
+### R2. Base page module with lifecycle scaffolding
+
+- **Why:** Every page repeats the same boilerplate: track auth unsubscriber, track event listeners, track timers. Easy to forget (see B4).
+- **Proposal:** A `createPage({ render, mount, unmount })` factory that:
+  - Provides `this.disposables.push(fn)` API
+  - Auto-flushes disposables on unmount
+  - Wraps mount in try/catch and logs to a central error reporter
+- **Files affected:** New `src/app/core/page.js`; gradually migrate pages (start with [\_template.js](../src/app/pages/_template.js)).
+
+### R3. State store for shared data (current user, favorites, active meal)
+
+- **Why:** Currently re-fetched per page. Module-local `this.state` doesn't survive navigation.
+- **Proposal:** Lightweight pub/sub store in `src/app/core/store.js` with slices: `auth`, `favorites`, `activeMeal`. Subscribers re-render on change.
+- **Files affected:** New `src/app/core/store.js`; refactor [auth-controller.js](../src/lib/auth/auth-controller.js), favorites flows, my-meal-page.
+
+### R4. Server-side pagination utility
+
+- **Why:** P2/P3 above both need cursor-based queries. Currently every page reinvents.
+- **Proposal:** Add `paginatedQuery(collection, { where, orderBy, pageSize })` to [FirestoreService](../src/js/services/firestore-service.js) returning `{ docs, nextCursor, hasMore }`.
+
+### R5. Storage rules — owner metadata
+
+- **Why:** Currently delete protection is impossible without owner info on the file.
+- **Proposal:** When uploading, set custom metadata `uploadedBy: uid`. Update storage.rules to `resource.metadata.uploadedBy == request.auth.uid || isManager()` for delete.
+
+---
+
+## Execution Plan
+
+Recommended order — each is a self-contained session:
+
+| Order | Item                                         | Rough effort         |
+| ----- | -------------------------------------------- | -------------------- |
+| 1     | S1 (Storage delete)                          | 30 min + tests       |
+| 2     | S2 + S3 (SSRF + buffer cap)                  | 1 hr                 |
+| 3     | S4 (Pub/Sub validation)                      | 30 min               |
+| 4     | B1 + B2 (listener leak + isLoading)          | 30 min               |
+| 5     | B3 (AbortController/mountId pattern)         | 1.5 hr               |
+| 6     | B4 + B5 (auth/listener audit)                | 1 hr                 |
+| 7     | P2 + P3 (server-side pagination)             | 2 hr (depends on R4) |
+| 8     | P1 (defer Firebase)                          | 1 hr                 |
+| 9     | P4 (responsive images)                       | 1.5 hr               |
+| 10    | P6 + P7 (image perf)                         | 1 hr                 |
+| 11    | S5 + S6 + S7 + S8 (hardening)                | 1.5 hr               |
+| 12    | R1 → R2 → R3 → R4 → R5 (refactors, in order) | spread over weeks    |
+
+---
+
+## Critical Files
+
+- [storage.rules](../storage.rules)
+- [firestore.rules](../firestore.rules)
+- [functions/index.js](../functions/index.js)
+- [src/app.js](../src/app.js)
+- [src/app/core/page-manager.js](../src/app/core/page-manager.js)
+- [src/app/pages/manager-dashboard-page.js](../src/app/pages/manager-dashboard-page.js)
+- [src/app/pages/categories-page.js](../src/app/pages/categories-page.js)
+- [src/app/pages/home-page.js](../src/app/pages/home-page.js)
+- [src/js/services/firestore-service.js](../src/js/services/firestore-service.js)
+- [src/lib/images/image-handler.js](../src/lib/images/image-handler.js)
+- [src/lib/recipes/recipe_component/recipe_component.js](../src/lib/recipes/recipe_component/recipe_component.js)
+
+## Verification Strategy
+
+- **Security rules:** Add `@firebase/rules-unit-testing` suite covering each rule change. Run via `firebase emulators:exec`.
+- **Cloud Functions:** Test SSRF/buffer fixes against the Functions emulator with crafted payloads.
+- **Memory leaks:** In Chrome DevTools → Memory → Allocation timeline, navigate between pages 20× and verify retained-size stays flat.
+- **Performance:** Lighthouse before/after for home + categories. Target LCP improvement after P1 + P4.
+- **Pagination:** Seed Firestore emulator with 200 recipes, verify category page loads in pages of 20.
+- **Regression:** `npm run test`, `npm run lint`, `npm run build`, plus a manual click-through of every route.
+
+---
+
+## Out of Scope
+
+Not covered in this pass — flag for follow-up if needed:
+
+- Accessibility audit
+- SEO / meta tags / structured data
+- Analytics / observability gaps
+- E2E test coverage gaps (Playwright suite exists but not audited here)

--- a/firestore.rules
+++ b/firestore.rules
@@ -44,7 +44,7 @@ service cloud.firestore {
                     && request.resource.data.role == 'user';
       
       // UPDATE:
-      // - Users can update their own profile (avatar, favorites, name)
+      // - Users can update their own profile (avatar, favorites, name, fcmTokens)
       // - CRITICAL: Users CANNOT change their role
       // - Managers can update anything (including roles)
       allow update: if (isOwner(userId) && request.resource.data.role == resource.data.role)

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,11 @@
 const { onMessagePublished } = require('firebase-functions/v2/pubsub');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
+const { onDocumentCreated } = require('firebase-functions/v2/firestore');
 const { initializeApp } = require('firebase-admin/app');
 const { getFirestore, FieldValue, Timestamp } = require('firebase-admin/firestore');
 const { getStorage } = require('firebase-admin/storage');
 const { extractRecipeFromImage, extractRecipeFromUrl } = require('./utils/gemini-service');
+const { sendNotificationToRole } = require('./notifications');
 
 // Initialize Firebase Admin
 initializeApp();
@@ -580,5 +582,42 @@ exports.extractRecipeFromUrl = onCall({ secrets: ['GEMINI_API_KEY'] }, async (re
       throw error;
     }
     throw new HttpsError('internal', 'Recipe extraction from URL failed', error.message);
+  }
+});
+
+/**
+ * Notify managers when a new recipe is submitted for approval.
+ *
+ * Fires on every recipe create; only sends when `approved === false` so it
+ * skips manager-authored recipes that are created already-approved and the
+ * processRecipeTransfer pipeline (which also lands recipes with approved=false
+ * — that's intentional, those should be reviewed too).
+ *
+ * One push per event for v1. Batching tracked separately.
+ */
+exports.onRecipeCreated = onDocumentCreated('recipes/{recipeId}', async (event) => {
+  const snap = event.data;
+  if (!snap) return;
+  const recipe = snap.data() || {};
+  if (recipe.approved === true) return;
+
+  const recipeId = event.params.recipeId;
+  const recipeName = recipe.name || 'מתכון חדש';
+
+  try {
+    const result = await sendNotificationToRole('manager', {
+      title: 'מתכון חדש ממתין לאישור',
+      body: recipeName,
+      collapseKey: 'recipe-approval',
+      url: '/dashboard',
+      data: {
+        type: 'recipe-approval',
+        recipeId,
+      },
+    });
+    console.log(`[onRecipeCreated] notified managers for ${recipeId}:`, result);
+  } catch (error) {
+    console.error(`[onRecipeCreated] notification failed for ${recipeId}:`, error);
+    // Don't rethrow — notification failure must not block the recipe creation.
   }
 });

--- a/functions/notifications.js
+++ b/functions/notifications.js
@@ -44,9 +44,17 @@ async function sendNotificationToUsers(uids, payload) {
 
   if (tokenIndex.length === 0) return { sent: 0, pruned: 0 };
 
+  // Data-only payload: when `notification` is present on a Web push, FCM auto-
+  // displays a banner using the site favicon AND the SW's onBackgroundMessage
+  // also fires our own — yielding two notifications. Sending only `data` makes
+  // the SW (and the page's onMessage) the single source of truth for display.
   const message = {
-    notification: { title: payload.title, body: payload.body },
-    data: stringifyData({ ...(payload.data || {}), url: payload.url || '/dashboard' }),
+    data: stringifyData({
+      ...(payload.data || {}),
+      title: payload.title,
+      body: payload.body,
+      url: payload.url || '/dashboard',
+    }),
     tokens: tokenIndex.map((t) => t.entry.token),
     webpush: {
       headers: payload.collapseKey ? { Topic: payload.collapseKey } : undefined,

--- a/functions/notifications.js
+++ b/functions/notifications.js
@@ -1,0 +1,110 @@
+/**
+ * Generic notification helper for Cloud Functions.
+ *
+ * Channel-agnostic API for sending notifications to users. Currently backed
+ * by FCM. Call sites (triggers, callables) should never call FCM directly —
+ * they go through these helpers so we can swap channels or add fan-out (email,
+ * in-app) without touching trigger code.
+ *
+ * Public API:
+ *   - sendNotificationToUsers(uids, payload): Send to a specific list of user IDs.
+ *   - sendNotificationToRole(role, payload):  Send to all users with the given role.
+ *
+ * payload shape:
+ *   {
+ *     title:        string,
+ *     body:         string,
+ *     data?:        object  // string-valued; merged into FCM data payload
+ *     collapseKey?: string  // groups notifications so a newer one replaces older
+ *     url?:         string  // deep link opened on notificationclick
+ *   }
+ */
+const { getFirestore, FieldValue } = require('firebase-admin/firestore');
+const { getMessaging } = require('firebase-admin/messaging');
+
+async function sendNotificationToUsers(uids, payload) {
+  if (!Array.isArray(uids) || uids.length === 0) return { sent: 0, pruned: 0 };
+
+  const db = getFirestore();
+  const userDocs = await Promise.all(uids.map((uid) => db.collection('users').doc(uid).get()));
+
+  // Flatten all tokens across the recipient set, keeping track of which user
+  // each token belongs to so we can prune dead tokens individually.
+  const tokenIndex = []; // [{ uid, entry }]
+  for (const snap of userDocs) {
+    if (!snap.exists) continue;
+    const data = snap.data() || {};
+    const tokens = Array.isArray(data.fcmTokens) ? data.fcmTokens : [];
+    for (const entry of tokens) {
+      if (entry && typeof entry.token === 'string' && entry.token) {
+        tokenIndex.push({ uid: snap.id, entry });
+      }
+    }
+  }
+
+  if (tokenIndex.length === 0) return { sent: 0, pruned: 0 };
+
+  const message = {
+    notification: { title: payload.title, body: payload.body },
+    data: stringifyData({ ...(payload.data || {}), url: payload.url || '/dashboard' }),
+    tokens: tokenIndex.map((t) => t.entry.token),
+    webpush: {
+      headers: payload.collapseKey ? { Topic: payload.collapseKey } : undefined,
+      fcmOptions: payload.url ? { link: payload.url } : undefined,
+    },
+  };
+
+  const response = await getMessaging().sendEachForMulticast(message);
+
+  // Prune tokens that came back as permanently invalid.
+  const deadByUser = new Map(); // uid -> [entry, ...]
+  response.responses.forEach((res, i) => {
+    if (res.success) return;
+    const code = res.error && res.error.code;
+    if (
+      code === 'messaging/registration-token-not-registered' ||
+      code === 'messaging/invalid-registration-token' ||
+      code === 'messaging/invalid-argument'
+    ) {
+      const { uid, entry } = tokenIndex[i];
+      if (!deadByUser.has(uid)) deadByUser.set(uid, []);
+      deadByUser.get(uid).push(entry);
+    }
+  });
+
+  let prunedCount = 0;
+  if (deadByUser.size > 0) {
+    await Promise.all(
+      Array.from(deadByUser.entries()).map(async ([uid, entries]) => {
+        prunedCount += entries.length;
+        await db
+          .collection('users')
+          .doc(uid)
+          .update({ fcmTokens: FieldValue.arrayRemove(...entries) })
+          .catch((err) => console.warn(`[notifications] prune failed for ${uid}:`, err.message));
+      }),
+    );
+  }
+
+  return { sent: response.successCount, failed: response.failureCount, pruned: prunedCount };
+}
+
+async function sendNotificationToRole(role, payload) {
+  if (!role) return { sent: 0, pruned: 0 };
+  const db = getFirestore();
+  const snap = await db.collection('users').where('role', '==', role).get();
+  const uids = snap.docs.map((d) => d.id);
+  return sendNotificationToUsers(uids, payload);
+}
+
+// FCM data payload must contain only string values.
+function stringifyData(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    out[k] = typeof v === 'string' ? v : String(v);
+  }
+  return out;
+}
+
+module.exports = { sendNotificationToUsers, sendNotificationToRole };

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,72 @@
+/* eslint-env serviceworker */
+/* global importScripts, firebase */
+
+// Firebase Cloud Messaging service worker.
+//
+// Registered separately from the main caching service worker (see
+// public/service-worker.js) and explicitly passed to getToken() via
+// `serviceWorkerRegistration`. Firebase config is supplied through the
+// registration URL's query string so this file stays free of hard-coded
+// values per-environment.
+
+const FIREBASE_VERSION = '11.6.1';
+
+importScripts(`https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-app-compat.js`);
+importScripts(
+  `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-messaging-compat.js`,
+);
+
+const params = new URLSearchParams(location.search);
+firebase.initializeApp({
+  apiKey: params.get('apiKey'),
+  authDomain: params.get('authDomain'),
+  projectId: params.get('projectId'),
+  storageBucket: params.get('storageBucket'),
+  messagingSenderId: params.get('messagingSenderId'),
+  appId: params.get('appId'),
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const data = payload.data || {};
+  const notification = payload.notification || {};
+  const title = notification.title || data.title || 'Our Kitchen Chronicles';
+  const options = {
+    body: notification.body || data.body || '',
+    icon: '/img/icon/prod/wooden-spoon-192.png',
+    badge: '/img/icon/prod/wooden-spoon-32.png',
+    data,
+    tag: data.tag || data.type || 'default',
+  };
+  return self.registration.showNotification(title, options);
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/dashboard';
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of allClients) {
+        const url = new URL(client.url);
+        if (url.origin === self.location.origin) {
+          await client.focus();
+          if ('navigate' in client) {
+            try {
+              await client.navigate(targetUrl);
+            } catch (_) {
+              // Some browsers disallow cross-origin navigate; ignore.
+            }
+          }
+          return;
+        }
+      }
+      await self.clients.openWindow(targetUrl);
+    })(),
+  );
+});

--- a/src/app/pages/manager-dashboard-page.html
+++ b/src/app/pages/manager-dashboard-page.html
@@ -1,4 +1,26 @@
 <main class="manager-dashboard">
+  <div
+    id="notifications-banner"
+    class="notifications-banner"
+    hidden
+    role="region"
+    aria-label="הפעלת התראות"
+  >
+    <span class="notifications-banner__text"> קבל התראה מיידית כשמתכון חדש ממתין לאישור </span>
+    <button type="button" id="enable-notifications-btn" class="notifications-banner__btn">
+      הפעל התראות במכשיר זה
+    </button>
+    <button
+      type="button"
+      id="dismiss-notifications-btn"
+      class="notifications-banner__dismiss"
+      aria-label="סגור"
+      title="סגור"
+    >
+      ×
+    </button>
+  </div>
+
   <div class="dashboard-header">
     <button class="refresh-icon master-refresh" id="master-refresh" title="רענן הכל">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">

--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -1,5 +1,6 @@
 import { FirestoreService } from '../../js/services/firestore-service.js';
 import authService from '../../js/services/auth-service.js';
+import notificationService from '../../js/services/notification-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import { CATEGORY_MAP, deleteRecipe } from '../../js/utils/recipes/recipe-data-utils.js';
 import { debounce } from '../../js/utils/common-utils.js';
@@ -41,6 +42,7 @@ export default {
     this.setupImageApprovalListeners();
     this.setupRefreshIconListeners();
     this.setupEditRecipeListener();
+    this.setupNotificationsBanner(currentUser);
   },
 
   async unmount() {
@@ -163,6 +165,50 @@ export default {
       console.log('Recipe updated:', event.detail.recipeId);
       // Refresh both all recipes and pending recipes (edits require re-approval)
       this.refreshManager.refreshRecipes(600);
+    });
+  },
+
+  async setupNotificationsBanner(user) {
+    const banner = document.getElementById('notifications-banner');
+    const enableBtn = document.getElementById('enable-notifications-btn');
+    const dismissBtn = document.getElementById('dismiss-notifications-btn');
+    if (!banner || !enableBtn || !dismissBtn || !user) return;
+
+    await notificationService.init();
+    const status = await notificationService.getStatus();
+
+    // Show only when the manager can still opt in. 'denied' (user blocked the
+    // browser prompt) and 'unsupported' both leave the banner hidden — there's
+    // nothing actionable to show.
+    if (status !== 'default' && status !== 'granted-unregistered') return;
+
+    banner.hidden = false;
+
+    enableBtn.addEventListener('click', async () => {
+      enableBtn.disabled = true;
+      const prevText = enableBtn.textContent;
+      enableBtn.textContent = 'מפעיל...';
+
+      const result = await notificationService.requestPermissionAndRegister(user.uid);
+      if (result.ok) {
+        banner.hidden = true;
+        this.showSuccess('התראות הופעלו במכשיר זה');
+      } else {
+        enableBtn.disabled = false;
+        enableBtn.textContent = prevText;
+        if (result.reason === 'denied') {
+          this.handleError(
+            new Error('הדפדפן חסם את ההתראות. כדי להפעיל, יש לאפשר התראות בהגדרות הדפדפן.'),
+          );
+          banner.hidden = true;
+        } else {
+          this.handleError(new Error('הפעלת ההתראות נכשלה. נסה שוב.'));
+        }
+      }
+    });
+
+    dismissBtn.addEventListener('click', () => {
+      banner.hidden = true;
     });
   },
 

--- a/src/js/services/auth-service.js
+++ b/src/js/services/auth-service.js
@@ -313,6 +313,17 @@ class AuthService {
    */
   async logout() {
     try {
+      // Best-effort: remove this device's push token before signing out, while
+      // we still hold auth (Firestore rules require it). Dynamic import keeps
+      // this an optional dependency — non-notification code paths never load it.
+      if (this._currentUser) {
+        try {
+          const { default: notificationService } = await import('./notification-service.js');
+          await notificationService.unregisterCurrentDevice(this._currentUser.uid);
+        } catch (error) {
+          console.warn('Failed to unregister push token on logout:', error);
+        }
+      }
       const auth = getAuthInstance();
       await signOut(auth);
     } catch (error) {

--- a/src/js/services/notification-service.js
+++ b/src/js/services/notification-service.js
@@ -87,12 +87,33 @@ class NotificationService {
           { scope: '/firebase-cloud-messaging-push-scope' },
         );
 
-        const { getMessaging, isSupported: fcmIsSupported } = await import('firebase/messaging');
+        const {
+          getMessaging,
+          isSupported: fcmIsSupported,
+          onMessage,
+        } = await import('firebase/messaging');
         if (!(await fcmIsSupported())) {
           console.warn('[notifications] FCM not supported on this browser.');
           return false;
         }
         this._messaging = getMessaging(getFirebaseApp());
+
+        // Foreground message handler. FCM does not auto-display notifications
+        // when the tab is focused — it calls onMessage instead. We route the
+        // display through the same SW registration as the background path so
+        // the SW's notificationclick handler manages navigation uniformly.
+        onMessage(this._messaging, (payload) => {
+          if (!this._swRegistration) return;
+          const data = payload.data || {};
+          const title = data.title || 'Our Kitchen Chronicles';
+          this._swRegistration.showNotification(title, {
+            body: data.body || '',
+            icon: '/img/icon/prod/wooden-spoon-192.png',
+            badge: '/img/icon/prod/wooden-spoon-32.png',
+            data,
+            tag: data.tag || data.type || 'default',
+          });
+        });
 
         // Cache last-known token so we can unregister on sign-out even if
         // getToken() can't be called in time (e.g. permission revoked).

--- a/src/js/services/notification-service.js
+++ b/src/js/services/notification-service.js
@@ -1,0 +1,227 @@
+/**
+ * NotificationService - Generic Web Push Notification Manager
+ *
+ * Channel-agnostic interface for managing push notifications. Currently backed
+ * by Firebase Cloud Messaging (FCM), but the public API is intentionally
+ * decoupled from the underlying channel so additional channels (email, in-app)
+ * can be layered in later without touching call sites.
+ *
+ * The service is not tied to any specific user role or notification type.
+ * Tokens are stored on `users/{uid}.fcmTokens` (array of { token, ua, createdAt }),
+ * so any future notification type can target any user.
+ *
+ * Public API:
+ *   - init(): One-time setup of FCM + service worker. Idempotent. Call on app start.
+ *   - isSupported(): Whether the current browser supports push notifications.
+ *   - getStatus(): One of 'unsupported' | 'denied' | 'default' | 'granted-unregistered' | 'granted-registered'.
+ *   - requestPermissionAndRegister(uid): Call from a user gesture. Requests
+ *       permission, acquires a token, and stores it on the user's doc.
+ *   - unregisterCurrentDevice(uid): Removes this device's token from the user's doc.
+ *       Called on sign-out.
+ */
+import { getFirebaseApp } from './firebase-service.js';
+import { doc, updateDoc, arrayUnion, arrayRemove, Timestamp } from 'firebase/firestore';
+import { getFirestoreInstance } from './firebase-service.js';
+
+const SW_PATH = '/firebase-messaging-sw.js';
+const TOKEN_CACHE_KEY = 'mcb_fcm_token_v1';
+
+class NotificationService {
+  constructor() {
+    this._initialized = false;
+    this._messaging = null;
+    this._swRegistration = null;
+    this._currentToken = null;
+    this._vapidKey = null;
+    this._initPromise = null;
+  }
+
+  isSupported() {
+    return (
+      typeof window !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      'Notification' in window &&
+      'PushManager' in window
+    );
+  }
+
+  /**
+   * One-time setup. Registers the FCM service worker and primes the messaging
+   * instance. Safe to call multiple times — returns the same in-flight promise.
+   *
+   * Does NOT request permission or register a token; that requires a user
+   * gesture and is handled by requestPermissionAndRegister().
+   */
+  init() {
+    if (this._initPromise) return this._initPromise;
+    if (!this.isSupported()) {
+      this._initPromise = Promise.resolve(false);
+      return this._initPromise;
+    }
+
+    this._initPromise = (async () => {
+      try {
+        this._vapidKey = import.meta.env.VITE_FCM_VAPID_KEY;
+        if (!this._vapidKey) {
+          // No VAPID key configured — push notifications cannot work.
+          // Init silently no-ops so the rest of the app keeps functioning.
+          console.warn(
+            '[notifications] VITE_FCM_VAPID_KEY is not set; push notifications disabled.',
+          );
+          return false;
+        }
+
+        // Register the messaging SW separately from the existing caching SW.
+        // Pass Firebase config via URL query params so the SW can initialize
+        // without us shipping config in a static file.
+        const params = new URLSearchParams({
+          apiKey: import.meta.env.VITE_FIREBASE_API_KEY || '',
+          authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || '',
+          projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || '',
+          storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || '',
+          messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '',
+          appId: import.meta.env.VITE_FIREBASE_APP_ID || '',
+        });
+        this._swRegistration = await navigator.serviceWorker.register(
+          `${SW_PATH}?${params.toString()}`,
+          { scope: '/firebase-cloud-messaging-push-scope' },
+        );
+
+        const { getMessaging, isSupported: fcmIsSupported } = await import('firebase/messaging');
+        if (!(await fcmIsSupported())) {
+          console.warn('[notifications] FCM not supported on this browser.');
+          return false;
+        }
+        this._messaging = getMessaging(getFirebaseApp());
+
+        // Cache last-known token so we can unregister on sign-out even if
+        // getToken() can't be called in time (e.g. permission revoked).
+        this._currentToken = localStorage.getItem(TOKEN_CACHE_KEY) || null;
+
+        this._initialized = true;
+        return true;
+      } catch (error) {
+        console.error('[notifications] init failed:', error);
+        return false;
+      }
+    })();
+
+    return this._initPromise;
+  }
+
+  /**
+   * Returns the current notification status. Useful for UI gating
+   * (e.g. showing or hiding an "enable notifications" banner).
+   *
+   * @returns {Promise<'unsupported'|'denied'|'default'|'granted-unregistered'|'granted-registered'>}
+   */
+  async getStatus() {
+    if (!this.isSupported()) return 'unsupported';
+    if (Notification.permission === 'denied') return 'denied';
+    if (Notification.permission === 'default') return 'default';
+    // permission === 'granted'
+    return this._currentToken ? 'granted-registered' : 'granted-unregistered';
+  }
+
+  /**
+   * Requests browser notification permission and registers an FCM token for
+   * the current device against the given user. MUST be called from a user
+   * gesture (button click) — browsers block requestPermission() otherwise.
+   *
+   * @param {string} uid - User ID to associate the token with.
+   * @returns {Promise<{ ok: boolean, reason?: string }>}
+   */
+  async requestPermissionAndRegister(uid) {
+    if (!uid) return { ok: false, reason: 'no-uid' };
+    const ready = await this.init();
+    if (!ready) return { ok: false, reason: 'not-supported' };
+
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return { ok: false, reason: permission };
+
+      const { getToken } = await import('firebase/messaging');
+      const token = await getToken(this._messaging, {
+        vapidKey: this._vapidKey,
+        serviceWorkerRegistration: this._swRegistration,
+      });
+      if (!token) return { ok: false, reason: 'no-token' };
+
+      await this._storeToken(uid, token);
+      this._currentToken = token;
+      localStorage.setItem(TOKEN_CACHE_KEY, token);
+      return { ok: true };
+    } catch (error) {
+      console.error('[notifications] requestPermissionAndRegister failed:', error);
+      return { ok: false, reason: 'error' };
+    }
+  }
+
+  /**
+   * Removes the current device's token from the user's doc. Called on sign-out
+   * to keep tokens fresh and avoid sending pushes to a device the user no
+   * longer wants to receive on.
+   *
+   * @param {string} uid - User ID to remove the token from.
+   */
+  async unregisterCurrentDevice(uid) {
+    const token = this._currentToken || localStorage.getItem(TOKEN_CACHE_KEY);
+    if (!token || !uid) return;
+    try {
+      const db = getFirestoreInstance();
+      const userRef = doc(db, 'users', uid);
+      // We don't know the full token object shape on the server, so we remove
+      // any entry with this token by writing back all-but-this-token. Cheaper:
+      // store the canonical entry locally and arrayRemove that exact object.
+      // We do the latter using the cached entry shape.
+      const cachedEntry = this._readCachedEntry();
+      if (cachedEntry) {
+        await updateDoc(userRef, { fcmTokens: arrayRemove(cachedEntry) });
+      }
+      // Best-effort: also delete the token from FCM itself.
+      try {
+        const { deleteToken } = await import('firebase/messaging');
+        if (this._messaging) await deleteToken(this._messaging);
+      } catch (_) {
+        // ignore — server-side pruning will catch dead tokens later
+      }
+    } catch (error) {
+      console.warn('[notifications] unregisterCurrentDevice failed:', error);
+    } finally {
+      this._currentToken = null;
+      localStorage.removeItem(TOKEN_CACHE_KEY);
+      localStorage.removeItem(`${TOKEN_CACHE_KEY}_entry`);
+    }
+  }
+
+  async _storeToken(uid, token) {
+    const db = getFirestoreInstance();
+    const userRef = doc(db, 'users', uid);
+    const entry = {
+      token,
+      ua: typeof navigator !== 'undefined' ? navigator.userAgent.slice(0, 200) : '',
+      createdAt: Timestamp.now(),
+    };
+    await updateDoc(userRef, { fcmTokens: arrayUnion(entry) });
+    localStorage.setItem(`${TOKEN_CACHE_KEY}_entry`, JSON.stringify(entry));
+  }
+
+  _readCachedEntry() {
+    try {
+      const raw = localStorage.getItem(`${TOKEN_CACHE_KEY}_entry`);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      // Re-hydrate the Timestamp so arrayRemove matches the stored object.
+      if (parsed.createdAt && typeof parsed.createdAt === 'object') {
+        parsed.createdAt = new Timestamp(parsed.createdAt.seconds, parsed.createdAt.nanoseconds);
+      }
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+const notificationService = new NotificationService();
+
+export { NotificationService, notificationService as default };

--- a/src/styles/pages/manager-dashboard-spa.css
+++ b/src/styles/pages/manager-dashboard-spa.css
@@ -247,6 +247,10 @@
   font-family: var(--font-ui-he);
 }
 
+.spa-content .manager-dashboard .notifications-banner[hidden] {
+  display: none;
+}
+
 .spa-content .manager-dashboard .notifications-banner__text {
   flex: 1;
   font-size: 14px;

--- a/src/styles/pages/manager-dashboard-spa.css
+++ b/src/styles/pages/manager-dashboard-spa.css
@@ -232,3 +232,72 @@
     margin-bottom: 16px;
   }
 }
+
+/* ---- Notifications opt-in banner ---- */
+
+.spa-content .manager-dashboard .notifications-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--surface-2, #f0ede6);
+  border: 1px solid var(--hairline, rgba(31, 29, 24, 0.08));
+  border-radius: var(--r-lg, 20px);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-family: var(--font-ui-he);
+}
+
+.spa-content .manager-dashboard .notifications-banner__text {
+  flex: 1;
+  font-size: 14px;
+  color: var(--ink);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 18px;
+  border-radius: var(--r-pill, 999px);
+  font-family: var(--font-ui-he);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--dur-1, 160ms) var(--ease, ease);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn:hover {
+  background: var(--primary-dark, #527f3a);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spa-content .manager-dashboard .notifications-banner__dismiss {
+  background: transparent;
+  border: none;
+  color: var(--ink-3);
+  font-size: 22px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  border-radius: var(--r-sm, 10px);
+}
+
+.spa-content .manager-dashboard .notifications-banner__dismiss:hover {
+  background: rgba(31, 29, 24, 0.06);
+}
+
+@media (max-width: 600px) {
+  .spa-content .manager-dashboard .notifications-banner {
+    flex-wrap: wrap;
+  }
+
+  .spa-content .manager-dashboard .notifications-banner__text {
+    flex-basis: 100%;
+  }
+}


### PR DESCRIPTION
Introduces a generic web push notification layer (FCM-backed) and uses it
to notify managers when a new recipe is submitted for approval. The
service is intentionally decoupled from any specific role or notification
type so future scenarios (image approval, new users, user-facing alerts)
can reuse the same infrastructure.

Client:
- src/js/services/notification-service.js: lazy, idempotent FCM setup +
  token registration/unregistration scoped to users/{uid}.fcmTokens.
- public/firebase-messaging-sw.js: dedicated FCM service worker; Firebase
  config is passed via registration query string so this file stays
  environment-agnostic.
- Manager dashboard banner offers a one-time opt-in on the user gesture
  required by Notification.requestPermission().
- Logout flow unregisters the current device's token before signOut so
  the Firestore write happens while auth is still valid.

Server:
- functions/notifications.js: channel-agnostic helper that fans out to
  a list of users or to all users of a given role; prunes dead tokens
  from Firestore based on FCM response codes.
- functions/index.js: onDocumentCreated('recipes/{id}') trigger sends a
  push to managers whenever a non-approved recipe is created. Coalesced
  via collapseKey per type — one banner per type, replaced on update.

Setup required outside this branch: generate a VAPID key in the Firebase
console (Cloud Messaging tab) and set VITE_FCM_VAPID_KEY in .env (and in
Netlify env for production). Push remains a no-op without it.

Out of scope for this PoC (tracked as follow-ups): image approval and
new-user notifications, per-type opt-in settings UI, batching, email.

https://claude.ai/code/session_01D5iiGpJWxe5rpyzgyCnSoW