### PR TITLE
Remove media type tags from recipes

### DIFF
--- a/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
@@ -438,6 +438,19 @@ class MediaInstructionsEditor extends HTMLElement {
           background: var(--surface-2, #f0ede6);
         }
 
+        .pending-badge {
+          position: absolute;
+          top: 50px;
+          left: 15px;
+          background: #e6a817;
+          color: #fff;
+          padding: 3px 8px;
+          border-radius: var(--r-pill, 999px);
+          font-family: var(--font-ui-he, sans-serif);
+          font-size: 11px;
+          font-weight: 500;
+        }
+
         .caption-input {
           width: 100%;
           padding: 10px 12px;
@@ -652,6 +665,7 @@ class MediaInstructionsEditor extends HTMLElement {
                 <button
                   class="delete-button"
                   aria-label="מחק פריט ${index + 1}">×</button>
+                ${isPending ? '<span class="pending-badge">ממתין</span>' : ''}
                 <span class="item-order" aria-hidden="true">${index + 1}</span>
                 ${mediaTag}
                 <input

--- a/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
@@ -438,24 +438,6 @@ class MediaInstructionsEditor extends HTMLElement {
           background: var(--surface-2, #f0ede6);
         }
 
-        .media-type-badge {
-          position: absolute;
-          top: 50px;
-          left: 15px;
-          background: rgba(31,29,24,0.65);
-          color: #fff;
-          padding: 3px 8px;
-          border-radius: var(--r-pill, 999px);
-          font-family: var(--font-ui-he, sans-serif);
-          font-size: 11px;
-          font-weight: 500;
-        }
-
-        .media-type-badge.pending-badge {
-          background: #e6a817;
-          color: #fff;
-        }
-
         .caption-input {
           width: 100%;
           padding: 10px 12px;
@@ -651,19 +633,16 @@ class MediaInstructionsEditor extends HTMLElement {
               }
 
               const isVideo = item.type === 'video';
-              const mediaTypeText = isVideo ? 'וידאו' : 'תמונה';
               const mediaTag = isVideo
                 ? `<video class="media-preview" src="${previewURL}" controls aria-label="${item.caption || 'וידאו ללא כיתוב'}"></video>`
                 : `<img class="media-preview" src="${previewURL}" alt="${item.caption || 'תמונה ללא תיאור'}">`;
-
-              const badgeText = isPending ? `${mediaTypeText} (ממתין)` : mediaTypeText;
 
               return `
               <div
                 class="media-item ${isPending ? 'pending' : ''}"
                 data-index="${index}"
                 role="article"
-                aria-label="פריט מדיה ${index + 1} מתוך ${this.mediaItems.length}: ${mediaTypeText}">
+                aria-label="פריט מדיה ${index + 1} מתוך ${this.mediaItems.length}">
                 <span
                   class="drag-handle"
                   draggable="true"
@@ -672,8 +651,7 @@ class MediaInstructionsEditor extends HTMLElement {
                   aria-label="גרור לשינוי סדר פריט ${index + 1}">⠿</span>
                 <button
                   class="delete-button"
-                  aria-label="מחק ${mediaTypeText} ${index + 1}">×</button>
-                <span class="media-type-badge ${isPending ? 'pending-badge' : ''}">${badgeText}</span>
+                  aria-label="מחק פריט ${index + 1}">×</button>
                 <span class="item-order" aria-hidden="true">${index + 1}</span>
                 ${mediaTag}
                 <input
@@ -681,7 +659,7 @@ class MediaInstructionsEditor extends HTMLElement {
                   class="caption-input"
                   placeholder="הוסף הסבר לשלב..."
                   value="${item.caption || ''}"
-                  aria-label="כיתוב עבור ${mediaTypeText} ${index + 1}"
+                  aria-label="כיתוב עבור פריט ${index + 1}"
                   dir="rtl"
                 >
               </div>

--- a/src/lib/utilities/media-scroller/media-scroller.js
+++ b/src/lib/utilities/media-scroller/media-scroller.js
@@ -197,20 +197,6 @@ class MediaScroller extends HTMLElement {
           to { transform: rotate(360deg); }
         }
 
-        .media-type-badge {
-          position: absolute;
-          top: 25px;
-          left: 25px;
-          background-color: rgba(0, 0, 0, 0.7);
-          color: white;
-          padding: 4px 8px;
-          border-radius: 4px;
-          font-size: 11px;
-          font-weight: bold;
-          text-transform: uppercase;
-          z-index: 5;
-        }
-
         .media-scroller__caption {
           margin-top: 5px;
           text-align: center;
@@ -236,16 +222,9 @@ class MediaScroller extends HTMLElement {
         console.warn(`[MediaScroller] Item at index ${index} is missing 'type' field`);
       }
 
-      const mediaType = isVideo ? 'וידאו' : 'תמונה';
-
       const itemElement = document.createElement('div');
       itemElement.className = 'media-scroller__item';
       itemElement.setAttribute('data-index', index.toString());
-
-      const badge = document.createElement('span');
-      badge.className = 'media-type-badge';
-      badge.textContent = mediaType;
-      itemElement.appendChild(badge);
 
       const mediaContainer = document.createElement('div');
       mediaContainer.className = 'media-scroller__media-container';


### PR DESCRIPTION
This change removes the "image/video" type tags from recipe media instructions. These tags were deemed redundant as users can infer the media type from the context. The removal was applied to both the presentation component (MediaScroller) and the editor component (MediaInstructionsEditor) to maintain consistency. Accessibility was preserved by updating aria-labels to use generic terms.

Fixes #174

---
*PR created automatically by Jules for task [2388363203109548338](https://jules.google.com/task/2388363203109548338) started by @roiguri*