### PR TITLE
feat(notifications): manager push notifications for pending recipe approvals

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -44,7 +44,7 @@ service cloud.firestore {
                     && request.resource.data.role == 'user';
       
       // UPDATE:
-      // - Users can update their own profile (avatar, favorites, name)
+      // - Users can update their own profile (avatar, favorites, name, fcmTokens)
       // - CRITICAL: Users CANNOT change their role
       // - Managers can update anything (including roles)
       allow update: if (isOwner(userId) && request.resource.data.role == resource.data.role)

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,9 +1,11 @@
 const { onMessagePublished } = require('firebase-functions/v2/pubsub');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
+const { onDocumentCreated } = require('firebase-functions/v2/firestore');
 const { initializeApp } = require('firebase-admin/app');
 const { getFirestore, FieldValue, Timestamp } = require('firebase-admin/firestore');
 const { getStorage } = require('firebase-admin/storage');
 const { extractRecipeFromImage, extractRecipeFromUrl } = require('./utils/gemini-service');
+const { sendNotificationToRole } = require('./notifications');
 
 // Initialize Firebase Admin
 initializeApp();
@@ -580,5 +582,42 @@ exports.extractRecipeFromUrl = onCall({ secrets: ['GEMINI_API_KEY'] }, async (re
       throw error;
     }
     throw new HttpsError('internal', 'Recipe extraction from URL failed', error.message);
+  }
+});
+
+/**
+ * Notify managers when a new recipe is submitted for approval.
+ *
+ * Fires on every recipe create; only sends when `approved === false` so it
+ * skips manager-authored recipes that are created already-approved and the
+ * processRecipeTransfer pipeline (which also lands recipes with approved=false
+ * — that's intentional, those should be reviewed too).
+ *
+ * One push per event for v1. Batching tracked separately.
+ */
+exports.onRecipeCreated = onDocumentCreated('recipes/{recipeId}', async (event) => {
+  const snap = event.data;
+  if (!snap) return;
+  const recipe = snap.data() || {};
+  if (recipe.approved === true) return;
+
+  const recipeId = event.params.recipeId;
+  const recipeName = recipe.name || 'מתכון חדש';
+
+  try {
+    const result = await sendNotificationToRole('manager', {
+      title: 'מתכון חדש ממתין לאישור',
+      body: recipeName,
+      collapseKey: 'recipe-approval',
+      url: '/dashboard',
+      data: {
+        type: 'recipe-approval',
+        recipeId,
+      },
+    });
+    console.log(`[onRecipeCreated] notified managers for ${recipeId}:`, result);
+  } catch (error) {
+    console.error(`[onRecipeCreated] notification failed for ${recipeId}:`, error);
+    // Don't rethrow — notification failure must not block the recipe creation.
   }
 });

--- a/functions/notifications.js
+++ b/functions/notifications.js
@@ -44,9 +44,17 @@ async function sendNotificationToUsers(uids, payload) {
 
   if (tokenIndex.length === 0) return { sent: 0, pruned: 0 };
 
+  // Data-only payload: when `notification` is present on a Web push, FCM auto-
+  // displays a banner using the site favicon AND the SW's onBackgroundMessage
+  // also fires our own — yielding two notifications. Sending only `data` makes
+  // the SW (and the page's onMessage) the single source of truth for display.
   const message = {
-    notification: { title: payload.title, body: payload.body },
-    data: stringifyData({ ...(payload.data || {}), url: payload.url || '/dashboard' }),
+    data: stringifyData({
+      ...(payload.data || {}),
+      title: payload.title,
+      body: payload.body,
+      url: payload.url || '/dashboard',
+    }),
     tokens: tokenIndex.map((t) => t.entry.token),
     webpush: {
       headers: payload.collapseKey ? { Topic: payload.collapseKey } : undefined,

--- a/functions/notifications.js
+++ b/functions/notifications.js
@@ -1,0 +1,110 @@
+/**
+ * Generic notification helper for Cloud Functions.
+ *
+ * Channel-agnostic API for sending notifications to users. Currently backed
+ * by FCM. Call sites (triggers, callables) should never call FCM directly —
+ * they go through these helpers so we can swap channels or add fan-out (email,
+ * in-app) without touching trigger code.
+ *
+ * Public API:
+ *   - sendNotificationToUsers(uids, payload): Send to a specific list of user IDs.
+ *   - sendNotificationToRole(role, payload):  Send to all users with the given role.
+ *
+ * payload shape:
+ *   {
+ *     title:        string,
+ *     body:         string,
+ *     data?:        object  // string-valued; merged into FCM data payload
+ *     collapseKey?: string  // groups notifications so a newer one replaces older
+ *     url?:         string  // deep link opened on notificationclick
+ *   }
+ */
+const { getFirestore, FieldValue } = require('firebase-admin/firestore');
+const { getMessaging } = require('firebase-admin/messaging');
+
+async function sendNotificationToUsers(uids, payload) {
+  if (!Array.isArray(uids) || uids.length === 0) return { sent: 0, pruned: 0 };
+
+  const db = getFirestore();
+  const userDocs = await Promise.all(uids.map((uid) => db.collection('users').doc(uid).get()));
+
+  // Flatten all tokens across the recipient set, keeping track of which user
+  // each token belongs to so we can prune dead tokens individually.
+  const tokenIndex = []; // [{ uid, entry }]
+  for (const snap of userDocs) {
+    if (!snap.exists) continue;
+    const data = snap.data() || {};
+    const tokens = Array.isArray(data.fcmTokens) ? data.fcmTokens : [];
+    for (const entry of tokens) {
+      if (entry && typeof entry.token === 'string' && entry.token) {
+        tokenIndex.push({ uid: snap.id, entry });
+      }
+    }
+  }
+
+  if (tokenIndex.length === 0) return { sent: 0, pruned: 0 };
+
+  const message = {
+    notification: { title: payload.title, body: payload.body },
+    data: stringifyData({ ...(payload.data || {}), url: payload.url || '/dashboard' }),
+    tokens: tokenIndex.map((t) => t.entry.token),
+    webpush: {
+      headers: payload.collapseKey ? { Topic: payload.collapseKey } : undefined,
+      fcmOptions: payload.url ? { link: payload.url } : undefined,
+    },
+  };
+
+  const response = await getMessaging().sendEachForMulticast(message);
+
+  // Prune tokens that came back as permanently invalid.
+  const deadByUser = new Map(); // uid -> [entry, ...]
+  response.responses.forEach((res, i) => {
+    if (res.success) return;
+    const code = res.error && res.error.code;
+    if (
+      code === 'messaging/registration-token-not-registered' ||
+      code === 'messaging/invalid-registration-token' ||
+      code === 'messaging/invalid-argument'
+    ) {
+      const { uid, entry } = tokenIndex[i];
+      if (!deadByUser.has(uid)) deadByUser.set(uid, []);
+      deadByUser.get(uid).push(entry);
+    }
+  });
+
+  let prunedCount = 0;
+  if (deadByUser.size > 0) {
+    await Promise.all(
+      Array.from(deadByUser.entries()).map(async ([uid, entries]) => {
+        prunedCount += entries.length;
+        await db
+          .collection('users')
+          .doc(uid)
+          .update({ fcmTokens: FieldValue.arrayRemove(...entries) })
+          .catch((err) => console.warn(`[notifications] prune failed for ${uid}:`, err.message));
+      }),
+    );
+  }
+
+  return { sent: response.successCount, failed: response.failureCount, pruned: prunedCount };
+}
+
+async function sendNotificationToRole(role, payload) {
+  if (!role) return { sent: 0, pruned: 0 };
+  const db = getFirestore();
+  const snap = await db.collection('users').where('role', '==', role).get();
+  const uids = snap.docs.map((d) => d.id);
+  return sendNotificationToUsers(uids, payload);
+}
+
+// FCM data payload must contain only string values.
+function stringifyData(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined || v === null) continue;
+    out[k] = typeof v === 'string' ? v : String(v);
+  }
+  return out;
+}
+
+module.exports = { sendNotificationToUsers, sendNotificationToRole };

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,72 @@
+/* eslint-env serviceworker */
+/* global importScripts, firebase */
+
+// Firebase Cloud Messaging service worker.
+//
+// Registered separately from the main caching service worker (see
+// public/service-worker.js) and explicitly passed to getToken() via
+// `serviceWorkerRegistration`. Firebase config is supplied through the
+// registration URL's query string so this file stays free of hard-coded
+// values per-environment.
+
+const FIREBASE_VERSION = '11.6.1';
+
+importScripts(`https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-app-compat.js`);
+importScripts(
+  `https://www.gstatic.com/firebasejs/${FIREBASE_VERSION}/firebase-messaging-compat.js`,
+);
+
+const params = new URLSearchParams(location.search);
+firebase.initializeApp({
+  apiKey: params.get('apiKey'),
+  authDomain: params.get('authDomain'),
+  projectId: params.get('projectId'),
+  storageBucket: params.get('storageBucket'),
+  messagingSenderId: params.get('messagingSenderId'),
+  appId: params.get('appId'),
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const data = payload.data || {};
+  const notification = payload.notification || {};
+  const title = notification.title || data.title || 'Our Kitchen Chronicles';
+  const options = {
+    body: notification.body || data.body || '',
+    icon: '/img/icon/prod/wooden-spoon-192.png',
+    badge: '/img/icon/prod/wooden-spoon-32.png',
+    data,
+    tag: data.tag || data.type || 'default',
+  };
+  return self.registration.showNotification(title, options);
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/dashboard';
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of allClients) {
+        const url = new URL(client.url);
+        if (url.origin === self.location.origin) {
+          await client.focus();
+          if ('navigate' in client) {
+            try {
+              await client.navigate(targetUrl);
+            } catch (_) {
+              // Some browsers disallow cross-origin navigate; ignore.
+            }
+          }
+          return;
+        }
+      }
+      await self.clients.openWindow(targetUrl);
+    })(),
+  );
+});

--- a/src/app/pages/manager-dashboard-page.html
+++ b/src/app/pages/manager-dashboard-page.html
@@ -1,4 +1,26 @@
 <main class="manager-dashboard">
+  <div
+    id="notifications-banner"
+    class="notifications-banner"
+    hidden
+    role="region"
+    aria-label="הפעלת התראות"
+  >
+    <span class="notifications-banner__text"> קבל התראה מיידית כשמתכון חדש ממתין לאישור </span>
+    <button type="button" id="enable-notifications-btn" class="notifications-banner__btn">
+      הפעל התראות במכשיר זה
+    </button>
+    <button
+      type="button"
+      id="dismiss-notifications-btn"
+      class="notifications-banner__dismiss"
+      aria-label="סגור"
+      title="סגור"
+    >
+      ×
+    </button>
+  </div>
+
   <div class="dashboard-header">
     <button class="refresh-icon master-refresh" id="master-refresh" title="רענן הכל">
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">

--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -1,5 +1,6 @@
 import { FirestoreService } from '../../js/services/firestore-service.js';
 import authService from '../../js/services/auth-service.js';
+import notificationService from '../../js/services/notification-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import { CATEGORY_MAP, deleteRecipe } from '../../js/utils/recipes/recipe-data-utils.js';
 import { debounce } from '../../js/utils/common-utils.js';
@@ -41,6 +42,7 @@ export default {
     this.setupImageApprovalListeners();
     this.setupRefreshIconListeners();
     this.setupEditRecipeListener();
+    this.setupNotificationsBanner(currentUser);
   },
 
   async unmount() {
@@ -163,6 +165,50 @@ export default {
       console.log('Recipe updated:', event.detail.recipeId);
       // Refresh both all recipes and pending recipes (edits require re-approval)
       this.refreshManager.refreshRecipes(600);
+    });
+  },
+
+  async setupNotificationsBanner(user) {
+    const banner = document.getElementById('notifications-banner');
+    const enableBtn = document.getElementById('enable-notifications-btn');
+    const dismissBtn = document.getElementById('dismiss-notifications-btn');
+    if (!banner || !enableBtn || !dismissBtn || !user) return;
+
+    await notificationService.init();
+    const status = await notificationService.getStatus();
+
+    // Show only when the manager can still opt in. 'denied' (user blocked the
+    // browser prompt) and 'unsupported' both leave the banner hidden — there's
+    // nothing actionable to show.
+    if (status !== 'default' && status !== 'granted-unregistered') return;
+
+    banner.hidden = false;
+
+    enableBtn.addEventListener('click', async () => {
+      enableBtn.disabled = true;
+      const prevText = enableBtn.textContent;
+      enableBtn.textContent = 'מפעיל...';
+
+      const result = await notificationService.requestPermissionAndRegister(user.uid);
+      if (result.ok) {
+        banner.hidden = true;
+        this.showSuccess('התראות הופעלו במכשיר זה');
+      } else {
+        enableBtn.disabled = false;
+        enableBtn.textContent = prevText;
+        if (result.reason === 'denied') {
+          this.handleError(
+            new Error('הדפדפן חסם את ההתראות. כדי להפעיל, יש לאפשר התראות בהגדרות הדפדפן.'),
+          );
+          banner.hidden = true;
+        } else {
+          this.handleError(new Error('הפעלת ההתראות נכשלה. נסה שוב.'));
+        }
+      }
+    });
+
+    dismissBtn.addEventListener('click', () => {
+      banner.hidden = true;
     });
   },
 

--- a/src/js/services/auth-service.js
+++ b/src/js/services/auth-service.js
@@ -313,6 +313,17 @@ class AuthService {
    */
   async logout() {
     try {
+      // Best-effort: remove this device's push token before signing out, while
+      // we still hold auth (Firestore rules require it). Dynamic import keeps
+      // this an optional dependency — non-notification code paths never load it.
+      if (this._currentUser) {
+        try {
+          const { default: notificationService } = await import('./notification-service.js');
+          await notificationService.unregisterCurrentDevice(this._currentUser.uid);
+        } catch (error) {
+          console.warn('Failed to unregister push token on logout:', error);
+        }
+      }
       const auth = getAuthInstance();
       await signOut(auth);
     } catch (error) {

--- a/src/js/services/notification-service.js
+++ b/src/js/services/notification-service.js
@@ -87,12 +87,33 @@ class NotificationService {
           { scope: '/firebase-cloud-messaging-push-scope' },
         );
 
-        const { getMessaging, isSupported: fcmIsSupported } = await import('firebase/messaging');
+        const {
+          getMessaging,
+          isSupported: fcmIsSupported,
+          onMessage,
+        } = await import('firebase/messaging');
         if (!(await fcmIsSupported())) {
           console.warn('[notifications] FCM not supported on this browser.');
           return false;
         }
         this._messaging = getMessaging(getFirebaseApp());
+
+        // Foreground message handler. FCM does not auto-display notifications
+        // when the tab is focused — it calls onMessage instead. We route the
+        // display through the same SW registration as the background path so
+        // the SW's notificationclick handler manages navigation uniformly.
+        onMessage(this._messaging, (payload) => {
+          if (!this._swRegistration) return;
+          const data = payload.data || {};
+          const title = data.title || 'Our Kitchen Chronicles';
+          this._swRegistration.showNotification(title, {
+            body: data.body || '',
+            icon: '/img/icon/prod/wooden-spoon-192.png',
+            badge: '/img/icon/prod/wooden-spoon-32.png',
+            data,
+            tag: data.tag || data.type || 'default',
+          });
+        });
 
         // Cache last-known token so we can unregister on sign-out even if
         // getToken() can't be called in time (e.g. permission revoked).

--- a/src/js/services/notification-service.js
+++ b/src/js/services/notification-service.js
@@ -1,0 +1,227 @@
+/**
+ * NotificationService - Generic Web Push Notification Manager
+ *
+ * Channel-agnostic interface for managing push notifications. Currently backed
+ * by Firebase Cloud Messaging (FCM), but the public API is intentionally
+ * decoupled from the underlying channel so additional channels (email, in-app)
+ * can be layered in later without touching call sites.
+ *
+ * The service is not tied to any specific user role or notification type.
+ * Tokens are stored on `users/{uid}.fcmTokens` (array of { token, ua, createdAt }),
+ * so any future notification type can target any user.
+ *
+ * Public API:
+ *   - init(): One-time setup of FCM + service worker. Idempotent. Call on app start.
+ *   - isSupported(): Whether the current browser supports push notifications.
+ *   - getStatus(): One of 'unsupported' | 'denied' | 'default' | 'granted-unregistered' | 'granted-registered'.
+ *   - requestPermissionAndRegister(uid): Call from a user gesture. Requests
+ *       permission, acquires a token, and stores it on the user's doc.
+ *   - unregisterCurrentDevice(uid): Removes this device's token from the user's doc.
+ *       Called on sign-out.
+ */
+import { getFirebaseApp } from './firebase-service.js';
+import { doc, updateDoc, arrayUnion, arrayRemove, Timestamp } from 'firebase/firestore';
+import { getFirestoreInstance } from './firebase-service.js';
+
+const SW_PATH = '/firebase-messaging-sw.js';
+const TOKEN_CACHE_KEY = 'mcb_fcm_token_v1';
+
+class NotificationService {
+  constructor() {
+    this._initialized = false;
+    this._messaging = null;
+    this._swRegistration = null;
+    this._currentToken = null;
+    this._vapidKey = null;
+    this._initPromise = null;
+  }
+
+  isSupported() {
+    return (
+      typeof window !== 'undefined' &&
+      'serviceWorker' in navigator &&
+      'Notification' in window &&
+      'PushManager' in window
+    );
+  }
+
+  /**
+   * One-time setup. Registers the FCM service worker and primes the messaging
+   * instance. Safe to call multiple times — returns the same in-flight promise.
+   *
+   * Does NOT request permission or register a token; that requires a user
+   * gesture and is handled by requestPermissionAndRegister().
+   */
+  init() {
+    if (this._initPromise) return this._initPromise;
+    if (!this.isSupported()) {
+      this._initPromise = Promise.resolve(false);
+      return this._initPromise;
+    }
+
+    this._initPromise = (async () => {
+      try {
+        this._vapidKey = import.meta.env.VITE_FCM_VAPID_KEY;
+        if (!this._vapidKey) {
+          // No VAPID key configured — push notifications cannot work.
+          // Init silently no-ops so the rest of the app keeps functioning.
+          console.warn(
+            '[notifications] VITE_FCM_VAPID_KEY is not set; push notifications disabled.',
+          );
+          return false;
+        }
+
+        // Register the messaging SW separately from the existing caching SW.
+        // Pass Firebase config via URL query params so the SW can initialize
+        // without us shipping config in a static file.
+        const params = new URLSearchParams({
+          apiKey: import.meta.env.VITE_FIREBASE_API_KEY || '',
+          authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || '',
+          projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || '',
+          storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || '',
+          messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || '',
+          appId: import.meta.env.VITE_FIREBASE_APP_ID || '',
+        });
+        this._swRegistration = await navigator.serviceWorker.register(
+          `${SW_PATH}?${params.toString()}`,
+          { scope: '/firebase-cloud-messaging-push-scope' },
+        );
+
+        const { getMessaging, isSupported: fcmIsSupported } = await import('firebase/messaging');
+        if (!(await fcmIsSupported())) {
+          console.warn('[notifications] FCM not supported on this browser.');
+          return false;
+        }
+        this._messaging = getMessaging(getFirebaseApp());
+
+        // Cache last-known token so we can unregister on sign-out even if
+        // getToken() can't be called in time (e.g. permission revoked).
+        this._currentToken = localStorage.getItem(TOKEN_CACHE_KEY) || null;
+
+        this._initialized = true;
+        return true;
+      } catch (error) {
+        console.error('[notifications] init failed:', error);
+        return false;
+      }
+    })();
+
+    return this._initPromise;
+  }
+
+  /**
+   * Returns the current notification status. Useful for UI gating
+   * (e.g. showing or hiding an "enable notifications" banner).
+   *
+   * @returns {Promise<'unsupported'|'denied'|'default'|'granted-unregistered'|'granted-registered'>}
+   */
+  async getStatus() {
+    if (!this.isSupported()) return 'unsupported';
+    if (Notification.permission === 'denied') return 'denied';
+    if (Notification.permission === 'default') return 'default';
+    // permission === 'granted'
+    return this._currentToken ? 'granted-registered' : 'granted-unregistered';
+  }
+
+  /**
+   * Requests browser notification permission and registers an FCM token for
+   * the current device against the given user. MUST be called from a user
+   * gesture (button click) — browsers block requestPermission() otherwise.
+   *
+   * @param {string} uid - User ID to associate the token with.
+   * @returns {Promise<{ ok: boolean, reason?: string }>}
+   */
+  async requestPermissionAndRegister(uid) {
+    if (!uid) return { ok: false, reason: 'no-uid' };
+    const ready = await this.init();
+    if (!ready) return { ok: false, reason: 'not-supported' };
+
+    try {
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') return { ok: false, reason: permission };
+
+      const { getToken } = await import('firebase/messaging');
+      const token = await getToken(this._messaging, {
+        vapidKey: this._vapidKey,
+        serviceWorkerRegistration: this._swRegistration,
+      });
+      if (!token) return { ok: false, reason: 'no-token' };
+
+      await this._storeToken(uid, token);
+      this._currentToken = token;
+      localStorage.setItem(TOKEN_CACHE_KEY, token);
+      return { ok: true };
+    } catch (error) {
+      console.error('[notifications] requestPermissionAndRegister failed:', error);
+      return { ok: false, reason: 'error' };
+    }
+  }
+
+  /**
+   * Removes the current device's token from the user's doc. Called on sign-out
+   * to keep tokens fresh and avoid sending pushes to a device the user no
+   * longer wants to receive on.
+   *
+   * @param {string} uid - User ID to remove the token from.
+   */
+  async unregisterCurrentDevice(uid) {
+    const token = this._currentToken || localStorage.getItem(TOKEN_CACHE_KEY);
+    if (!token || !uid) return;
+    try {
+      const db = getFirestoreInstance();
+      const userRef = doc(db, 'users', uid);
+      // We don't know the full token object shape on the server, so we remove
+      // any entry with this token by writing back all-but-this-token. Cheaper:
+      // store the canonical entry locally and arrayRemove that exact object.
+      // We do the latter using the cached entry shape.
+      const cachedEntry = this._readCachedEntry();
+      if (cachedEntry) {
+        await updateDoc(userRef, { fcmTokens: arrayRemove(cachedEntry) });
+      }
+      // Best-effort: also delete the token from FCM itself.
+      try {
+        const { deleteToken } = await import('firebase/messaging');
+        if (this._messaging) await deleteToken(this._messaging);
+      } catch (_) {
+        // ignore — server-side pruning will catch dead tokens later
+      }
+    } catch (error) {
+      console.warn('[notifications] unregisterCurrentDevice failed:', error);
+    } finally {
+      this._currentToken = null;
+      localStorage.removeItem(TOKEN_CACHE_KEY);
+      localStorage.removeItem(`${TOKEN_CACHE_KEY}_entry`);
+    }
+  }
+
+  async _storeToken(uid, token) {
+    const db = getFirestoreInstance();
+    const userRef = doc(db, 'users', uid);
+    const entry = {
+      token,
+      ua: typeof navigator !== 'undefined' ? navigator.userAgent.slice(0, 200) : '',
+      createdAt: Timestamp.now(),
+    };
+    await updateDoc(userRef, { fcmTokens: arrayUnion(entry) });
+    localStorage.setItem(`${TOKEN_CACHE_KEY}_entry`, JSON.stringify(entry));
+  }
+
+  _readCachedEntry() {
+    try {
+      const raw = localStorage.getItem(`${TOKEN_CACHE_KEY}_entry`);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      // Re-hydrate the Timestamp so arrayRemove matches the stored object.
+      if (parsed.createdAt && typeof parsed.createdAt === 'object') {
+        parsed.createdAt = new Timestamp(parsed.createdAt.seconds, parsed.createdAt.nanoseconds);
+      }
+      return parsed;
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+const notificationService = new NotificationService();
+
+export { NotificationService, notificationService as default };

--- a/src/styles/pages/manager-dashboard-spa.css
+++ b/src/styles/pages/manager-dashboard-spa.css
@@ -247,6 +247,10 @@
   font-family: var(--font-ui-he);
 }
 
+.spa-content .manager-dashboard .notifications-banner[hidden] {
+  display: none;
+}
+
 .spa-content .manager-dashboard .notifications-banner__text {
   flex: 1;
   font-size: 14px;

--- a/src/styles/pages/manager-dashboard-spa.css
+++ b/src/styles/pages/manager-dashboard-spa.css
@@ -232,3 +232,72 @@
     margin-bottom: 16px;
   }
 }
+
+/* ---- Notifications opt-in banner ---- */
+
+.spa-content .manager-dashboard .notifications-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--surface-2, #f0ede6);
+  border: 1px solid var(--hairline, rgba(31, 29, 24, 0.08));
+  border-radius: var(--r-lg, 20px);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  font-family: var(--font-ui-he);
+}
+
+.spa-content .manager-dashboard .notifications-banner__text {
+  flex: 1;
+  font-size: 14px;
+  color: var(--ink);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 18px;
+  border-radius: var(--r-pill, 999px);
+  font-family: var(--font-ui-he);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--dur-1, 160ms) var(--ease, ease);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn:hover {
+  background: var(--primary-dark, #527f3a);
+}
+
+.spa-content .manager-dashboard .notifications-banner__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spa-content .manager-dashboard .notifications-banner__dismiss {
+  background: transparent;
+  border: none;
+  color: var(--ink-3);
+  font-size: 22px;
+  line-height: 1;
+  padding: 4px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+  border-radius: var(--r-sm, 10px);
+}
+
+.spa-content .manager-dashboard .notifications-banner__dismiss:hover {
+  background: rgba(31, 29, 24, 0.06);
+}
+
+@media (max-width: 600px) {
+  .spa-content .manager-dashboard .notifications-banner {
+    flex-wrap: wrap;
+  }
+
+  .spa-content .manager-dashboard .notifications-banner__text {
+    flex-basis: 100%;
+  }
+}


### PR DESCRIPTION
Closes #177

## Summary

- Adds a generic web push notification layer (FCM-backed) so managers get an OS-level banner within seconds of a user proposing a recipe, without needing the dashboard open.
- Opt-in banner on the manager dashboard (single user gesture, respects browser permission state).
- Per-device token storage on `users/{uid}.fcmTokens` with logout-time cleanup and server-side dead-token pruning.
- Firestore-triggered Cloud Function (`onRecipeCreated`) fans out to all manager-role users when a recipe with `approved: false` is created.
- Three follow-up fixes validated during testing: data-only FCM payload (eliminates duplicate notifications), foreground `onMessage` handler (notifications appear whether tab is focused or not), and CSS `[hidden]` specificity fix (banner hides correctly on dismiss/approval).

## Manual setup required (per environment, not in this PR)

- Generate a VAPID key in Firebase Console (Cloud Messaging tab) for each project.
- Set `VITE_FCM_VAPID_KEY` in `.env.local` and in Netlify env vars per deploy context.
- Enable "Firebase Cloud Messaging API" (`fcm.googleapis.com`) in GCP — not the legacy "Cloud Messaging" API.
- Deploy Cloud Function: `firebase deploy --only functions:onRecipeCreated`

## Test plan

- [x] Firestore trigger fires on recipe create with `approved: false` — logs `sent: N`
- [x] Manager receives OS notification with tab in background
- [x] Manager receives OS notification with tab in foreground (no duplicates)
- [x] Clicking notification navigates to `/dashboard`
- [x] Opt-in banner dismisses correctly (× button and after approval)
- [x] Token written to `users/{uid}.fcmTokens` on opt-in
- [x] Token removed from Firestore on logout
- [x] Recipes created with `approved: true` do not trigger a notification

## Follow-ups tracked in #178

- Notification settings panel (opt-out per device, persistent banner dismiss, status page)
- Notification click deep-link to the specific recipe approval flow