### PR TITLE
Centralize media type config and improve upload error handling

### DIFF
--- a/src/js/config/media-types.js
+++ b/src/js/config/media-types.js
@@ -1,0 +1,109 @@
+/**
+ * Shared media type configuration for recipe images and instruction media.
+ *
+ * Two distinct contexts:
+ * - Recipe images (main images on a recipe): photo formats only.
+ * - Instruction media (step-by-step images/videos): photo formats + animated GIF + video.
+ *
+ * Both share the same photo format list so users get consistent behaviour across
+ * iPhone (HEIC/HEIF), modern Android/Pixel (HEIC/AVIF), and desktop (JPEG/PNG/WebP).
+ */
+
+export const ALLOWED_RECIPE_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+  'image/avif',
+];
+
+export const ALLOWED_INSTRUCTION_IMAGE_TYPES = [...ALLOWED_RECIPE_IMAGE_TYPES, 'image/gif'];
+
+export const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
+
+export const ALLOWED_INSTRUCTION_MEDIA_TYPES = [
+  ...ALLOWED_INSTRUCTION_IMAGE_TYPES,
+  ...ALLOWED_VIDEO_TYPES,
+];
+
+export const MAX_RECIPE_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB (HEIC files can be larger than JPEG)
+export const MAX_INSTRUCTION_MEDIA_SIZE = 50 * 1024 * 1024; // 50MB (matches storage.rules cap)
+
+export const RECIPE_IMAGE_ACCEPT_ATTR = ALLOWED_RECIPE_IMAGE_TYPES.join(',');
+export const INSTRUCTION_MEDIA_ACCEPT_ATTR = ALLOWED_INSTRUCTION_MEDIA_TYPES.join(',');
+
+function formatSizeMB(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(2);
+}
+
+function formatLimitMB(bytes) {
+  return Math.round(bytes / (1024 * 1024));
+}
+
+/**
+ * Validates a recipe image file (main recipe image).
+ * @param {File|Blob} file
+ * @returns {{ isValid: boolean, errors: string[] }}
+ */
+export function validateRecipeImageFile(file) {
+  const errors = [];
+
+  if (!file) {
+    errors.push('לא סופק קובץ');
+    return { isValid: false, errors };
+  }
+
+  if (!ALLOWED_RECIPE_IMAGE_TYPES.includes(file.type)) {
+    errors.push(
+      `סוג הקובץ ${file.type || 'לא ידוע'} אינו נתמך. סוגי קבצים מותרים: JPEG, PNG, WebP, HEIC, HEIF, AVIF`,
+    );
+  }
+
+  if (file.size > MAX_RECIPE_IMAGE_SIZE) {
+    errors.push(
+      `התמונה גדולה מדי (${formatSizeMB(file.size)}MB). גודל מקסימלי: ${formatLimitMB(MAX_RECIPE_IMAGE_SIZE)}MB`,
+    );
+  }
+
+  return { isValid: errors.length === 0, errors };
+}
+
+/**
+ * Validates an instruction media file (image or video for instruction steps).
+ * @param {File|Blob} file
+ * @returns {{ isValid: boolean, errors: string[] }}
+ */
+export function validateInstructionMediaFile(file) {
+  const errors = [];
+
+  if (!file) {
+    errors.push('לא סופק קובץ');
+    return { isValid: false, errors };
+  }
+
+  if (!ALLOWED_INSTRUCTION_MEDIA_TYPES.includes(file.type)) {
+    errors.push(
+      `סוג הקובץ ${file.type || 'לא ידוע'} אינו נתמך. תמונות: JPEG, PNG, WebP, GIF, HEIC, HEIF, AVIF. סרטונים: MP4, WebM, MOV`,
+    );
+  }
+
+  if (file.size > MAX_INSTRUCTION_MEDIA_SIZE) {
+    errors.push(
+      `הקובץ גדול מדי (${formatSizeMB(file.size)}MB). גודל מקסימלי: ${formatLimitMB(MAX_INSTRUCTION_MEDIA_SIZE)}MB`,
+    );
+  }
+
+  return { isValid: errors.length === 0, errors };
+}
+
+/**
+ * Determines if a file is an image or video based on its MIME type.
+ * @param {File|Blob} file
+ * @returns {'image'|'video'|null}
+ */
+export function getInstructionMediaType(file) {
+  if (ALLOWED_INSTRUCTION_IMAGE_TYPES.includes(file.type)) return 'image';
+  if (ALLOWED_VIDEO_TYPES.includes(file.type)) return 'video';
+  return null;
+}

--- a/src/js/services/storage-service.js
+++ b/src/js/services/storage-service.js
@@ -15,28 +15,72 @@ import { LRUCache } from '../utils/lru-cache.js';
 
 const urlCache = new LRUCache(500);
 
+// Firebase Storage error codes that are worth retrying — transient network failures
+// or server-side cancellations. Permission errors and quota errors are NOT retried.
+const TRANSIENT_STORAGE_ERROR_CODES = new Set([
+  'storage/retry-limit-exceeded',
+  'storage/canceled',
+  'storage/unknown',
+  'storage/server-file-wrong-size',
+]);
+
+function isTransientUploadError(error) {
+  if (!error) return false;
+  if (TRANSIENT_STORAGE_ERROR_CODES.has(error.code)) return true;
+  const message = (error.message || '').toLowerCase();
+  return message.includes('network') || message.includes('fetch');
+}
+
+function wrapStorageError(error, action) {
+  // Preserve Firebase error.code so error-handler.js can produce a meaningful Hebrew message.
+  // Wrapping into a generic Error here strips that code and is the main reason upload failures
+  // look "silent" to users — getErrorMessage() falls through to the generic fallback.
+  const wrapped = new Error(error?.message || `Failed to ${action} file`);
+  if (error?.code) wrapped.code = error.code;
+  if (error?.serverResponse) wrapped.serverResponse = error.serverResponse;
+  wrapped.cause = error;
+  return wrapped;
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * StorageService: General-purpose file upload, retrieval, and deletion using Firebase Storage.
  */
 export class StorageService {
   /**
-   * Uploads a file to Firebase Storage.
+   * Uploads a file to Firebase Storage with one retry for transient errors.
+   * Preserves Firebase error codes (e.g. storage/unauthorized) on failure so callers
+   * can show meaningful messages via error-handler.js.
    * @param {File|Blob} file - The file to upload
    * @param {string} path - The storage path (e.g. 'uploads/myfile.txt')
    * @returns {Promise<string>} The download URL of the uploaded file
    */
   static async uploadFile(file, path) {
-    try {
-      const storage = getStorageInstance();
-      const storageRef = ref(storage, path);
-      await uploadBytes(storageRef, file);
-      const url = await getDownloadURL(storageRef);
-      urlCache.set(path, url);
-      return url;
-    } catch (error) {
-      console.error('Error uploading file:', error);
-      throw new Error('Failed to upload file');
+    const maxAttempts = 2;
+    let lastError;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const storage = getStorageInstance();
+        const storageRef = ref(storage, path);
+        await uploadBytes(storageRef, file);
+        const url = await getDownloadURL(storageRef);
+        urlCache.set(path, url);
+        return url;
+      } catch (error) {
+        lastError = error;
+        console.error(
+          `Error uploading file (attempt ${attempt}/${maxAttempts}, code=${error?.code || 'unknown'}):`,
+          error,
+        );
+        if (attempt < maxAttempts && isTransientUploadError(error)) {
+          await sleep(1000 * attempt);
+          continue;
+        }
+        break;
+      }
     }
+    throw wrapStorageError(lastError, 'upload');
   }
 
   /**
@@ -57,7 +101,7 @@ export class StorageService {
       return url;
     } catch (error) {
       console.error('Error getting file URL:', error);
-      throw new Error('Failed to get file URL');
+      throw wrapStorageError(error, 'get URL for');
     }
   }
 
@@ -74,7 +118,7 @@ export class StorageService {
       urlCache.delete(path);
     } catch (error) {
       console.error('Error deleting file:', error);
-      throw new Error('Failed to delete file');
+      throw wrapStorageError(error, 'delete');
     }
   }
 

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -57,24 +57,11 @@
 // --- Imports ---
 import { StorageService } from '../../services/storage-service.js';
 import { FirestoreService } from '../../services/firestore-service.js';
-
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
-const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+import { validateRecipeImageFile } from '../../config/media-types.js';
 
 // --- Validation ---
 export function validateImageFile(file) {
-  const errors = [];
-  if (!file) {
-    errors.push('No file provided');
-  } else {
-    if (!ALLOWED_TYPES.includes(file.type)) {
-      errors.push('Invalid file type');
-    }
-    if (file.size > MAX_SIZE) {
-      errors.push('File is too large (max 5MB)');
-    }
-  }
-  return { isValid: errors.length === 0, errors };
+  return validateRecipeImageFile(file);
 }
 
 // --- Storage Path Helpers ---
@@ -361,13 +348,24 @@ export async function uploadAndBuildImageMetadata({
   isPrimary,
   uploadedBy,
 }) {
-  const fileExtension = file.name.split('.').pop();
-  const fileName = isPrimary ? 'primary.jpg' : `${Date.now()}.${fileExtension}`;
+  const validation = validateImageFile(file);
+  if (!validation.isValid) {
+    const err = new Error(`בדיקת הקובץ נכשלה: ${validation.errors.join(', ')}`);
+    err.code = 'validation/invalid-image';
+    throw err;
+  }
+
+  const id = generateImageId();
+  // Use the unique id (not Date.now()) to prevent filename collisions when multiple
+  // images are uploaded in parallel within the same millisecond.
+  const rawExtension = (file.name.split('.').pop() || '').toLowerCase();
+  const safeExtension = rawExtension.replace(/[^a-z0-9]/g, '') || 'bin';
+  const fileName = isPrimary ? `primary.${safeExtension}` : `${id}.${safeExtension}`;
   const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
   await StorageService.uploadFile(file, fullPath);
 
   return {
-    id: generateImageId(),
+    id,
     full: fullPath,
     fileName,
     isPrimary,
@@ -392,7 +390,14 @@ export async function addPendingImages(recipeId, files, category, uploader) {
 
   // Upload all images in parallel for better performance
   const uploadPromises = files.map(async (file) => {
-    const fileExtension = file.name.split('.').pop();
+    const validation = validateImageFile(file);
+    if (!validation.isValid) {
+      const err = new Error(`בדיקת הקובץ נכשלה: ${validation.errors.join(', ')}`);
+      err.code = 'validation/invalid-image';
+      throw err;
+    }
+    const rawExtension = (file.name.split('.').pop() || '').toLowerCase();
+    const fileExtension = rawExtension.replace(/[^a-z0-9]/g, '') || 'bin';
     const id = generateImageId();
     const fileName = `${id}.${fileExtension}`;
     // Upload full-size

--- a/src/js/utils/recipes/recipe-media-utils.js
+++ b/src/js/utils/recipes/recipe-media-utils.js
@@ -30,12 +30,7 @@
 
 // --- Imports ---
 import { StorageService } from '../../services/storage-service.js';
-
-// --- Constants ---
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
-const ALLOWED_TYPES = [...ALLOWED_IMAGE_TYPES, ...ALLOWED_VIDEO_TYPES];
-const MAX_SIZE = 50 * 1024 * 1024; // 50MB
+import { validateInstructionMediaFile, getInstructionMediaType } from '../../config/media-types.js';
 
 // --- Validation ---
 /**
@@ -44,25 +39,7 @@ const MAX_SIZE = 50 * 1024 * 1024; // 50MB
  * @returns {{ isValid: boolean, errors: string[] }}
  */
 export function validateMediaFile(file) {
-  const errors = [];
-
-  if (!file) {
-    errors.push('לא סופק קובץ');
-    return { isValid: false, errors };
-  }
-
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    errors.push(
-      `סוג קובץ לא תקין: ${file.type}. סוגי קבצים מותרים: תמונות (JPEG, PNG, WebP, GIF) וסרטונים (MP4, WebM, MOV)`,
-    );
-  }
-
-  if (file.size > MAX_SIZE) {
-    const sizeMB = (file.size / (1024 * 1024)).toFixed(2);
-    errors.push(`הקובץ גדול מדי (${sizeMB}MB). גודל מקסימלי: 50MB`);
-  }
-
-  return { isValid: errors.length === 0, errors };
+  return validateInstructionMediaFile(file);
 }
 
 /**
@@ -131,13 +108,7 @@ export function generateMediaInstructionId() {
  * @returns {'image'|'video'|null}
  */
 function getMediaType(file) {
-  if (ALLOWED_IMAGE_TYPES.includes(file.type)) {
-    return 'image';
-  }
-  if (ALLOWED_VIDEO_TYPES.includes(file.type)) {
-    return 'video';
-  }
-  return null;
+  return getInstructionMediaType(file);
 }
 
 // --- Upload & Delete ---
@@ -204,7 +175,10 @@ export async function uploadMediaInstructionFile(file, recipeId, userId, onProgr
     return metadata;
   } catch (error) {
     console.error('Error uploading media instruction file:', error);
-    throw new Error(`העלאת הקובץ נכשלה: ${error.message}`);
+    const wrapped = new Error(`העלאת הקובץ נכשלה: ${error.message}`);
+    if (error?.code) wrapped.code = error.code;
+    wrapped.cause = error;
+    throw wrapped;
   }
 }
 

--- a/src/lib/images/image-handler.js
+++ b/src/lib/images/image-handler.js
@@ -1,12 +1,19 @@
 import { generateImageId } from '../../js/utils/recipes/recipe-image-utils.js';
 import { uploadZoneStyles } from '../../styles/components/upload-zone-styles.js';
+import {
+  ALLOWED_RECIPE_IMAGE_TYPES,
+  MAX_RECIPE_IMAGE_SIZE,
+  RECIPE_IMAGE_ACCEPT_ATTR,
+  validateRecipeImageFile,
+} from '../../js/config/media-types.js';
 
 class ImageHandler extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    this.maxFileSize = 5 * 1024 * 1024; // 5MB
-    this.allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+    this.maxFileSize = MAX_RECIPE_IMAGE_SIZE;
+    this.allowedTypes = ALLOWED_RECIPE_IMAGE_TYPES;
+    this.acceptAttr = RECIPE_IMAGE_ACCEPT_ATTR;
     this.images = [];
     this.maxImages = 5;
     this.draggedImage = null;
@@ -274,7 +281,7 @@ class ImageHandler extends HTMLElement {
           </div>
           <div class="selected-files"></div>
         </div>
-        <input type="file" class="file-input" accept="image/jpeg,image/png,image/webp" multiple>
+        <input type="file" class="file-input" accept="${this.acceptAttr}" multiple>
         <div class="error-message"></div>
         <div class="preview-container"></div>
       </div>
@@ -451,20 +458,10 @@ class ImageHandler extends HTMLElement {
   }
 
   validateFile(file) {
-    if (!this.allowedTypes.includes(file.type)) {
-      return {
-        valid: false,
-        error: 'סוג הקובץ לא נתמך. נא להעלות תמונות מסוג JPEG, PNG או WebP בלבד',
-      };
+    const result = validateRecipeImageFile(file);
+    if (!result.isValid) {
+      return { valid: false, error: result.errors.join(' • ') };
     }
-
-    if (file.size > this.maxFileSize) {
-      return {
-        valid: false,
-        error: 'התמונה גדולה מדי. הגודל המקסימלי המותר הוא 5MB',
-      };
-    }
-
     return { valid: true };
   }
 
@@ -650,14 +647,22 @@ class ImageHandler extends HTMLElement {
     }
   }
 
-  showError(message) {
+  showError(message, durationMs = 5000) {
     const errorContainer = this.shadowRoot.querySelector('.error-container');
     errorContainer.textContent = message;
     errorContainer.style.display = 'block';
 
-    setTimeout(() => {
-      errorContainer.style.display = 'none';
-    }, 5000);
+    if (this._errorTimeoutId) {
+      clearTimeout(this._errorTimeoutId);
+      this._errorTimeoutId = null;
+    }
+
+    if (durationMs > 0) {
+      this._errorTimeoutId = setTimeout(() => {
+        errorContainer.style.display = 'none';
+        this._errorTimeoutId = null;
+      }, durationMs);
+    }
   }
 
   // Public API Methods

--- a/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/recipes/media-instructions-editor/media-instructions-editor.js
@@ -26,6 +26,7 @@ import {
   validateMediaFile,
   getMediaInstructionUrl,
 } from '../../../js/utils/recipes/recipe-media-utils.js';
+import { INSTRUCTION_MEDIA_ACCEPT_ATTR } from '../../../js/config/media-types.js';
 import { uploadZoneStyles } from '../../../styles/components/upload-zone-styles.js';
 
 class MediaInstructionsEditor extends HTMLElement {
@@ -567,9 +568,9 @@ class MediaInstructionsEditor extends HTMLElement {
         <div class="upload-zone" role="button" tabindex="0" aria-label="העלאת קבצי מדיה - גרור קבצים או לחץ לבחירה">
           גרור תמונות או סרטונים לכאן או לחץ להעלאה
           <div class="status-message">
-            (תמונות: JPEG, PNG, WebP, GIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
+            (תמונות: JPEG, PNG, WebP, GIF, HEIC, AVIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
           </div>
-          <input type="file" class="file-input" multiple accept="image/*,video/*" aria-label="בחר קבצי מדיה">
+          <input type="file" class="file-input" multiple accept="${INSTRUCTION_MEDIA_ACCEPT_ATTR}" aria-label="בחר קבצי מדיה">
         </div>
 
         <!-- Media List -->
@@ -597,9 +598,9 @@ class MediaInstructionsEditor extends HTMLElement {
       uploadZone.innerHTML = `
           גרור תמונות או סרטונים לכאן או לחץ להעלאה
           <div class="status-message">
-            (תמונות: JPEG, PNG, WebP, GIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
+            (תמונות: JPEG, PNG, WebP, GIF, HEIC, AVIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
           </div>
-          <input type="file" class="file-input" multiple accept="image/*,video/*" aria-label="בחר קבצי מדיה">
+          <input type="file" class="file-input" multiple accept="${INSTRUCTION_MEDIA_ACCEPT_ATTR}" aria-label="בחר קבצי מדיה">
       `;
 
       // Re-attach file input change listener (new element created by innerHTML)

--- a/src/lib/recipes/recipe_form_component/propose_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/propose_recipe_component.js
@@ -84,14 +84,23 @@ class ProposeRecipeComponent extends HTMLElement {
       // Generate ID before uploading so we can use it for storage paths
       const recipeId = FirestoreService.generateId('recipes');
 
-      // Upload images if provided
+      // Upload images if provided. If any image fails, abort the whole submission —
+      // a recipe without its primary image is not useful.
       if (imagesToUpload.length > 0) {
-        const imageUploadResults = await this.uploadRecipeImages(
-          recipeId,
-          imagesToUpload,
-          recipeDataForFirestore.category,
-          user?.uid || 'anonymous',
-        );
+        let imageUploadResults;
+        try {
+          imageUploadResults = await this.uploadRecipeImages(
+            recipeId,
+            imagesToUpload,
+            recipeDataForFirestore.category,
+            user?.uid || 'anonymous',
+          );
+        } catch (uploadError) {
+          // Surface the real Firebase error code in the image-handler so the user sees
+          // a meaningful message right next to the upload area (not just a fleeting toast).
+          this.showImageUploadError(uploadError);
+          throw uploadError;
+        }
         recipeDataForFirestore.images = imageUploadResults;
         recipeDataForFirestore.allowImageSuggestions = true;
         uploadedFilesToCleanup.push(...imageUploadResults);
@@ -102,10 +111,11 @@ class ProposeRecipeComponent extends HTMLElement {
       let hasPartialFailure = false;
       let successCount = 0;
       let failedCount = 0;
+      let pendingCount = 0;
 
       if (formComponent && typeof formComponent.uploadPendingMediaInstructions === 'function') {
         const allMedia = formComponent.getAllMediaInOrder();
-        const pendingCount = allMedia.filter((item) => item.file).length;
+        pendingCount = allMedia.filter((item) => item.file).length;
 
         if (pendingCount > 0) {
           const uploadedMedia = await formComponent.uploadPendingMediaInstructions(
@@ -125,10 +135,14 @@ class ProposeRecipeComponent extends HTMLElement {
               console.warn(`${failedCount} of ${pendingCount} media file(s) failed to upload`);
             }
           } else {
-            // If there were pending files but none uploaded, count as failure
-            hasPartialFailure = true;
-            failedCount = pendingCount;
-            console.warn(`All ${pendingCount} media file(s) failed to upload`);
+            // All media failed — the inline editor already shows per-file errors.
+            // Abort submission so the user can retry instead of getting a recipe
+            // missing all its step media silently.
+            const err = new Error(
+              `כל ${pendingCount} קבצי המדיה נכשלו בהעלאה. אנא בדוק את החיבור ונסה שוב.`,
+            );
+            err.code = 'upload/media-all-failed';
+            throw err;
           }
         }
       }
@@ -201,6 +215,17 @@ class ProposeRecipeComponent extends HTMLElement {
   showErrorMessage(error) {
     logError(error, 'Recipe proposal');
     showToast(getErrorMessage(error), 'error', 5000);
+  }
+
+  showImageUploadError(error) {
+    // Surface the real Firebase error inline on the image-handler so the user sees
+    // the failure right next to the upload area rather than a brief toast.
+    const formComponent = this.shadowRoot.querySelector('recipe-form-component');
+    const imageHandler = formComponent?.shadowRoot?.getElementById('recipe-images');
+    if (imageHandler && typeof imageHandler.showError === 'function') {
+      // 0 = sticky; the user needs to see the failure long enough to act on it.
+      imageHandler.showError(getErrorMessage(error), 0);
+    }
   }
 
   clearForm() {

--- a/src/lib/recipes/recipe_form_component/propose_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/propose_recipe_component.js
@@ -96,9 +96,8 @@ class ProposeRecipeComponent extends HTMLElement {
             user?.uid || 'anonymous',
           );
         } catch (uploadError) {
-          // Surface the real Firebase error code in the image-handler so the user sees
-          // a meaningful message right next to the upload area (not just a fleeting toast).
-          this.showImageUploadError(uploadError);
+          // Let the outer catch route the real Firebase error to the form's
+          // top-of-form error banner via showErrorMessage().
           throw uploadError;
         }
         recipeDataForFirestore.images = imageUploadResults;
@@ -214,17 +213,14 @@ class ProposeRecipeComponent extends HTMLElement {
 
   showErrorMessage(error) {
     logError(error, 'Recipe proposal');
-    showToast(getErrorMessage(error), 'error', 5000);
-  }
-
-  showImageUploadError(error) {
-    // Surface the real Firebase error inline on the image-handler so the user sees
-    // the failure right next to the upload area rather than a brief toast.
+    const message = getErrorMessage(error);
+    // Use the form's top-of-form error banner so async failures appear in the
+    // same spot users already look for validation errors.
     const formComponent = this.shadowRoot.querySelector('recipe-form-component');
-    const imageHandler = formComponent?.shadowRoot?.getElementById('recipe-images');
-    if (imageHandler && typeof imageHandler.showError === 'function') {
-      // 0 = sticky; the user needs to see the failure long enough to act on it.
-      imageHandler.showError(getErrorMessage(error), 0);
+    if (formComponent && typeof formComponent.showFormError === 'function') {
+      formComponent.showFormError(message);
+    } else {
+      showToast(message, 'error', 5000);
     }
   }
 

--- a/src/lib/recipes/recipe_form_component/recipe_form_component.js
+++ b/src/lib/recipes/recipe_form_component/recipe_form_component.js
@@ -140,7 +140,7 @@ class RecipeFormComponent extends HTMLElement {
                 <h2 class="recipe-sect__h">התמונה <em>הסופית.</em></h2>
                 <p class="recipe-sect__sub">תמונה ראשית בולטת, ותמונות נוספות של המתכון לפי רצונך.</p>
               </div>
-              <span class="recipe-sect__meta">JPG, PNG · עד 20MB</span>
+              <span class="recipe-sect__meta">JPG, PNG, WebP, HEIC, AVIF · עד 10MB</span>
             </header>
             <div class="recipe-form__group">
               <image-handler id="recipe-images"></image-handler>

--- a/src/lib/recipes/recipe_form_component/recipe_form_component.js
+++ b/src/lib/recipes/recipe_form_component/recipe_form_component.js
@@ -673,6 +673,29 @@ class RecipeFormComponent extends HTMLElement {
   }
 
   /**
+   * Public API: Show an error in the top-of-form error banner. Used by hosts
+   * (propose/edit components) to surface async failures (image/media upload,
+   * Firestore write, etc.) in the same spot as field-validation errors.
+   * @param {string} message
+   */
+  showFormError(message) {
+    const el = this.shadowRoot.querySelector('.recipe-form__error-message');
+    if (!el) return;
+    el.textContent = message;
+    el.style.display = 'block';
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+
+  /**
+   * Public API: Hide the top-of-form error banner.
+   */
+  hideFormError() {
+    const el = this.shadowRoot.querySelector('.recipe-form__error-message');
+    if (!el) return;
+    el.style.display = 'none';
+  }
+
+  /**
    * Public API: Upload pending media instructions
    * Delegates to the media-instructions-editor component without exposing internal structure
    * @param {string} recipeId - Recipe ID for storage path

--- a/tests/js/services/storage-service.test.mjs
+++ b/tests/js/services/storage-service.test.mjs
@@ -37,12 +37,49 @@ describe('StorageService', () => {
       expect(url).toBe(mockUrl);
     });
 
-    it('throws an error if upload fails', async () => {
-      uploadBytes.mockRejectedValue(new Error('fail'));
+    it('throws an error if upload fails and preserves the Firebase error code', async () => {
+      const firebaseError = new Error('User does not have permission');
+      firebaseError.code = 'storage/unauthorized';
+      uploadBytes.mockRejectedValue(firebaseError);
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      await expect(StorageService.uploadFile(mockFile, mockPath)).rejects.toThrow(
-        'Failed to upload file',
-      );
+
+      let thrown;
+      try {
+        await StorageService.uploadFile(mockFile, mockPath);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeDefined();
+      expect(thrown.code).toBe('storage/unauthorized');
+      expect(thrown.message).toBe('User does not have permission');
+      errorSpy.mockRestore();
+    });
+
+    it('retries transient errors once then succeeds', async () => {
+      const transientError = new Error('canceled');
+      transientError.code = 'storage/canceled';
+      uploadBytes.mockRejectedValueOnce(transientError).mockResolvedValueOnce({});
+      getDownloadURL.mockResolvedValue(mockUrl);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const url = await StorageService.uploadFile(mockFile, mockPath);
+
+      expect(uploadBytes).toHaveBeenCalledTimes(2);
+      expect(url).toBe(mockUrl);
+      errorSpy.mockRestore();
+    });
+
+    it('does not retry non-transient errors (e.g. unauthorized)', async () => {
+      const permissionError = new Error('Permission denied');
+      permissionError.code = 'storage/unauthorized';
+      uploadBytes.mockRejectedValue(permissionError);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.uploadFile(mockFile, mockPath)).rejects.toMatchObject({
+        code: 'storage/unauthorized',
+      });
+      expect(uploadBytes).toHaveBeenCalledTimes(1);
       errorSpy.mockRestore();
     });
   });
@@ -67,10 +104,15 @@ describe('StorageService', () => {
       expect(url2).toBe(mockUrl);
     });
 
-    it('throws an error if getDownloadURL fails', async () => {
-      getDownloadURL.mockRejectedValue(new Error('fail'));
+    it('throws an error if getDownloadURL fails and preserves the code', async () => {
+      const err = new Error('not found');
+      err.code = 'storage/object-not-found';
+      getDownloadURL.mockRejectedValue(err);
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      await expect(StorageService.getFileUrl(mockPath)).rejects.toThrow('Failed to get file URL');
+      await expect(StorageService.getFileUrl(mockPath)).rejects.toMatchObject({
+        code: 'storage/object-not-found',
+        message: 'not found',
+      });
       errorSpy.mockRestore();
     });
   });
@@ -84,10 +126,14 @@ describe('StorageService', () => {
       expect(deleteObject).toHaveBeenCalledWith({ storage: mockStorage, path: mockPath });
     });
 
-    it('throws an error if deleteObject fails', async () => {
-      deleteObject.mockRejectedValue(new Error('fail'));
+    it('throws an error if deleteObject fails and preserves the code', async () => {
+      const err = new Error('not found');
+      err.code = 'storage/object-not-found';
+      deleteObject.mockRejectedValue(err);
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-      await expect(StorageService.deleteFile(mockPath)).rejects.toThrow('Failed to delete file');
+      await expect(StorageService.deleteFile(mockPath)).rejects.toMatchObject({
+        code: 'storage/object-not-found',
+      });
       errorSpy.mockRestore();
     });
   });

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -94,7 +94,7 @@ describe('recipe-image-utils', () => {
       expect(validateImageFile(file).isValid).toBe(false);
     });
     it('rejects too large', () => {
-      const file = createFakeFile('big.jpg', 'image/jpeg', 6 * 1024 * 1024);
+      const file = createFakeFile('big.jpg', 'image/jpeg', 11 * 1024 * 1024);
       expect(validateImageFile(file).isValid).toBe(false);
     });
   });
@@ -324,13 +324,13 @@ describe('recipe-image-utils', () => {
       expect(uploadFileMock).toHaveBeenCalledTimes(1);
       expect(meta).toHaveProperty('id');
       expect(meta.full).toContain('img/recipes/full/cat/rid/');
-      expect(meta.fileName).toBe('primary.jpg');
+      expect(meta.fileName).toMatch(/^primary\.jpg$/);
       expect(meta.isPrimary).toBe(true);
       expect(meta.uploadedBy).toBe('user1');
       expect(meta.access).toBe('public');
       expect(meta.uploadTimestamp).toBeDefined();
     });
-    it('uses a timestamped fileName for non-primary', async () => {
+    it('uses a unique image id for the fileName when non-primary (avoids parallel-upload collisions)', async () => {
       uploadFileMock.mockResolvedValue('url');
       const file = createFakeFile('test2.jpg', 'image/jpeg', 1234);
       const meta = await uploadAndBuildImageMetadata({
@@ -340,7 +340,8 @@ describe('recipe-image-utils', () => {
         isPrimary: false,
         uploadedBy: 'user2',
       });
-      expect(meta.fileName).toMatch(/\.jpg$/);
+      expect(meta.fileName).toMatch(/^img-.+\.jpg$/);
+      expect(meta.fileName).toContain(meta.id);
       expect(meta.isPrimary).toBe(false);
       expect(meta.uploadedBy).toBe('user2');
     });

--- a/tests/js/utils/recipes/recipe-media-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-media-utils.test.mjs
@@ -111,14 +111,14 @@ describe('recipe-media-utils', () => {
       const result = validateMediaFile(file);
       expect(result.isValid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
-      expect(result.errors[0]).toContain('סוג קובץ לא תקין');
+      expect(result.errors[0]).toContain('אינו נתמך');
     });
 
     it('rejects wrong type (text)', () => {
       const file = createFakeFile('test.txt', 'text/plain', 1000);
       const result = validateMediaFile(file);
       expect(result.isValid).toBe(false);
-      expect(result.errors[0]).toContain('סוג קובץ לא תקין');
+      expect(result.errors[0]).toContain('אינו נתמך');
     });
 
     it('rejects file too large (>50MB)', () => {


### PR DESCRIPTION
## Summary
This PR consolidates media type validation and configuration into a single source of truth, improves Firebase Storage error handling with retry logic and error code preservation, and enhances user feedback for upload failures.

## Key Changes

### New Media Type Configuration Module
- Created `src/js/config/media-types.js` to centralize all media type definitions and validation logic
  - Defines allowed types for recipe images (JPEG, PNG, WebP, HEIC, HEIF, AVIF) and instruction media (photos + GIF + video)
  - Exports validation functions `validateRecipeImageFile()` and `validateInstructionMediaFile()` with Hebrew error messages
  - Provides size limits: 10MB for recipe images, 50MB for instruction media
  - Includes helper `getInstructionMediaType()` to determine if a file is image or video

### Storage Service Improvements
- Added retry logic for transient upload errors (network failures, server cancellations) with 1-second exponential backoff
- Implemented `wrapStorageError()` to preserve Firebase error codes (e.g., `storage/unauthorized`) so error-handler.js can produce meaningful Hebrew messages
- Updated error handling in `getFileUrl()` and `deleteFile()` to preserve error codes
- Non-transient errors (permission, quota) are not retried

### Recipe Image & Media Utilities Refactoring
- Migrated validation logic from `recipe-image-utils.js` and `recipe-media-utils.js` to use centralized `media-types.js` functions
- Updated `uploadAndBuildImageMetadata()` to use unique IDs instead of timestamps to prevent filename collisions during parallel uploads
- Added file extension sanitization to prevent invalid characters in storage paths
- Enhanced error wrapping to preserve error codes through the upload chain

### Form Error Handling
- Added `showFormError()` and `hideFormError()` public APIs to `recipe-form-component.js` for displaying async failures in the top-of-form error banner
- Updated `propose_recipe_component.js` to route upload failures to the form's error banner instead of toast notifications
- Changed media upload failure behavior: if all instruction media fails, abort submission with a clear error instead of silently creating a recipe without media

### UI Updates
- Updated image-handler and media-instructions-editor to use centralized media type configuration
- Updated recipe form metadata text to reflect new supported formats (HEIC, AVIF) and correct size limits
- Improved error message display with better timeout handling in `image-handler.js`

### Test Updates
- Updated storage-service tests to verify error code preservation and retry behavior
- Updated recipe-image-utils and recipe-media-utils tests to reflect new size limits and validation behavior

## Notable Implementation Details
- Error codes are preserved through the entire upload chain so users see meaningful Hebrew error messages instead of generic fallbacks
- Transient errors are retried once with exponential backoff; permission/quota errors fail immediately
- File extension sanitization prevents storage path injection issues
- Parallel image uploads now use unique IDs instead of timestamps to avoid collisions
- Form-level error banner provides consistent UX for both validation and async failures

https://claude.ai/code/session_01HAxwjnw8xDv69e4YQUrXq8