### PR TITLE
refactor(media): extract reusable upload-zone web component

### DIFF
--- a/src/lib/media/image-handler/image-handler.js
+++ b/src/lib/media/image-handler/image-handler.js
@@ -1,16 +1,20 @@
 import { generateImageId } from '../../../js/utils/recipes/recipe-image-utils.js';
-import { uploadZoneStyles } from '../../../styles/components/upload-zone-styles.js';
+import '../upload-zone/upload-zone.js';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 class ImageHandler extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    this.maxFileSize = 5 * 1024 * 1024; // 5MB
-    this.allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
     this.images = [];
     this.maxImages = 5;
     this.draggedImage = null;
     this.removedImages = [];
+
+    this.handleAccepted = this.handleAccepted.bind(this);
+    this.handleRejected = this.handleRejected.bind(this);
   }
 
   static get observedAttributes() {
@@ -39,6 +43,10 @@ class ImageHandler extends HTMLElement {
     }
   }
 
+  get uploadZoneHint() {
+    return `(מקסימום ${this.maxImages} תמונות, גודל מקסימלי 5MB לתמונה)`;
+  }
+
   render() {
     this.shadowRoot.innerHTML = `
       <style>
@@ -49,15 +57,7 @@ class ImageHandler extends HTMLElement {
           box-sizing: border-box;
         }
 
-        ${uploadZoneStyles}
-
-        :host([hide-upload]) .upload-zone { display: none; }
-
-        .selected-files {
-          margin-top: 10px;
-          font-size: 12px;
-          color: var(--ink-3, rgba(31,29,24,0.55));
-        }
+        :host([hide-upload]) upload-zone { display: none; }
 
         .preview-container {
           position: relative;
@@ -199,16 +199,6 @@ class ImageHandler extends HTMLElement {
           transition: width 0.3s ease;
         }
 
-        .error-message {
-          display: none;
-        }
-
-        .status-message {
-          margin-top: 6px;
-          font-size: 12px;
-          color: var(--ink-3, rgba(31,29,24,0.55));
-        }
-
         .drop-indicator {
           position: absolute;
           width: calc(100% - 2rem);
@@ -263,19 +253,24 @@ class ImageHandler extends HTMLElement {
           font-family: var(--font-ui-he, sans-serif);
           display: none;
         }
+
+        .selected-files {
+          margin-top: 10px;
+          font-size: 12px;
+          color: var(--ink-3, rgba(31,29,24,0.55));
+        }
       </style>
 
       <div class="image-handler">
         <div class="error-container"></div>
-        <div class="upload-zone" data-disabled="false">
-          גרור תמונות לכאן או לחץ להעלאה
-          <div class="status-message">
-            (מקסימום ${this.maxImages} תמונות, גודל מקסימלי 5MB לתמונה)
-          </div>
-          <div class="selected-files"></div>
-        </div>
-        <input type="file" class="file-input" accept="image/jpeg,image/png,image/webp" multiple>
-        <div class="error-message"></div>
+        <upload-zone
+          accept="${ALLOWED_TYPES.join(',')}"
+          multiple
+          max-size="${MAX_FILE_SIZE}"
+          label="גרור תמונות לכאן או לחץ להעלאה"
+          hint="${this.uploadZoneHint}">
+        </upload-zone>
+        <div class="selected-files"></div>
         <div class="preview-container"></div>
       </div>
     `;
@@ -290,47 +285,11 @@ class ImageHandler extends HTMLElement {
   }
 
   setupEventListeners() {
-    const uploadArea = this.shadowRoot.querySelector('.upload-zone');
-    const fileInput = this.shadowRoot.querySelector('.file-input');
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    uploadZone.addEventListener('upload-files-accepted', this.handleAccepted);
+    uploadZone.addEventListener('upload-files-rejected', this.handleRejected);
 
-    // Click to upload
-    uploadArea.addEventListener('click', () => {
-      if (uploadArea.getAttribute('data-disabled') !== 'true') {
-        fileInput.click();
-      }
-    });
-
-    // File input change
-    fileInput.addEventListener('change', (e) => {
-      this.handleFiles(Array.from(e.target.files));
-      fileInput.value = ''; // Reset input
-    });
-
-    // Drag and drop
-    uploadArea.addEventListener('dragover', (e) => {
-      e.preventDefault();
-      if (uploadArea.getAttribute('data-disabled') !== 'true') {
-        uploadArea.classList.add('drag-over');
-      }
-    });
-
-    uploadArea.addEventListener('dragleave', () => {
-      uploadArea.classList.remove('drag-over');
-    });
-
-    uploadArea.addEventListener('drop', (e) => {
-      e.preventDefault();
-      uploadArea.classList.remove('drag-over');
-
-      if (uploadArea.getAttribute('data-disabled') !== 'true') {
-        const files = Array.from(e.dataTransfer.files).filter((file) =>
-          this.allowedTypes.includes(file.type),
-        );
-        this.handleFiles(files);
-      }
-    });
-
-    // Drag and drop reordering
+    // Drag and drop reordering on preview container
     const previewContainer = this.shadowRoot.querySelector('.preview-container');
     const dropIndicator = document.createElement('div');
     dropIndicator.className = 'drop-indicator';
@@ -341,7 +300,6 @@ class ImageHandler extends HTMLElement {
       if (preview) {
         this.draggedImage = preview;
         preview.classList.add('dragging');
-        // Set dragged element data
         e.dataTransfer.setData('text/plain', preview.getAttribute('data-id'));
         e.dataTransfer.effectAllowed = 'move';
       }
@@ -371,7 +329,6 @@ class ImageHandler extends HTMLElement {
         const targetRect = target.getBoundingClientRect();
         const containerRect = previewContainer.getBoundingClientRect();
 
-        // Calculate position for drop indicator
         if (targetIndex > draggedIndex) {
           dropIndicator.style.transform = `translateY(${targetRect.bottom - containerRect.top}px)`;
         } else {
@@ -401,12 +358,12 @@ class ImageHandler extends HTMLElement {
       const fromIndex = allPreviews.indexOf(this.draggedImage);
       const toIndex = allPreviews.indexOf(target);
 
-      // Perform the reorder
       this.reorderImages(fromIndex, toIndex);
     });
   }
 
-  async handleFiles(files) {
+  async handleAccepted(event) {
+    const files = event.detail.files;
     const remainingSlots = this.maxImages - this.images.length;
 
     if (remainingSlots <= 0) {
@@ -415,15 +372,11 @@ class ImageHandler extends HTMLElement {
     }
 
     const filesToProcess = files.slice(0, remainingSlots);
+    if (files.length > remainingSlots) {
+      this.showError(`לא ניתן להעלות יותר מ-${this.maxImages} תמונות`);
+    }
 
     for (const file of filesToProcess) {
-      const validation = this.validateFile(file);
-
-      if (!validation.valid) {
-        this.showError(validation.error);
-        continue;
-      }
-
       try {
         const preview = await this.createImagePreview(file);
         const imageData = {
@@ -434,7 +387,6 @@ class ImageHandler extends HTMLElement {
 
         this.addImage(imageData);
 
-        // Dispatch event for new file
         this.dispatchEvent(
           new CustomEvent('file-added', {
             detail: { imageData },
@@ -450,22 +402,15 @@ class ImageHandler extends HTMLElement {
     this.updateUploadAreaState();
   }
 
-  validateFile(file) {
-    if (!this.allowedTypes.includes(file.type)) {
-      return {
-        valid: false,
-        error: 'סוג הקובץ לא נתמך. נא להעלות תמונות מסוג JPEG, PNG או WebP בלבד',
-      };
-    }
+  handleRejected(event) {
+    const rejected = event.detail.rejected;
+    const reasons = new Set(rejected.flatMap((item) => item.reasons));
 
-    if (file.size > this.maxFileSize) {
-      return {
-        valid: false,
-        error: 'התמונה גדולה מדי. הגודל המקסימלי המותר הוא 5MB',
-      };
+    if (reasons.has('type')) {
+      this.showError('סוג הקובץ לא נתמך. נא להעלות תמונות מסוג JPEG, PNG או WebP בלבד');
+    } else if (reasons.has('size')) {
+      this.showError('התמונה גדולה מדי. הגודל המקסימלי המותר הוא 5MB');
     }
-
-    return { valid: true };
   }
 
   updateSelectedFiles() {
@@ -519,7 +464,6 @@ class ImageHandler extends HTMLElement {
     const removedImage = this.images.find((img) => img.id === imageId);
     const wasPrimary = removedImage?.isPrimary;
 
-    // Track removed images if they have id/full (i.e., are existing images)
     if (removedImage && (removedImage.id || removedImage.full)) {
       this.removedImages.push({
         id: removedImage.id,
@@ -529,7 +473,6 @@ class ImageHandler extends HTMLElement {
 
     this.images = this.images.filter((img) => img.id !== imageId);
 
-    // If we removed the primary image and there are other images, make the first one primary
     if (wasPrimary && this.images.length > 0) {
       this.images[0].isPrimary = true;
     }
@@ -537,7 +480,6 @@ class ImageHandler extends HTMLElement {
     this.updatePreviewContainer();
     this.updateUploadAreaState();
 
-    // Clear the selected files if no images remain
     if (wasOnlyImage) {
       this.updateSelectedFiles();
     }
@@ -571,7 +513,7 @@ class ImageHandler extends HTMLElement {
     const container = this.shadowRoot.querySelector('.preview-container');
     container.innerHTML = '';
 
-    this.images.forEach((image, index) => {
+    this.images.forEach((image) => {
       const preview = document.createElement('div');
       preview.className = `image-preview${image.isPrimary ? ' primary' : ''}`;
       preview.draggable = true;
@@ -593,26 +535,18 @@ class ImageHandler extends HTMLElement {
       const removeButton = preview.querySelector('.remove-button');
       const primaryButton = preview.querySelector('.primary-button');
 
-      // Toggle overlay visibility on click (for mobile)
       preview.addEventListener('click', (e) => {
-        if (e.target.closest('.control-button')) {
-          return;
-        }
+        if (e.target.closest('.control-button')) return;
 
         e.stopPropagation();
 
-        // Close all other overlays
         container.querySelectorAll('.image-controls.visible').forEach((ctrl) => {
-          if (ctrl !== controls) {
-            ctrl.classList.remove('visible');
-          }
+          if (ctrl !== controls) ctrl.classList.remove('visible');
         });
 
-        // Toggle this overlay
         controls.classList.toggle('visible');
       });
 
-      // Button event handlers (prevent event bubbling to avoid toggle)
       removeButton.addEventListener('click', (e) => {
         e.stopPropagation();
         this.removeImage(image.id);
@@ -631,22 +565,22 @@ class ImageHandler extends HTMLElement {
   }
 
   updateUploadAreaState() {
-    const uploadArea = this.shadowRoot.querySelector('.upload-zone');
-    uploadArea.setAttribute('data-disabled', this.images.length >= this.maxImages);
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    if (!uploadZone) return;
+    const atMax = this.images.length >= this.maxImages;
+    if (!this.hasAttribute('hide-upload')) {
+      uploadZone.toggleAttribute('disabled', atMax);
+    }
   }
 
   updateUploadAreaVisibility() {
-    const uploadArea = this.shadowRoot?.querySelector('.upload-zone');
-    if (!uploadArea) return;
+    const uploadZone = this.shadowRoot?.querySelector('upload-zone');
+    if (!uploadZone) return;
 
-    const shouldHide = this.hasAttribute('hide-upload');
-
-    if (shouldHide) {
-      uploadArea.style.display = 'none';
-      uploadArea.setAttribute('data-disabled', 'true');
+    if (this.hasAttribute('hide-upload')) {
+      uploadZone.setAttribute('disabled', '');
     } else {
-      uploadArea.style.display = '';
-      uploadArea.setAttribute('data-disabled', this.images.length >= this.maxImages);
+      uploadZone.toggleAttribute('disabled', this.images.length >= this.maxImages);
     }
   }
 
@@ -664,8 +598,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Set upload progress for a specific image
-   * @param {string} imageId - The ID of the image
-   * @param {number} progress - Progress percentage (0-100)
    */
   setImageProgress(imageId, progress) {
     const imageEl = this.shadowRoot.querySelector(`.image-preview[data-id="${imageId}"]`);
@@ -679,8 +611,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Mark an image as uploading
-   * @param {string} imageId - The ID of the image
-   * @param {boolean} isUploading - Whether the image is currently uploading
    */
   setImageUploading(imageId, isUploading) {
     const imageEl = this.shadowRoot.querySelector(`.image-preview[data-id="${imageId}"]`);
@@ -695,8 +625,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Mark an image as uploaded successfully
-   * @param {string} imageId - The ID of the image
-   * @param {string} uploadedUrl - The URL of the uploaded image
    */
   setImageUploaded(imageId, uploadedUrl) {
     const imageData = this.images.find((img) => img.id === imageId);
@@ -708,8 +636,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Show error for a specific image
-   * @param {string} imageId - The ID of the image
-   * @param {string} error - Error message
    */
   setImageError(imageId, error) {
     const imageEl = this.shadowRoot.querySelector(`.image-preview[data-id="${imageId}"]`);
@@ -722,7 +648,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Get all selected images
-   * @returns {Array} Array of image data objects
    */
   getImages() {
     return [...this.images];
@@ -730,7 +655,6 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Get all removed images (for deletion)
-   * @returns {Array} Array of removed image data objects
    */
   getRemovedImages() {
     return [...this.removedImages];
@@ -749,37 +673,31 @@ class ImageHandler extends HTMLElement {
 
   /**
    * Set maximum number of images allowed
-   * @param {number} count - Maximum number of images
    */
   setMaxImages(count) {
     this.maxImages = count;
-    this.shadowRoot.querySelector('.status-message').textContent =
-      `(מקסימום ${this.maxImages} תמונות, גודל מקסימלי 5MB לתמונה)`;
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    if (uploadZone) {
+      uploadZone.setAttribute('hint', this.uploadZoneHint);
+    }
     this.updateUploadAreaState();
   }
 
   setDisabled(isDisabled) {
-    const uploadArea = this.shadowRoot.querySelector('.upload-zone');
-    uploadArea.setAttribute('data-disabled', isDisabled.toString());
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    if (uploadZone) {
+      uploadZone.toggleAttribute('disabled', isDisabled);
+    }
 
     const controlButtons = this.shadowRoot.querySelectorAll('.image-preview .control-button');
     controlButtons.forEach((button) => {
       button.disabled = isDisabled;
     });
 
-    // Additionally, disable the file input itself to prevent programmatic clicking if any
-    const fileInput = this.shadowRoot.querySelector('.file-input');
-    if (fileInput) {
-      fileInput.disabled = isDisabled;
-    }
-
-    // Prevent drag-and-drop on previews when disabled
     const previews = this.shadowRoot.querySelectorAll('.image-preview');
     previews.forEach((preview) => {
       preview.draggable = !isDisabled;
     });
-    // The main upload area click is already handled by checking data-disabled.
-    // Drag-over on upload area also checks data-disabled.
   }
 }
 

--- a/src/lib/media/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/media/media-instructions-editor/media-instructions-editor.js
@@ -26,7 +26,13 @@ import {
   validateMediaFile,
   getMediaInstructionUrl,
 } from '../../../js/utils/recipes/recipe-media-utils.js';
-import { uploadZoneStyles } from '../../../styles/components/upload-zone-styles.js';
+import '../upload-zone/upload-zone.js';
+
+const ACCEPT_MIME =
+  'image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm,video/quicktime';
+const MAX_FILE_SIZE = 50 * 1024 * 1024;
+const UPLOAD_LABEL = 'גרור תמונות או סרטונים לכאן או לחץ להעלאה';
+const UPLOAD_HINT = '(תמונות: JPEG, PNG, WebP, GIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)';
 
 class MediaInstructionsEditor extends HTMLElement {
   constructor() {
@@ -40,12 +46,8 @@ class MediaInstructionsEditor extends HTMLElement {
     this.errors = [];
     this.draggedIndex = null;
 
-    this.handleDragOver = this.handleDragOver.bind(this);
-    this.handleDragLeave = this.handleDragLeave.bind(this);
-    this.handleDrop = this.handleDrop.bind(this);
-    this.handleFileSelect = this.handleFileSelect.bind(this);
-    this.handleUploadZoneClick = this.handleUploadZoneClick.bind(this);
-    this.handleUploadZoneKeyDown = this.handleUploadZoneKeyDown.bind(this);
+    this.handleAccepted = this.handleAccepted.bind(this);
+    this.handleRejected = this.handleRejected.bind(this);
   }
 
   static get observedAttributes() {
@@ -58,8 +60,6 @@ class MediaInstructionsEditor extends HTMLElement {
   }
 
   disconnectedCallback() {
-    this.removeEventListeners();
-
     // Clean up any pending blob URLs to prevent memory leaks
     this.mediaItems.forEach((item) => {
       if (item.preview && item.file) {
@@ -97,84 +97,27 @@ class MediaInstructionsEditor extends HTMLElement {
   }
 
   setupEventListeners() {
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    const fileInput = this.shadowRoot.querySelector('.file-input');
-
-    // Drag & Drop events
-    uploadZone.addEventListener('dragover', this.handleDragOver);
-    uploadZone.addEventListener('dragleave', this.handleDragLeave);
-    uploadZone.addEventListener('drop', this.handleDrop);
-
-    // Click to browse
-    uploadZone.addEventListener('click', this.handleUploadZoneClick);
-
-    // Keyboard accessibility for upload zone
-    uploadZone.addEventListener('keydown', this.handleUploadZoneKeyDown);
-
-    fileInput.addEventListener('change', this.handleFileSelect);
-  }
-
-  removeEventListeners() {
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    const fileInput = this.shadowRoot.querySelector('.file-input');
-
-    if (uploadZone) {
-      uploadZone.removeEventListener('dragover', this.handleDragOver);
-      uploadZone.removeEventListener('dragleave', this.handleDragLeave);
-      uploadZone.removeEventListener('drop', this.handleDrop);
-      uploadZone.removeEventListener('click', this.handleUploadZoneClick);
-      uploadZone.removeEventListener('keydown', this.handleUploadZoneKeyDown);
-    }
-
-    if (fileInput) {
-      fileInput.removeEventListener('change', this.handleFileSelect);
-    }
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    uploadZone.addEventListener('upload-files-accepted', this.handleAccepted);
+    uploadZone.addEventListener('upload-files-rejected', this.handleRejected);
   }
 
   // --- File Upload Handlers ---
 
-  handleDragOver(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    uploadZone.classList.add('drag-over');
+  async handleAccepted(event) {
+    await this.uploadFiles(event.detail.files);
   }
 
-  handleDragLeave(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    uploadZone.classList.remove('drag-over');
-  }
-
-  async handleDrop(e) {
-    e.preventDefault();
-    e.stopPropagation();
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    uploadZone.classList.remove('drag-over');
-
-    const files = Array.from(e.dataTransfer.files);
-    await this.uploadFiles(files);
-  }
-
-  async handleFileSelect(e) {
-    const files = Array.from(e.target.files);
-    await this.uploadFiles(files);
-    // Reset input so same file can be selected again
-    e.target.value = '';
-  }
-
-  handleUploadZoneClick() {
-    const currentFileInput = this.shadowRoot.querySelector('.file-input');
-    if (currentFileInput) currentFileInput.click();
-  }
-
-  handleUploadZoneKeyDown(e) {
-    // Trigger file input on Enter or Space (standard button behavior)
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      this.handleUploadZoneClick();
+  handleRejected(event) {
+    const rejected = event.detail.rejected;
+    // Run domain validator to get localized error messages.
+    for (const { file } of rejected) {
+      const validation = validateMediaFile(file);
+      if (!validation.isValid) {
+        this.errors.push(`${file.name}: ${validation.errors.join(', ')}`);
+      }
     }
+    this.renderErrors();
   }
 
   async uploadFiles(files) {
@@ -331,15 +274,9 @@ class MediaInstructionsEditor extends HTMLElement {
 
         .editor-container { width: 100%; }
 
-        ${uploadZoneStyles}
-
-        .upload-zone.uploading {
-          opacity: 0.55;
-          pointer-events: none;
-        }
-
-        .status-message {
-          direction: rtl;
+        upload-zone {
+          display: block;
+          margin-bottom: 10px;
         }
 
         .media-list-container { display: none; }
@@ -540,32 +477,16 @@ class MediaInstructionsEditor extends HTMLElement {
           color: var(--secondary-dark, #bc4749);
           margin: 4px 0;
         }
-
-        .loading-spinner {
-          border: 3px solid var(--surface-2, #f0ede6);
-          border-top: 3px solid var(--primary, #6a994e);
-          border-radius: 50%;
-          width: 30px;
-          height: 30px;
-          animation: spin 1s linear infinite;
-          margin: 20px auto;
-        }
-
-        @keyframes spin {
-          0%   { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
-        }
       </style>
 
       <div class="editor-container">
-        <!-- Upload Zone -->
-        <div class="upload-zone" role="button" tabindex="0" aria-label="העלאת קבצי מדיה - גרור קבצים או לחץ לבחירה">
-          גרור תמונות או סרטונים לכאן או לחץ להעלאה
-          <div class="status-message">
-            (תמונות: JPEG, PNG, WebP, GIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
-          </div>
-          <input type="file" class="file-input" multiple accept="image/*,video/*" aria-label="בחר קבצי מדיה">
-        </div>
+        <upload-zone
+          accept="${ACCEPT_MIME}"
+          multiple
+          max-size="${MAX_FILE_SIZE}"
+          label="${UPLOAD_LABEL}"
+          hint="${UPLOAD_HINT}">
+        </upload-zone>
 
         <!-- Media List -->
         <div class="media-list-container"></div>
@@ -578,31 +499,11 @@ class MediaInstructionsEditor extends HTMLElement {
     this.renderMediaList();
   }
 
-  renderUploadingState() {
-    const uploadZone = this.shadowRoot.querySelector('.upload-zone');
-    if (this.uploading) {
-      uploadZone.classList.add('uploading');
-      uploadZone.innerHTML = `
-        <div class="loading-spinner"></div>
-        <div class="upload-text">מעלה קבצים...</div>
-      `;
-    } else {
-      uploadZone.classList.remove('uploading');
-      // Restore original content
-      uploadZone.innerHTML = `
-          גרור תמונות או סרטונים לכאן או לחץ להעלאה
-          <div class="status-message">
-            (תמונות: JPEG, PNG, WebP, GIF | סרטונים: MP4, WebM, MOV | מקסימום: 50MB)
-          </div>
-          <input type="file" class="file-input" multiple accept="image/*,video/*" aria-label="בחר קבצי מדיה">
-      `;
-
-      // Re-attach file input change listener (new element created by innerHTML)
-      const fileInput = this.shadowRoot.querySelector('.file-input');
-      fileInput.addEventListener('change', this.handleFileSelect);
-
-      // Note: uploadZone listeners (drag/drop/click/keydown) remain intact because
-      // uploadZone element itself is not replaced, only its innerHTML children are replaced
+  setUploading(isUploading) {
+    this.uploading = isUploading;
+    const uploadZone = this.shadowRoot.querySelector('upload-zone');
+    if (uploadZone) {
+      uploadZone.toggleAttribute('loading', isUploading);
     }
   }
 
@@ -772,8 +673,7 @@ class MediaInstructionsEditor extends HTMLElement {
       return [];
     }
 
-    this.uploading = true;
-    this.renderUploadingState();
+    this.setUploading(true);
 
     const uploadedMedia = [];
 
@@ -807,8 +707,7 @@ class MediaInstructionsEditor extends HTMLElement {
       item.order = index;
     });
 
-    this.uploading = false;
-    this.renderUploadingState();
+    this.setUploading(false);
     this.emitChange();
     this.renderMediaList();
     this.renderErrors();

--- a/src/lib/media/upload-zone/upload-zone.js
+++ b/src/lib/media/upload-zone/upload-zone.js
@@ -1,0 +1,349 @@
+/**
+ * UploadZone Web Component
+ * ========================
+ * A focused upload zone with drag-and-drop, click-to-browse, file validation,
+ * keyboard accessibility, and loading/disabled states. Consumers handle the
+ * accepted files; this component is responsible only for the upload surface.
+ *
+ * @attribute {string} accept - Comma-separated MIME types (supports wildcards
+ *   like "image/*"). Defaults to "*\/*".
+ * @attribute {boolean} multiple - Allow selecting multiple files.
+ * @attribute {number} max-size - Maximum file size in bytes (0 = no limit).
+ * @attribute {string} label - Primary text shown in the zone.
+ * @attribute {string} hint - Secondary status text shown below the label.
+ * @attribute {string} loading-text - Text shown while loading. Defaults to
+ *   "מעלה קבצים...".
+ * @attribute {boolean} disabled - Disable interaction.
+ * @attribute {boolean} loading - Show loading spinner and block interaction.
+ *
+ * @fires upload-files-accepted - Files that passed type/size validation.
+ *   detail: { files: File[] }
+ * @fires upload-files-rejected - Files that failed validation.
+ *   detail: { rejected: Array<{ file: File, reasons: string[] }> }
+ *
+ * @example
+ * <upload-zone
+ *   accept="image/jpeg,image/png,image/webp"
+ *   multiple
+ *   max-size="5242880"
+ *   label="גרור תמונות לכאן או לחץ להעלאה"
+ *   hint="(מקסימום 5 תמונות, גודל מקסימלי 5MB לתמונה)">
+ * </upload-zone>
+ */
+
+import { uploadZoneStyles } from '../../../styles/components/upload-zone-styles.js';
+
+const DEFAULT_LOADING_TEXT = 'מעלה קבצים...';
+
+function buildAcceptMatcher(accept) {
+  const patterns = accept
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (patterns.length === 0 || patterns.includes('*/*')) {
+    return () => true;
+  }
+
+  return (mime) =>
+    patterns.some((pat) => {
+      if (pat.endsWith('/*')) {
+        return mime.startsWith(pat.slice(0, -1));
+      }
+      return mime === pat;
+    });
+}
+
+class UploadZone extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+
+    this.handleZoneClick = this.handleZoneClick.bind(this);
+    this.handleZoneKeyDown = this.handleZoneKeyDown.bind(this);
+    this.handleDragOver = this.handleDragOver.bind(this);
+    this.handleDragLeave = this.handleDragLeave.bind(this);
+    this.handleDrop = this.handleDrop.bind(this);
+    this.handleFileChange = this.handleFileChange.bind(this);
+  }
+
+  static get observedAttributes() {
+    return [
+      'accept',
+      'multiple',
+      'max-size',
+      'label',
+      'hint',
+      'loading-text',
+      'disabled',
+      'loading',
+    ];
+  }
+
+  connectedCallback() {
+    this.render();
+    this.attachListeners();
+    this.applyState();
+  }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (oldVal === newVal || !this.isConnected) return;
+
+    if (name === 'disabled' || name === 'loading') {
+      this.applyState();
+      return;
+    }
+
+    // Text/config attributes — re-render content but keep the zone element.
+    this.updateContent();
+    const fileInput = this.shadowRoot.querySelector('.file-input');
+    if (fileInput) {
+      fileInput.setAttribute('accept', this.accept);
+      fileInput.toggleAttribute('multiple', this.multiple);
+    }
+  }
+
+  // --- Reflected props ---
+
+  get accept() {
+    return this.getAttribute('accept') || '*/*';
+  }
+  get multiple() {
+    return this.hasAttribute('multiple');
+  }
+  get maxSize() {
+    return parseInt(this.getAttribute('max-size') || '0', 10);
+  }
+  get label() {
+    return this.getAttribute('label') || '';
+  }
+  get hint() {
+    return this.getAttribute('hint') || '';
+  }
+  get loadingText() {
+    return this.getAttribute('loading-text') || DEFAULT_LOADING_TEXT;
+  }
+  get disabled() {
+    return this.hasAttribute('disabled');
+  }
+  get loading() {
+    return this.hasAttribute('loading');
+  }
+
+  // --- Rendering ---
+
+  render() {
+    this.shadowRoot.innerHTML = `
+      <style>
+        :host { display: block; }
+
+        ${uploadZoneStyles}
+
+        .upload-zone {
+          margin-bottom: 0;
+        }
+
+        .upload-zone__content {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .upload-zone__content[hidden] { display: none; }
+
+        .loading-spinner-inner {
+          border: 3px solid var(--surface-2, #f0ede6);
+          border-top: 3px solid var(--primary, #6a994e);
+          border-radius: 50%;
+          width: 30px;
+          height: 30px;
+          animation: upload-zone-spin 1s linear infinite;
+        }
+
+        @keyframes upload-zone-spin {
+          0%   { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+      </style>
+
+      <div
+        class="upload-zone"
+        role="button"
+        tabindex="0"
+        aria-label="${this.label || 'Upload files'}"
+      >
+        <div class="upload-zone__content upload-zone__default" data-role="default"></div>
+        <div class="upload-zone__content upload-zone__loading" data-role="loading" hidden>
+          <div class="loading-spinner-inner" aria-hidden="true"></div>
+          <div class="upload-zone__loading-text"></div>
+        </div>
+        <input
+          type="file"
+          class="file-input"
+          accept="${this.accept}"
+          ${this.multiple ? 'multiple' : ''}
+          aria-hidden="true"
+        />
+      </div>
+    `;
+
+    this.updateContent();
+  }
+
+  updateContent() {
+    const defaultEl = this.shadowRoot.querySelector('.upload-zone__default');
+    if (defaultEl) {
+      defaultEl.innerHTML = `
+        <div>${this.label}</div>
+        ${this.hint ? `<div class="status-message">${this.hint}</div>` : ''}
+      `;
+    }
+    const loadingTextEl = this.shadowRoot.querySelector('.upload-zone__loading-text');
+    if (loadingTextEl) {
+      loadingTextEl.textContent = this.loadingText;
+    }
+    const zone = this.shadowRoot.querySelector('.upload-zone');
+    if (zone) {
+      zone.setAttribute('aria-label', this.label || 'Upload files');
+    }
+  }
+
+  attachListeners() {
+    const zone = this.shadowRoot.querySelector('.upload-zone');
+    const fileInput = this.shadowRoot.querySelector('.file-input');
+    zone.addEventListener('click', this.handleZoneClick);
+    zone.addEventListener('keydown', this.handleZoneKeyDown);
+    zone.addEventListener('dragover', this.handleDragOver);
+    zone.addEventListener('dragleave', this.handleDragLeave);
+    zone.addEventListener('drop', this.handleDrop);
+    fileInput.addEventListener('change', this.handleFileChange);
+  }
+
+  // --- Interaction handlers ---
+
+  handleZoneClick(e) {
+    if (e.target.closest('.file-input')) return;
+    this.openPicker();
+  }
+
+  handleZoneKeyDown(e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.openPicker();
+    }
+  }
+
+  handleDragOver(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (this.disabled || this.loading) return;
+    const zone = this.shadowRoot.querySelector('.upload-zone');
+    zone.classList.add('drag-over');
+  }
+
+  handleDragLeave(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const zone = this.shadowRoot.querySelector('.upload-zone');
+    zone.classList.remove('drag-over');
+  }
+
+  handleDrop(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const zone = this.shadowRoot.querySelector('.upload-zone');
+    zone.classList.remove('drag-over');
+    if (this.disabled || this.loading) return;
+    this.processFiles(Array.from(e.dataTransfer.files));
+  }
+
+  handleFileChange(e) {
+    this.processFiles(Array.from(e.target.files));
+    e.target.value = '';
+  }
+
+  // --- File validation ---
+
+  processFiles(files) {
+    if (!files.length) return;
+
+    const matchesAccept = buildAcceptMatcher(this.accept);
+    const maxSize = this.maxSize;
+
+    const accepted = [];
+    const rejected = [];
+
+    for (const file of files) {
+      const reasons = [];
+      if (!matchesAccept(file.type)) reasons.push('type');
+      if (maxSize > 0 && file.size > maxSize) reasons.push('size');
+      if (reasons.length) {
+        rejected.push({ file, reasons });
+      } else {
+        accepted.push(file);
+      }
+    }
+
+    if (accepted.length) {
+      this.dispatchEvent(
+        new CustomEvent('upload-files-accepted', {
+          detail: { files: accepted },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+
+    if (rejected.length) {
+      this.dispatchEvent(
+        new CustomEvent('upload-files-rejected', {
+          detail: { rejected },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+  }
+
+  // --- State application ---
+
+  applyState() {
+    const zone = this.shadowRoot?.querySelector('.upload-zone');
+    if (!zone) return;
+
+    const disabled = this.disabled;
+    const loading = this.loading;
+
+    zone.setAttribute('data-disabled', String(disabled));
+    zone.classList.toggle('uploading', loading);
+    zone.tabIndex = disabled || loading ? -1 : 0;
+
+    const fileInput = this.shadowRoot.querySelector('.file-input');
+    if (fileInput) fileInput.disabled = disabled || loading;
+
+    const defaultEl = this.shadowRoot.querySelector('.upload-zone__default');
+    const loadingEl = this.shadowRoot.querySelector('.upload-zone__loading');
+    if (defaultEl) defaultEl.hidden = loading;
+    if (loadingEl) loadingEl.hidden = !loading;
+  }
+
+  // --- Public API ---
+
+  openPicker() {
+    if (this.disabled || this.loading) return;
+    this.shadowRoot.querySelector('.file-input')?.click();
+  }
+
+  setLoading(value) {
+    this.toggleAttribute('loading', !!value);
+  }
+
+  setDisabled(value) {
+    this.toggleAttribute('disabled', !!value);
+  }
+}
+
+customElements.define('upload-zone', UploadZone);
+
+export default UploadZone;


### PR DESCRIPTION
## Summary

The \`image-handler\` and \`media-instructions-editor\` components each implemented their own drag-drop upload surface, file validation, disabled state, and loading state. This PR extracts a shared \`<upload-zone>\` web component that owns the upload UI behavior and emits accepted/rejected files via custom events.

Reopens the work from the now-closed #185 (auto-closed when its base branch \`claude/reorganize-media-components-53nwb\` was deleted on merge of #184). Rebased onto current \`development\` so only the upload-zone extraction commit remains — the reorg commit it depended on is already present as \`32d9c8e\`.

## Changes

| File | Diff |
|---|---|
| \`src/lib/media/upload-zone/upload-zone.js\` | new (349 LOC) |
| \`src/lib/media/image-handler/image-handler.js\` | refactored to embed \`<upload-zone>\` and listen for \`upload-files-accepted\` |
| \`src/lib/media/media-instructions-editor/media-instructions-editor.js\` | refactored to embed \`<upload-zone>\`, uses the \`loading\` attribute instead of swapping innerHTML during uploads |

Net: +453 / −287 across 3 files. Public APIs and events on both host components remain intact.

## Component contract

Attributes: \`accept\`, \`multiple\`, \`max-size\`, \`label\`, \`hint\`, \`disabled\`, \`loading\`.
Events: \`upload-files-accepted\`, \`upload-files-rejected\`.

## Test plan

- [ ] Recipe images: drag-drop, browse, primary-toggle, remove, reorder still work
- [ ] Recipe instruction media: photo/video add, drag-drop, reorder, remove, caption still work
- [ ] Disabled state visually correct on both hosts
- [ ] Loading state (during upload) visually correct on both hosts
- [ ] File-type/size validation messages still surface