### PR TITLE
fix(form): disable save button when form is pristine

### DIFF
--- a/src/lib/recipes/recipe_form_component/recipe_form_component.js
+++ b/src/lib/recipes/recipe_form_component/recipe_form_component.js
@@ -45,9 +45,7 @@ class RecipeFormComponent extends HTMLElement {
     this.render();
     this.setupEventListeners();
 
-    if (!this.formProtectionDisabled) {
-      this.setupFormProtection();
-    }
+    this.setupFormProtection();
 
     // Auth observer for dynamic button visibility
     this.handleAuthUpdate = this.handleAuthUpdate.bind(this);
@@ -57,13 +55,10 @@ class RecipeFormComponent extends HTMLElement {
     if (recipeId) {
       await this.setRecipeData(recipeId);
     } else {
-      // Enable protection for new forms after initial render (only if not disabled)
-      if (!this.formProtectionDisabled) {
-        setTimeout(() => {
-          this.collectFormData();
-          this.enableFormProtection(this.recipeData);
-        }, 500);
-      }
+      setTimeout(() => {
+        this.collectFormData();
+        this.enableFormProtection(this.recipeData);
+      }, 500);
     }
   }
 
@@ -404,27 +399,27 @@ class RecipeFormComponent extends HTMLElement {
         this.recipeData = data;
         await this.populateFromData(data, recipeId);
 
-        // Enable protection only if not disabled
-        if (!this.formProtectionDisabled) {
-          setTimeout(() => this.enableFormProtection(this.recipeData), 500);
-        }
+        // Re-collect from the form so the dirty-state baseline matches
+        // the shape produced by subsequent captures (Firestore-raw and
+        // form-collected shapes diverge — e.g. source:'existing' on
+        // images, instruction string normalization).
+        setTimeout(() => {
+          this.collectFormData();
+          this.enableFormProtection(this.recipeData);
+        }, 500);
       } else {
         console.warn('No such document!');
-        if (!this.formProtectionDisabled) {
-          setTimeout(() => {
-            this.collectFormData();
-            this.enableFormProtection(this.recipeData);
-          }, 500);
-        }
-      }
-    } catch (error) {
-      console.error('Error fetching recipe:', error);
-      if (!this.formProtectionDisabled) {
         setTimeout(() => {
           this.collectFormData();
           this.enableFormProtection(this.recipeData);
         }, 500);
       }
+    } catch (error) {
+      console.error('Error fetching recipe:', error);
+      setTimeout(() => {
+        this.collectFormData();
+        this.enableFormProtection(this.recipeData);
+      }, 500);
     }
   }
 
@@ -557,9 +552,7 @@ class RecipeFormComponent extends HTMLElement {
     const debouncedDirtyCheck = () => {
       clearTimeout(checkDirtyStateTimeout);
       checkDirtyStateTimeout = setTimeout(() => {
-        if (this.isProtectionEnabled) {
-          formProtectionManager.checkDirtyState();
-        }
+        formProtectionManager.checkDirtyState();
       }, 300);
     };
 
@@ -585,11 +578,17 @@ class RecipeFormComponent extends HTMLElement {
    * @param {Object} initialData - Initial form data (optional)
    */
   enableFormProtection(initialData = null) {
-    if (this.formProtectionDisabled || this.isProtectionEnabled) return;
+    if (this.isProtectionEnabled) return;
 
     const dataToUse = initialData || this.recipeData;
     formProtectionManager.initialize(this.shadowRoot, dataToUse);
     this.isProtectionEnabled = true;
+
+    // disable-form-protection silences nav-away prompts but keeps
+    // dirty-state events flowing for save-button gating.
+    if (this.formProtectionDisabled) {
+      formProtectionManager.temporaryDisable();
+    }
   }
 
   /**

--- a/src/lib/recipes/recipe_preview_modal/edit_preview_recipe.js
+++ b/src/lib/recipes/recipe_preview_modal/edit_preview_recipe.js
@@ -227,7 +227,7 @@ class EditPreviewRecipe extends HTMLElement {
                   ${icons.closeX}
                   <span class="btn-label">נקה</span>
                 </button>
-                <button class="toolbar-btn toolbar-btn--save" id="toolbar-save" ${isPreview ? 'disabled' : ''} aria-label="שמור">
+                <button class="toolbar-btn toolbar-btn--save" id="toolbar-save" disabled aria-label="שמור">
                   ${icons.floppyDisk}
                   <span class="btn-label">שמור</span>
                 </button>
@@ -262,7 +262,7 @@ class EditPreviewRecipe extends HTMLElement {
         toggleImg.src = this.path + 'eye.png';
         toggleImg.alt = 'צפה';
         toggleLbl.textContent = 'תצוגה מקדימה';
-        saveBtn.disabled = false;
+        saveBtn.disabled = true;
         clearBtn.disabled = false;
       } else {
         this.mode = 'preview';
@@ -292,6 +292,11 @@ class EditPreviewRecipe extends HTMLElement {
       const editComp = modalBody.querySelector('edit-recipe-component');
       const formComp = editComp?.shadowRoot?.querySelector('recipe-form-component');
       formComp?.requestClear();
+    });
+
+    modalBody.addEventListener('form-dirty-changed', (event) => {
+      if (this.mode !== 'edit') return;
+      saveBtn.disabled = !event.detail.isDirty;
     });
   }
 


### PR DESCRIPTION
## Summary

The recipe form's dirty-state plumbing was coupled to the nav-away prompt. Setting \`disable-form-protection\` (used by the edit-recipe flow to suppress \"unsaved changes\" prompts during async \`populateImages\`) short-circuited the entire dirty-tracking pipeline — so the save button was always enabled, and clicking it on an unmodified form triggered a full Firestore write with no real changes.

This PR decouples those two concerns: dirty tracking now always runs, but the nav-away prompt is the only thing actually gated by \`disable-form-protection\`. The submit button is then bound to dirty state.

Fixes #191

## Approach (option A from the issue)

1. \`enableFormProtection\` always initializes the manager. If \`disable-form-protection\` is set, immediately call \`temporaryDisable()\` on the manager so the prompts stay off but dirty tracking keeps running.
2. The debounced dirty-check no longer guards on \`isProtectionEnabled\`. \`formProtectionManager.checkDirtyState()\` is already a safe no-op before \`initialize()\` captures a baseline.
3. \`updateDirtyStateIndicators(isDirty)\` now also toggles the submit button (via a new \`setSubmitDisabled\` on \`form-button-group\` so the clear button stays usable).
4. Submit is set disabled immediately on mount to cover the ~500 ms window between render and \`enableFormProtection\` running.

## Side effects this kills

All listed in #191:
- Spurious Firestore writes from no-op saves.
- Silent \`mediaInstructions[].order\` renormalization on no-op saves.
- Misleading \"המתכון עודכן בהצלחה!\" modal after a no-op.

## Test plan

- [ ] Edit-recipe: open a recipe → submit disabled on mount → change a field → submit enabled → revert → submit disabled again.
- [ ] Edit-recipe: confirm no nav-away \"unsaved changes\" prompt was reintroduced when navigating away with unsaved changes.
- [ ] Propose-recipe: form opens with submit disabled → start typing → submit enables → clear form → submit disables → confirm nav-away prompt **still** fires for unsaved propose-form changes.
- [ ] Clear button works in both pristine and dirty states.
- [ ] Save flow itself unchanged when there *are* edits.