### PR TITLE
fix(auth): ensure profile modal renders content on open

### DIFF
--- a/src/lib/auth/auth-controller.js
+++ b/src/lib/auth/auth-controller.js
@@ -271,18 +271,26 @@ class AuthController extends HTMLElement {
     }
   }
 
-  async loadAuthComponents() {
-    try {
-      await Promise.all([
-        import('./components/login-form.js'),
-        import('./components/signup-form.js'),
-        import('./components/forgot-password.js'),
-        import('./components/user-profile.js'),
-      ]);
-      this._authComponentsLoaded = true;
-    } catch (error) {
-      console.error('Failed to lazy load auth components:', error);
-    }
+  loadAuthComponents() {
+    // Cache the in-flight promise so concurrent callers share it and a
+    // resolved load is a no-op. Without this, callers that need the
+    // <user-profile> element to be upgraded before manipulating it (e.g.
+    // auth-avatar's click handler) could race against openModal's own load.
+    if (this._authComponentsPromise) return this._authComponentsPromise;
+    this._authComponentsPromise = Promise.all([
+      import('./components/login-form.js'),
+      import('./components/signup-form.js'),
+      import('./components/forgot-password.js'),
+      import('./components/user-profile.js'),
+    ])
+      .then(() => {
+        this._authComponentsLoaded = true;
+      })
+      .catch((error) => {
+        console.error('Failed to lazy load auth components:', error);
+        this._authComponentsPromise = null;
+      });
+    return this._authComponentsPromise;
   }
 
   closeModal() {

--- a/src/lib/auth/components/auth-avatar.js
+++ b/src/lib/auth/components/auth-avatar.js
@@ -160,8 +160,7 @@ class AuthAvatar extends HTMLElement {
     }
   }
 
-  handleClick() {
-    const user = authService.getCurrentUser();
+  async handleClick() {
     const authController = document.querySelector('auth-controller');
     const authContent = document.querySelector('auth-content');
 
@@ -170,11 +169,16 @@ class AuthAvatar extends HTMLElement {
       return;
     }
 
+    // Ensure slot components (especially <user-profile>) are upgraded before
+    // we toggle .active on them or call methods like showPanel(). Otherwise
+    // the slot may render visible but empty — only the profile head/tabs
+    // show, with no form fields underneath.
+    await authController.loadAuthComponents();
+
+    const user = authService.getCurrentUser();
     if (user) {
-      // Show profile for logged in user
       authContent.showUserProfile();
     } else {
-      // Show login form for non-authenticated user
       authContent.showAuthForms();
     }
 


### PR DESCRIPTION
The profile modal could open with only its title banner — the user-profile
form fields underneath were missing — because auth-avatar's click handler
toggled .active and called showPanel() on the <user-profile> element
before user-profile.js was lazy-loaded, leaving the slot visible but its
shadow DOM empty.

Wait for loadAuthComponents() to resolve before configuring DOM state, and
make loadAuthComponents() idempotent so concurrent callers share one
in-flight promise.

https://claude.ai/code/session_018YveV3cc5XE2mf7QMjrqhm