### PR TITLE
refactor(services): introduce RecipeService + RecipeImageProposalService (PR-A)

### DIFF
--- a/src/js/services/recipe-image-proposal-service.js
+++ b/src/js/services/recipe-image-proposal-service.js
@@ -1,0 +1,67 @@
+// src/js/services/recipe-image-proposal-service.js
+
+import {
+  addPendingImages,
+  approvePendingImageById,
+  rejectPendingImageById,
+  getPendingImages,
+} from '../utils/recipes/recipe-image-utils.js';
+
+/**
+ * RecipeImageProposalService — Image Proposal & Moderation
+ *
+ * Distinct workflow from owner CRUD: end-users propose images on existing
+ * recipes; managers approve/reject. Kept separate from RecipeService so the
+ * owner surface stays focused.
+ *
+ * Public API:
+ *   - propose(recipeId, files, category, uploadedBy)
+ *   - approve(recipeId, pendingImageId)
+ *   - reject(recipeId, pendingImageId)
+ *   - listPending(recipeId)
+ */
+export class RecipeImageProposalService {
+  /**
+   * Upload one or more images as proposals against an existing recipe.
+   * @param {string} recipeId
+   * @param {File[]} files
+   * @param {string} category
+   * @param {string} uploadedBy
+   * @returns {Promise<Array>} pending image metadata
+   */
+  static async propose(recipeId, files, category, uploadedBy) {
+    return await addPendingImages(recipeId, files, category, uploadedBy);
+  }
+
+  /**
+   * Approve a pending image, moving it into the approved images array.
+   * @param {string} recipeId
+   * @param {string} pendingImageId
+   * @returns {Promise<string>} new image ID
+   */
+  static async approve(recipeId, pendingImageId) {
+    return await approvePendingImageById(recipeId, pendingImageId);
+  }
+
+  /**
+   * Reject a pending image, deleting its files and removing it from the
+   * pending array.
+   * @param {string} recipeId
+   * @param {string} pendingImageId
+   * @returns {Promise<void>}
+   */
+  static async reject(recipeId, pendingImageId) {
+    return await rejectPendingImageById(recipeId, pendingImageId);
+  }
+
+  /**
+   * List all pending images for a recipe.
+   * @param {string} recipeId
+   * @returns {Promise<Array>}
+   */
+  static async listPending(recipeId) {
+    return await getPendingImages(recipeId);
+  }
+}
+
+export const recipeImageProposalService = RecipeImageProposalService;

--- a/src/js/services/recipe-service.js
+++ b/src/js/services/recipe-service.js
@@ -1,0 +1,400 @@
+// src/js/services/recipe-service.js
+
+import { FirestoreService } from './firestore-service.js';
+import {
+  uploadAndBuildImageMetadata,
+  deleteImageFiles,
+  migrateImageToCategory,
+  removeAllRecipeImages,
+  setPrimaryImage as setPrimaryImageInternal,
+} from '../utils/recipes/recipe-image-utils.js';
+import {
+  uploadMediaInstructionFile,
+  removeAllMediaInstructions,
+} from '../utils/recipes/recipe-media-utils.js';
+
+/**
+ * RecipeService — Recipe-Aware Service Layer
+ *
+ * Single entry point for all recipe owner CRUD. Internalizes image
+ * upload/delete/migration and media-instruction upload so callers no longer
+ * orchestrate Storage + Firestore manually.
+ *
+ * Public API:
+ *   - get(recipeId)
+ *   - list(queryParams)
+ *   - generateId()
+ *   - create({ recipeData, imagesToUpload, mediaItemsOrdered, uploadedBy })
+ *   - update(recipeId, { changes, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved })
+ *   - delete(recipeId)
+ *
+ * Image proposal/moderation (the pending-images workflow) lives in
+ * RecipeImageProposalService.
+ */
+
+const RECIPES_COLLECTION = 'recipes';
+
+async function uploadImagesAtomic(recipeId, category, imagesToUpload, uploadedBy) {
+  // allSettled (not all) so we can clean up resolutions when any sibling
+  // rejects — Promise.all leaves us blind to which uploads actually landed.
+  const settled = await Promise.allSettled(
+    imagesToUpload.map(({ file, isPrimary }) =>
+      uploadAndBuildImageMetadata({
+        recipeId,
+        category,
+        file,
+        isPrimary: !!isPrimary,
+        uploadedBy: uploadedBy || 'anonymous',
+      }),
+    ),
+  );
+  const uploaded = settled.filter((s) => s.status === 'fulfilled').map((s) => s.value);
+  const firstRejection = settled.find((s) => s.status === 'rejected');
+  if (firstRejection) {
+    await Promise.all(
+      uploaded.map((img) =>
+        deleteImageFiles(img).catch((e) =>
+          console.warn('Failed to cleanup partially-uploaded image:', e),
+        ),
+      ),
+    );
+    throw firstRejection.reason;
+  }
+  return uploaded;
+}
+
+async function uploadMediaItems(recipeId, mediaItemsOrdered, uploadedBy) {
+  const safeOrdered = Array.isArray(mediaItemsOrdered) ? mediaItemsOrdered : [];
+  const pendingItems = safeOrdered
+    .map((item, position) => ({ item, position }))
+    .filter(({ item }) => !!item.file);
+
+  const uploaded = [];
+  const failed = [];
+
+  for (const { item, position } of pendingItems) {
+    try {
+      const metadata = await uploadMediaInstructionFile(
+        item.file,
+        recipeId,
+        uploadedBy || 'anonymous',
+      );
+      metadata.caption = item.caption || '';
+      uploaded.push({ position, metadata });
+    } catch (error) {
+      failed.push({ position, error: error.message || String(error), originalItem: item });
+    }
+  }
+
+  const uploadedByPos = new Map(uploaded.map(({ position, metadata }) => [position, metadata]));
+  const finalArray = [];
+  let order = 0;
+  for (let i = 0; i < safeOrdered.length; i++) {
+    const item = safeOrdered[i];
+    if (item.file) {
+      const meta = uploadedByPos.get(i);
+      if (meta) {
+        finalArray.push({ ...meta, order });
+        order++;
+      }
+      // Failed uploads are simply omitted from the saved array.
+    } else {
+      const { position: _p, ...rest } = item;
+      finalArray.push({ ...rest, order });
+      order++;
+    }
+  }
+
+  return {
+    finalArray,
+    results: {
+      uploaded,
+      failed,
+      totalPending: pendingItems.length,
+      successCount: uploaded.length,
+      failedCount: failed.length,
+    },
+  };
+}
+
+function stripUndefined(obj) {
+  if (!obj || typeof obj !== 'object') return obj;
+  const out = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v === undefined) continue;
+    if (Array.isArray(v)) {
+      out[k] = v.filter((item) => item !== undefined);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function withFirestoreWriteTimeout(promise, timeoutMs, timeoutMessage) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs)),
+  ]);
+}
+
+export class RecipeService {
+  /**
+   * Generate a new recipe document ID without writing.
+   * @returns {string}
+   */
+  static generateId() {
+    return FirestoreService.generateId(RECIPES_COLLECTION);
+  }
+
+  /**
+   * Fetch a single recipe by ID (raw document).
+   * @param {string} recipeId
+   * @returns {Promise<Object|null>}
+   */
+  static async get(recipeId) {
+    return await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+  }
+
+  /**
+   * Query recipes with the same shape as FirestoreService.queryDocuments.
+   * @param {Object} queryParams
+   * @returns {Promise<Array<Object>>}
+   */
+  static async list(queryParams = {}) {
+    return await FirestoreService.queryDocuments(RECIPES_COLLECTION, queryParams);
+  }
+
+  /**
+   * Create a new recipe. Generates an ID, uploads images and media
+   * instructions, then writes the document. On error any successfully
+   * uploaded image files are cleaned up (best-effort).
+   *
+   * @param {Object} params
+   * @param {Object} params.recipeData - Base recipe fields (no images/mediaInstructions/toDelete).
+   *                                     Caller is responsible for timestamps, userId, approved.
+   * @param {Array<{file: File, isPrimary: boolean}>} [params.imagesToUpload]
+   * @param {Array<Object>} [params.mediaItemsOrdered] - Ordered media items
+   *        from the editor; each entry has either `file` (pending) or
+   *        existing metadata.
+   * @param {string} params.uploadedBy - User UID for uploads.
+   * @returns {Promise<{ recipeId: string, mediaUploadResults: Object }>}
+   */
+  static async create({ recipeData, imagesToUpload, mediaItemsOrdered, uploadedBy } = {}) {
+    if (!recipeData || typeof recipeData !== 'object') {
+      throw new Error('RecipeService.create: recipeData is required');
+    }
+    const recipeId = RecipeService.generateId();
+    const cleanedData = stripUndefined(recipeData);
+    let uploadedImages = [];
+
+    try {
+      if (Array.isArray(imagesToUpload) && imagesToUpload.length > 0) {
+        uploadedImages = await uploadImagesAtomic(
+          recipeId,
+          cleanedData.category,
+          imagesToUpload,
+          uploadedBy,
+        );
+      }
+
+      const { finalArray: mediaInstructions, results: mediaUploadResults } = await uploadMediaItems(
+        recipeId,
+        mediaItemsOrdered,
+        uploadedBy,
+      );
+
+      const docPayload = { ...cleanedData };
+      if (uploadedImages.length > 0) {
+        docPayload.images = uploadedImages;
+        docPayload.allowImageSuggestions = true;
+      }
+      if (mediaInstructions.length > 0) {
+        docPayload.mediaInstructions = mediaInstructions;
+      }
+
+      // Firestore buffers writes while offline rather than rejecting, so race
+      // it against a timeout so the caller's UI doesn't hang indefinitely.
+      await withFirestoreWriteTimeout(
+        FirestoreService.setDocument(RECIPES_COLLECTION, recipeId, docPayload),
+        15000,
+        'אין חיבור לאינטרנט. אנא בדוק את החיבור ונסה שוב.',
+      );
+
+      return { recipeId, mediaUploadResults };
+    } catch (error) {
+      await Promise.all(
+        uploadedImages.map((img) =>
+          deleteImageFiles(img).catch((e) =>
+            console.warn('Failed to cleanup uploaded image on error:', e),
+          ),
+        ),
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Patch-update an existing recipe. Only fields that are explicitly passed
+   * are touched — omit `images` and the recipe's existing images are left
+   * alone; omit `mediaItemsOrdered` and existing media is preserved.
+   *
+   * @param {string} recipeId
+   * @param {Object} params
+   * @param {Object} [params.changes] - Field changes (no images / media / toDelete).
+   * @param {Array<Object>} [params.images] - Form-shaped image entries:
+   *        `{source:'new', file, isPrimary, uploadedBy}` or
+   *        `{source:'existing', ...metadata}`. Omit to leave images unchanged.
+   * @param {Array<Object>} [params.imagesToDelete] - Storage cleanup for
+   *        removed images. Independent of `images` so callers can delete
+   *        without re-writing the array.
+   * @param {Array<Object>} [params.mediaItemsOrdered] - Ordered media items.
+   *        Omit to leave media unchanged.
+   * @param {string} [params.uploadedBy] - User UID for new uploads.
+   * @param {boolean} [params.approved] - Pass `true` to auto-approve (e.g.
+   *        manager edits). Omit to leave the approval flag untouched.
+   * @returns {Promise<{ mediaUploadResults: Object, migrationWarnings: Array }>}
+   */
+  static async update(
+    recipeId,
+    { changes = {}, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved } = {},
+  ) {
+    if (!recipeId) {
+      throw new Error('RecipeService.update: recipeId is required');
+    }
+
+    const originalRecipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!originalRecipe) {
+      throw new Error(`RecipeService.update: recipe ${recipeId} not found`);
+    }
+
+    const newCategory = changes.category ?? originalRecipe.category;
+    const categoryChanged = originalRecipe.category !== newCategory;
+    const migrationWarnings = [];
+    let mediaUploadResults = {
+      uploaded: [],
+      failed: [],
+      totalPending: 0,
+      successCount: 0,
+      failedCount: 0,
+    };
+
+    // 1. Delete removed images (best-effort).
+    if (Array.isArray(imagesToDelete)) {
+      for (const img of imagesToDelete) {
+        if (img && img.full) {
+          await deleteImageFiles(img).catch((e) =>
+            console.warn(`Failed to delete removed image ${img.id}:`, e),
+          );
+        }
+      }
+    }
+
+    // 2. Process images only when explicitly provided.
+    let newImages;
+    if (Array.isArray(images)) {
+      newImages = [];
+      const uploadedThisCall = [];
+      try {
+        for (const img of images) {
+          if (img.source === 'new' && img.file) {
+            const meta = await uploadAndBuildImageMetadata({
+              recipeId,
+              category: newCategory,
+              file: img.file,
+              isPrimary: !!img.isPrimary,
+              uploadedBy: img.uploadedBy || uploadedBy || 'anonymous',
+            });
+            uploadedThisCall.push(meta);
+            newImages.push(meta);
+          } else if (img.source === 'existing') {
+            // Drop transient form-internal fields; filter undefined to keep
+            // Firestore (no ignoreUndefinedProperties) happy.
+            const { source: _s, file: _f, preview: _p, ...rest } = img;
+            let existingImage = Object.fromEntries(
+              Object.entries(rest).filter(([, v]) => v !== undefined),
+            );
+            if (categoryChanged) {
+              try {
+                existingImage = await migrateImageToCategory(
+                  existingImage,
+                  recipeId,
+                  originalRecipe.category,
+                  newCategory,
+                );
+              } catch (error) {
+                migrationWarnings.push({ imageId: img.id, error: error.message });
+              }
+            }
+            newImages.push(existingImage);
+          }
+        }
+      } catch (error) {
+        await Promise.all(
+          uploadedThisCall.map((img) =>
+            deleteImageFiles(img).catch((e) =>
+              console.warn('Failed to cleanup uploaded image on update error:', e),
+            ),
+          ),
+        );
+        throw error;
+      }
+    }
+
+    // 3. Process media only when explicitly provided.
+    let mediaInstructions;
+    if (Array.isArray(mediaItemsOrdered)) {
+      const result = await uploadMediaItems(recipeId, mediaItemsOrdered, uploadedBy);
+      mediaInstructions = result.finalArray;
+      mediaUploadResults = result.results;
+    }
+
+    // 4. Build write payload — only include fields the caller asked us to touch.
+    const docPayload = { ...stripUndefined(changes) };
+    if (newImages !== undefined) docPayload.images = newImages;
+    if (mediaInstructions !== undefined) docPayload.mediaInstructions = mediaInstructions;
+    if (approved !== undefined) docPayload.approved = approved;
+
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, docPayload);
+
+    return { mediaUploadResults, migrationWarnings };
+  }
+
+  /**
+   * Mark a single image on a recipe as the primary one. Clears `isPrimary`
+   * on the rest. Throws if the recipe has no images.
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @returns {Promise<void>}
+   */
+  static async setPrimaryImage(recipeId, imageId) {
+    return await setPrimaryImageInternal(recipeId, imageId);
+  }
+
+  /**
+   * Completely delete a recipe and all associated media from Storage.
+   * Idempotent if the recipe document does not exist.
+   * @param {string} recipeId
+   * @returns {Promise<void>}
+   */
+  static async delete(recipeId) {
+    if (!recipeId) {
+      throw new Error('RecipeService.delete: recipeId is required');
+    }
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe) {
+      console.warn('Recipe not found for deletion:', recipeId);
+      return;
+    }
+
+    await removeAllRecipeImages(recipeId);
+
+    if (Array.isArray(recipe.mediaInstructions) && recipe.mediaInstructions.length > 0) {
+      await removeAllMediaInstructions(recipe.mediaInstructions);
+    }
+
+    await FirestoreService.deleteDocument(RECIPES_COLLECTION, recipeId);
+  }
+}
+
+export const recipeService = RecipeService;

--- a/tests/js/services/recipe-image-proposal-service.test.mjs
+++ b/tests/js/services/recipe-image-proposal-service.test.mjs
@@ -1,0 +1,54 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let RecipeImageProposalService;
+
+const imageUtilMocks = {
+  addPendingImages: jest.fn(),
+  approvePendingImageById: jest.fn(),
+  rejectPendingImageById: jest.fn(),
+  getPendingImages: jest.fn(),
+};
+
+jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(imageUtilMocks).forEach((m) => m.mockReset());
+  ({ RecipeImageProposalService } = await import(
+    'src/js/services/recipe-image-proposal-service.js'
+  ));
+});
+
+describe('RecipeImageProposalService', () => {
+  it('propose delegates to addPendingImages', async () => {
+    imageUtilMocks.addPendingImages.mockResolvedValue([{ id: 'p1' }]);
+    const files = [new File([new Blob(['a'])], 'a.jpg', { type: 'image/jpeg' })];
+    const result = await RecipeImageProposalService.propose('r1', files, 'cat', 'user-1');
+    expect(imageUtilMocks.addPendingImages).toHaveBeenCalledWith('r1', files, 'cat', 'user-1');
+    expect(result).toEqual([{ id: 'p1' }]);
+  });
+
+  it('approve delegates to approvePendingImageById', async () => {
+    imageUtilMocks.approvePendingImageById.mockResolvedValue('new-id');
+    const result = await RecipeImageProposalService.approve('r1', 'pid');
+    expect(imageUtilMocks.approvePendingImageById).toHaveBeenCalledWith('r1', 'pid');
+    expect(result).toBe('new-id');
+  });
+
+  it('reject delegates to rejectPendingImageById', async () => {
+    imageUtilMocks.rejectPendingImageById.mockResolvedValue();
+    await RecipeImageProposalService.reject('r1', 'pid');
+    expect(imageUtilMocks.rejectPendingImageById).toHaveBeenCalledWith('r1', 'pid');
+  });
+
+  it('listPending delegates to getPendingImages', async () => {
+    imageUtilMocks.getPendingImages.mockResolvedValue([{ id: 'p1' }]);
+    const result = await RecipeImageProposalService.listPending('r1');
+    expect(imageUtilMocks.getPendingImages).toHaveBeenCalledWith('r1');
+    expect(result).toEqual([{ id: 'p1' }]);
+  });
+});

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -1,0 +1,382 @@
+import { jest } from '@jest/globals';
+
+// Mocks for the underlying Firebase modules
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let RecipeService;
+
+const firestoreMocks = {
+  getDocument: jest.fn(),
+  setDocument: jest.fn(),
+  updateDocument: jest.fn(),
+  deleteDocument: jest.fn(),
+  queryDocuments: jest.fn(),
+  generateId: jest.fn(() => 'recipe-123'),
+};
+
+const imageUtilMocks = {
+  uploadAndBuildImageMetadata: jest.fn(),
+  deleteImageFiles: jest.fn(() => Promise.resolve()),
+  migrateImageToCategory: jest.fn(),
+  removeAllRecipeImages: jest.fn(() => Promise.resolve()),
+  setPrimaryImage: jest.fn(() => Promise.resolve()),
+};
+
+const mediaUtilMocks = {
+  uploadMediaInstructionFile: jest.fn(),
+  removeAllMediaInstructions: jest.fn(() => Promise.resolve({ success: 0, failed: 0, errors: [] })),
+};
+
+jest.unstable_mockModule('src/js/services/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+jest.unstable_mockModule('src/js/utils/recipes/recipe-media-utils.js', () => mediaUtilMocks);
+
+function makeFile(name = 'a.jpg', type = 'image/jpeg') {
+  return new File([new Blob(['a'], { type })], name, { type });
+}
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
+  firestoreMocks.generateId.mockImplementation(() => 'recipe-123');
+  Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
+  imageUtilMocks.deleteImageFiles.mockImplementation(() => Promise.resolve());
+  imageUtilMocks.removeAllRecipeImages.mockImplementation(() => Promise.resolve());
+  imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
+  Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
+  mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
+    Promise.resolve({ success: 0, failed: 0, errors: [] }),
+  );
+
+  ({ RecipeService } = await import('src/js/services/recipe-service.js'));
+});
+
+describe('RecipeService', () => {
+  describe('get / list / generateId', () => {
+    it('get delegates to FirestoreService.getDocument', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'r1', name: 'Bread' });
+      const result = await RecipeService.get('r1');
+      expect(firestoreMocks.getDocument).toHaveBeenCalledWith('recipes', 'r1');
+      expect(result).toEqual({ id: 'r1', name: 'Bread' });
+    });
+
+    it('list delegates to FirestoreService.queryDocuments', async () => {
+      firestoreMocks.queryDocuments.mockResolvedValue([{ id: 'a' }]);
+      const result = await RecipeService.list({ limit: 5 });
+      expect(firestoreMocks.queryDocuments).toHaveBeenCalledWith('recipes', { limit: 5 });
+      expect(result).toEqual([{ id: 'a' }]);
+    });
+
+    it('generateId calls FirestoreService.generateId for recipes', () => {
+      expect(RecipeService.generateId()).toBe('recipe-123');
+      expect(firestoreMocks.generateId).toHaveBeenCalledWith('recipes');
+    });
+  });
+
+  describe('create', () => {
+    it('uploads images, writes doc, returns id and media result', async () => {
+      imageUtilMocks.uploadAndBuildImageMetadata
+        .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
+        .mockResolvedValueOnce({ id: 'img-2', full: 'p/2.jpg' });
+      firestoreMocks.setDocument.mockResolvedValue();
+
+      const result = await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts' },
+        imagesToUpload: [
+          { file: makeFile('1.jpg'), isPrimary: true },
+          { file: makeFile('2.jpg'), isPrimary: false },
+        ],
+        mediaItemsOrdered: [],
+        uploadedBy: 'user-1',
+      });
+
+      expect(result.recipeId).toBe('recipe-123');
+      expect(result.mediaUploadResults).toEqual({
+        uploaded: [],
+        failed: [],
+        totalPending: 0,
+        successCount: 0,
+        failedCount: 0,
+      });
+      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(2);
+      expect(firestoreMocks.setDocument).toHaveBeenCalledWith(
+        'recipes',
+        'recipe-123',
+        expect.objectContaining({
+          name: 'Cake',
+          category: 'desserts',
+          allowImageSuggestions: true,
+          images: [
+            { id: 'img-1', full: 'p/1.jpg' },
+            { id: 'img-2', full: 'p/2.jpg' },
+          ],
+        }),
+      );
+    });
+
+    it('skips images and allowImageSuggestions when there are none', async () => {
+      firestoreMocks.setDocument.mockResolvedValue();
+      await RecipeService.create({
+        recipeData: { name: 'Plain', category: 'mains' },
+        uploadedBy: 'user-1',
+      });
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload).not.toHaveProperty('images');
+      expect(payload).not.toHaveProperty('allowImageSuggestions');
+    });
+
+    it('cleans up uploaded images if a later image fails', async () => {
+      imageUtilMocks.uploadAndBuildImageMetadata
+        .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
+        .mockRejectedValueOnce(new Error('upload failed'));
+
+      await expect(
+        RecipeService.create({
+          recipeData: { name: 'Cake', category: 'desserts' },
+          imagesToUpload: [
+            { file: makeFile('1.jpg'), isPrimary: true },
+            { file: makeFile('2.jpg'), isPrimary: false },
+          ],
+          uploadedBy: 'user-1',
+        }),
+      ).rejects.toThrow('upload failed');
+
+      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+        id: 'img-1',
+        full: 'p/1.jpg',
+      });
+      expect(firestoreMocks.setDocument).not.toHaveBeenCalled();
+    });
+
+    it('uploads pending media and assembles sequential order', async () => {
+      mediaUtilMocks.uploadMediaInstructionFile
+        .mockResolvedValueOnce({ id: 'm-1', path: 'mp/1', order: 0 })
+        .mockResolvedValueOnce({ id: 'm-2', path: 'mp/2', order: 0 });
+      firestoreMocks.setDocument.mockResolvedValue();
+
+      const result = await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts' },
+        mediaItemsOrdered: [
+          { file: makeFile('m1.jpg'), caption: 'cap1' },
+          { id: 'existing-1', path: 'mp/existing', caption: 'cap-existing' },
+          { file: makeFile('m2.jpg'), caption: 'cap2' },
+        ],
+        uploadedBy: 'user-1',
+      });
+
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload.mediaInstructions).toEqual([
+        expect.objectContaining({ id: 'm-1', caption: 'cap1', order: 0 }),
+        expect.objectContaining({ id: 'existing-1', caption: 'cap-existing', order: 1 }),
+        expect.objectContaining({ id: 'm-2', caption: 'cap2', order: 2 }),
+      ]);
+      expect(result.mediaUploadResults.successCount).toBe(2);
+      expect(result.mediaUploadResults.failedCount).toBe(0);
+    });
+
+    it('skips failed media uploads but keeps successful ones', async () => {
+      mediaUtilMocks.uploadMediaInstructionFile
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ id: 'm-2', path: 'mp/2', order: 0 });
+      firestoreMocks.setDocument.mockResolvedValue();
+
+      const result = await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts' },
+        mediaItemsOrdered: [
+          { file: makeFile('m1.jpg'), caption: 'cap1' },
+          { file: makeFile('m2.jpg'), caption: 'cap2' },
+        ],
+        uploadedBy: 'user-1',
+      });
+
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload.mediaInstructions).toEqual([
+        expect.objectContaining({ id: 'm-2', caption: 'cap2', order: 0 }),
+      ]);
+      expect(result.mediaUploadResults.successCount).toBe(1);
+      expect(result.mediaUploadResults.failedCount).toBe(1);
+      expect(result.mediaUploadResults.totalPending).toBe(2);
+    });
+
+    it('strips undefined recipeData fields', async () => {
+      firestoreMocks.setDocument.mockResolvedValue();
+      await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts', attribution: undefined },
+        uploadedBy: 'user-1',
+      });
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload).not.toHaveProperty('attribution');
+    });
+
+    it('throws when recipeData is missing', async () => {
+      await expect(RecipeService.create({})).rejects.toThrow('recipeData is required');
+    });
+  });
+
+  describe('update', () => {
+    beforeEach(() => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        category: 'desserts',
+        images: [],
+      });
+      firestoreMocks.updateDocument.mockResolvedValue();
+    });
+
+    it('throws when recipe is missing', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      await expect(RecipeService.update('missing', { changes: {} })).rejects.toThrow('not found');
+    });
+
+    it('deletes removed images, uploads new ones, keeps existing', async () => {
+      imageUtilMocks.uploadAndBuildImageMetadata.mockResolvedValueOnce({
+        id: 'img-new',
+        full: 'p/new.jpg',
+      });
+
+      await RecipeService.update('recipe-9', {
+        changes: { name: 'Updated' },
+        images: [
+          { source: 'existing', id: 'img-old', full: 'p/old.jpg', isPrimary: true },
+          { source: 'new', file: makeFile('new.jpg'), isPrimary: false },
+        ],
+        imagesToDelete: [{ id: 'img-rm', full: 'p/rm.jpg' }],
+        uploadedBy: 'user-1',
+        approved: true,
+      });
+
+      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+        id: 'img-rm',
+        full: 'p/rm.jpg',
+      });
+      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(1);
+      const payload = firestoreMocks.updateDocument.mock.calls[0][2];
+      expect(payload.approved).toBe(true);
+      expect(payload.images.map((i) => i.id)).toEqual(['img-old', 'img-new']);
+    });
+
+    it('patches only the supplied fields — omitted images/media are not wiped', async () => {
+      await RecipeService.update('recipe-9', {
+        changes: { relatedRecipes: ['r-1', 'r-2'] },
+      });
+      const payload = firestoreMocks.updateDocument.mock.calls[0][2];
+      expect(payload).toEqual({ relatedRecipes: ['r-1', 'r-2'] });
+      expect(payload).not.toHaveProperty('images');
+      expect(payload).not.toHaveProperty('mediaInstructions');
+      expect(payload).not.toHaveProperty('approved');
+    });
+
+    it('migrates existing images on category change', async () => {
+      imageUtilMocks.migrateImageToCategory.mockResolvedValueOnce({
+        id: 'img-keep',
+        full: 'img/recipes/full/mains/recipe-9/keep.jpg',
+      });
+
+      await RecipeService.update('recipe-9', {
+        changes: { category: 'mains' },
+        images: [
+          {
+            source: 'existing',
+            id: 'img-keep',
+            full: 'img/recipes/full/desserts/recipe-9/keep.jpg',
+          },
+        ],
+        uploadedBy: 'user-1',
+      });
+
+      expect(imageUtilMocks.migrateImageToCategory).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'img-keep' }),
+        'recipe-9',
+        'desserts',
+        'mains',
+      );
+    });
+
+    it('collects migration warnings when migration fails', async () => {
+      imageUtilMocks.migrateImageToCategory.mockRejectedValueOnce(new Error('migrate failed'));
+
+      const result = await RecipeService.update('recipe-9', {
+        changes: { category: 'mains' },
+        images: [
+          { source: 'existing', id: 'img-bad', full: 'img/recipes/full/desserts/recipe-9/x.jpg' },
+        ],
+        uploadedBy: 'user-1',
+      });
+
+      expect(result.migrationWarnings).toEqual([{ imageId: 'img-bad', error: 'migrate failed' }]);
+    });
+
+    it('rolls back uploaded images when an image upload throws mid-loop', async () => {
+      imageUtilMocks.uploadAndBuildImageMetadata
+        .mockResolvedValueOnce({ id: 'new-1', full: 'p/n1.jpg' })
+        .mockRejectedValueOnce(new Error('upload boom'));
+
+      await expect(
+        RecipeService.update('recipe-9', {
+          changes: {},
+          images: [
+            { source: 'new', file: makeFile('n1.jpg'), isPrimary: false },
+            { source: 'new', file: makeFile('n2.jpg'), isPrimary: false },
+          ],
+          uploadedBy: 'user-1',
+        }),
+      ).rejects.toThrow('upload boom');
+
+      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+        id: 'new-1',
+        full: 'p/n1.jpg',
+      });
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('writes the approved flag when explicitly provided', async () => {
+      await RecipeService.update('recipe-9', {
+        changes: { name: 'Updated' },
+        approved: false,
+        uploadedBy: 'user-1',
+      });
+      const payload = firestoreMocks.updateDocument.mock.calls[0][2];
+      expect(payload.approved).toBe(false);
+    });
+  });
+
+  describe('setPrimaryImage', () => {
+    it('delegates to the image util', async () => {
+      await RecipeService.setPrimaryImage('recipe-x', 'img-1');
+      expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
+    });
+  });
+
+  describe('delete', () => {
+    it('removes images, media, and the document', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-x',
+        mediaInstructions: [{ path: 'mp/1' }],
+      });
+      await RecipeService.delete('recipe-x');
+      expect(imageUtilMocks.removeAllRecipeImages).toHaveBeenCalledWith('recipe-x');
+      expect(mediaUtilMocks.removeAllMediaInstructions).toHaveBeenCalledWith([{ path: 'mp/1' }]);
+      expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-x');
+    });
+
+    it('is idempotent when the recipe does not exist', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      await RecipeService.delete('missing');
+      expect(imageUtilMocks.removeAllRecipeImages).not.toHaveBeenCalled();
+      expect(firestoreMocks.deleteDocument).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('skips media cleanup when there are no media instructions', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'recipe-y' });
+      await RecipeService.delete('recipe-y');
+      expect(mediaUtilMocks.removeAllMediaInstructions).not.toHaveBeenCalled();
+      expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-y');
+    });
+  });
+});


### PR DESCRIPTION
Phase 1, PR-A of the service-layer refactor umbrella.

## Scope

Adds the two new services as the single public entry points for recipe data + media operations. **No callers are migrated** — both services coexist with existing direct utility/Firestore calls until later PRs swap them. The full suite stays green.

## What lands

### `RecipeService` — `src/js/services/recipe-service.js`

- `get(recipeId)` / `list(queryParams)` / `generateId()`
- `create({ recipeData, imagesToUpload, mediaItemsOrdered, uploadedBy })`
  - Generates ID, uploads images (atomic with rollback on any failure), uploads pending media, writes the doc, races Firestore against a 15s timeout.
- `update(recipeId, { changes, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved })`
  - **PATCH semantics:** only fields the caller passes are touched. Omit `images` and the recipe's existing images are left alone. This guarantees safety for narrow patches (e.g. self-heal calls that only want to update `relatedRecipes`).
- `setPrimaryImage(recipeId, imageId)`
- `delete(recipeId)` — removes images + media from Storage, then the document.

### `RecipeImageProposalService` — `src/js/services/recipe-image-proposal-service.js`

Distinct from owner CRUD: end-users propose images, managers approve/reject.

- `propose / approve / reject / listPending`

## Tests

- `tests/js/services/recipe-service.test.mjs` — 21 cases.
- `tests/js/services/recipe-image-proposal-service.test.mjs` — 4 cases.

Notable coverage:
- Atomic image upload uses \`Promise.allSettled\` and rolls back resolved uploads when a sibling rejects (regression test for a \`Promise.all\` bug that was caught during development).
- \`update\` PATCH guarantee: omitted images/media/approved must not appear in the Firestore payload.
- \`delete\` is idempotent when the recipe is missing.

Full suite: **443/443 passing**. Lint + build clean.

## Acceptance

- All existing callers continue working unchanged (they still use the old code paths).
- Smoke test of recipe flows in dev server confirms no behavior change.

## Umbrella context

Part of \`refactor/service-layer\` (master umbrella). Subsequent sub-PRs (PR-B through PR-H) migrate each caller surface to these services. The umbrella merges to \`development\` only once every domain (recipes, users, favorites, active-meals, failed-url-extractions) is on the new convention and an ESLint rule enforces it.