### PR TITLE
refactor(services): route recipe form submit through RecipeService (PR-B)

### DIFF
--- a/src/lib/media/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/media/media-instructions-editor/media-instructions-editor.js
@@ -14,14 +14,9 @@
  *   media-data='[]'
  *   recipe-id="recipe-123">
  * </media-instructions-editor>
- *
- * // To upload pending files, call:
- * const editor = document.querySelector('media-instructions-editor');
- * const uploadedMedia = await editor.uploadPendingFiles(recipeId, userId);
  */
 
 import {
-  uploadMediaInstructionFile,
   deleteMediaInstructionFile,
   validateMediaFile,
   getMediaInstructionUrl,
@@ -657,64 +652,6 @@ class MediaInstructionsEditor extends HTMLElement {
     this.renderErrors();
   }
 
-  // --- Pending Files Management ---
-
-  /**
-   * Upload all pending files to Firebase Storage
-   * @param {string} recipeId - The recipe ID for storage paths
-   * @param {string} userId - The user ID performing the upload
-   * @returns {Promise<Array>} Array of uploaded media metadata objects
-   */
-  async uploadPendingFiles(recipeId, userId) {
-    // Get pending items from unified array
-    const pendingItems = this.mediaItems.filter((item) => item.file);
-
-    if (!recipeId || !userId || pendingItems.length === 0) {
-      return [];
-    }
-
-    this.setUploading(true);
-
-    const uploadedMedia = [];
-
-    // Upload each pending item and preserve its position in unified array
-    for (const pending of pendingItems) {
-      try {
-        // Capture the item's position BEFORE uploading
-        const originalIndex = this.mediaItems.indexOf(pending);
-
-        const metadata = await uploadMediaInstructionFile(pending.file, recipeId, userId);
-        metadata.caption = pending.caption || '';
-        // Set order based on position in unified array (not just existing count)
-        metadata.order = originalIndex;
-        uploadedMedia.push(metadata);
-
-        // Replace pending item with uploaded metadata at the same position
-        this.mediaItems[originalIndex] = metadata;
-
-        // Clean up blob URL
-        if (pending.preview) {
-          URL.revokeObjectURL(pending.preview);
-        }
-      } catch (error) {
-        console.error('Error uploading pending file:', error);
-        this.errors.push(`${pending.file.name}: ${error.message}`);
-      }
-    }
-
-    // Update order for all items based on current positions in unified array
-    this.mediaItems.forEach((item, index) => {
-      item.order = index;
-    });
-
-    this.setUploading(false);
-    this.emitChange();
-    this.renderMediaList();
-    this.renderErrors();
-
-    return uploadedMedia;
-  }
-
   // --- Communication with Parent ---
 
   emitChange() {
@@ -757,6 +694,44 @@ class MediaInstructionsEditor extends HTMLElement {
       ...item,
       position: index, // Track position for order preservation during upload
     }));
+  }
+
+  /**
+   * Sync editor state with the result of an external upload (RecipeService).
+   * Replaces pending entries at the recorded position with their uploaded
+   * metadata so a subsequent save won't re-upload them. Failed positions
+   * remain pending and their errors are surfaced to the user.
+   *
+   * @param {{ uploaded: Array<{position:number, metadata:Object}>, failed: Array<{position:number, error:string, originalItem?:Object}> }} uploadResults
+   */
+  applyUploadResults(uploadResults) {
+    if (!uploadResults) return;
+    const { uploaded = [], failed = [] } = uploadResults;
+
+    for (const { position, metadata } of uploaded) {
+      const item = this.mediaItems[position];
+      if (!item) continue;
+      if (item.preview && item.file) {
+        URL.revokeObjectURL(item.preview);
+      }
+      this.mediaItems[position] = {
+        ...metadata,
+        caption: item.caption ?? metadata.caption ?? '',
+      };
+    }
+
+    this.mediaItems.forEach((item, index) => {
+      item.order = index;
+    });
+
+    for (const { originalItem, error } of failed) {
+      const name = originalItem?.file?.name || 'media';
+      this.errors.push(`${name}: ${error}`);
+    }
+
+    this.emitChange();
+    this.renderMediaList();
+    this.renderErrors();
   }
 
   /**

--- a/src/lib/recipes/recipe_form_component/edit_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/edit_recipe_component.js
@@ -1,13 +1,6 @@
 // edit-recipe-component.js
-import { FirestoreService } from '../../../js/services/firestore-service.js';
-import { StorageService } from '../../../js/services/storage-service.js';
+import { RecipeService } from '../../../js/services/recipe-service.js';
 import authService from '../../../js/services/auth-service.js';
-import {
-  getImageStoragePath,
-  uploadAndBuildImageMetadata,
-  migrateImageToCategory,
-  deleteImageFiles,
-} from '../../../js/utils/recipes/recipe-image-utils.js';
 
 import '../../modals/message-modal/message-modal.js';
 import '../../utilities/loading-spinner/loading-spinner.js';
@@ -51,127 +44,45 @@ class EditRecipeComponent extends HTMLElement {
     const spinner = this.shadowRoot.querySelector('loading-spinner');
     try {
       spinner.setAttribute('active', '');
-      const originalRecipe = await FirestoreService.getDocument('recipes', this.recipeId);
-      const categoryChanged = originalRecipe.category !== recipeData.category;
+      const user = authService.getCurrentUser();
+      const uploadedBy = user?.uid || 'anonymous';
 
-      if (Array.isArray(recipeData.toDelete)) {
-        for (const img of recipeData.toDelete) {
-          if (img.full) await deleteImageFiles(img).catch(() => {});
-        }
-      }
+      const {
+        images: formImages = [],
+        toDelete: imagesToDelete = [],
+        mediaInstructions: _m,
+        ...changes
+      } = recipeData;
 
-      const newImages = [];
-      for (const img of recipeData.images) {
-        if (img.source === 'new' && img.file) {
-          const meta = await uploadAndBuildImageMetadata({
-            recipeId: this.recipeId,
-            category: recipeData.category,
-            file: img.file,
-            isPrimary: img.isPrimary,
-            uploadedBy: img.uploadedBy,
-          });
-          newImages.push(meta);
-        } else if (img.source === 'existing') {
-          // Spread all persistent fields (e.g. aiEnhanced) and drop transient
-          // form-internal ones. Filter undefined values since Firestore is not
-          // configured with ignoreUndefinedProperties.
-          const { source: _s, file: _f, preview: _p, ...rest } = img;
-          let existingImage = Object.fromEntries(
-            Object.entries(rest).filter(([, v]) => v !== undefined),
-          );
+      const mediaItemsOrdered = this.formComponent?.getAllMediaInOrder?.() || [];
 
-          if (categoryChanged) {
-            try {
-              existingImage = await migrateImageToCategory(
-                existingImage,
-                this.recipeId,
-                originalRecipe.category,
-                recipeData.category,
-              );
-            } catch (error) {
-              console.error(`Failed to migrate image ${img.id}:`, error);
-              this.showWarningMessage(
-                `אזהרה: לא ניתן להעביר תמונה ${img.id} לתיקיית קטגוריה חדשה. התמונה תישאר בתיקייה הישנה.`,
-              );
-            }
-          }
-
-          newImages.push(existingImage);
-        }
-      }
-
-      const mediaInstructions = [];
-      const formComponent = this.formComponent;
-
-      const allMediaInOrder = formComponent?.getAllMediaInOrder() || [];
-      let uploadedMediaMap = new Map();
-      let failedCount = 0;
-      let successCount = 0;
-
-      if (formComponent && typeof formComponent.uploadPendingMediaInstructions === 'function') {
-        const user = authService.getCurrentUser();
-        const pendingCount = allMediaInOrder.filter((item) => item.file).length;
-
-        const uploadedMedia = await formComponent.uploadPendingMediaInstructions(
-          this.recipeId,
-          user?.uid || 'anonymous',
-        );
-
-        if (uploadedMedia && Array.isArray(uploadedMedia)) {
-          successCount = uploadedMedia.length;
-          uploadedMedia.forEach((media) => {
-            uploadedMediaMap.set(media.order, media);
-          });
-
-          // Detect partial failure
-          if (pendingCount > 0 && uploadedMedia.length < pendingCount) {
-            failedCount = pendingCount - uploadedMedia.length;
-            console.warn(`${failedCount} of ${pendingCount} media file(s) failed to upload`);
-          }
-        }
-      }
-
-      // Now process all media in unified array order (preserves UI reordering)
-      let finalOrder = 0;
-      for (const item of allMediaInOrder) {
-        if (item.file) {
-          // This is a pending file - use uploaded metadata from map
-          const uploaded = uploadedMediaMap.get(item.position);
-          if (uploaded) {
-            uploaded.order = finalOrder; // Assign sequential order
-            mediaInstructions.push(uploaded);
-            finalOrder++;
-          } else {
-            console.warn(
-              `Media at position ${item.position} failed to upload, will be excluded from save`,
-            );
-          }
-        } else {
-          // Existing media - keep it with updated order
-          const existingMedia = { ...item, order: finalOrder };
-          delete existingMedia.position; // Remove temporary position field
-          mediaInstructions.push(existingMedia);
-          finalOrder++;
-        }
-      }
-
-      const { images, toDelete, mediaInstructions: _, ...rest } = recipeData;
-
-      // Manager edits are trusted and should not require re-approval.
-      // - If saving an already approved recipe, it stays approved.
-      // - If saving a pending recipe, it is auto-approved.
-      await FirestoreService.updateDocument('recipes', this.recipeId, {
-        ...rest,
+      // Manager edits are trusted; auto-approve so pending recipes
+      // become approved after a save.
+      const { mediaUploadResults, migrationWarnings } = await RecipeService.update(this.recipeId, {
+        changes,
+        images: formImages,
+        imagesToDelete,
+        mediaItemsOrdered,
+        uploadedBy,
         approved: true,
-        images: newImages,
-        mediaInstructions: mediaInstructions,
       });
 
-      if (failedCount > 0) {
+      const mediaEditor = this.formComponent?.shadowRoot?.getElementById(
+        'media-instructions-editor',
+      );
+      mediaEditor?.applyUploadResults?.(mediaUploadResults);
+
+      for (const warning of migrationWarnings) {
+        this.showWarningMessage(
+          `אזהרה: לא ניתן להעביר תמונה ${warning.imageId} לתיקיית קטגוריה חדשה. התמונה תישאר בתיקייה הישנה.`,
+        );
+      }
+
+      if (mediaUploadResults.failedCount > 0) {
         this.showWarningMessage(
           `המתכון עודכן בהצלחה!\n\n` +
-            `${successCount} קבצי מדיה הועלו בהצלחה.\n` +
-            `${failedCount} קבצי מדיה נכשלו בהעלאה.\n\n` +
+            `${mediaUploadResults.successCount} קבצי מדיה הועלו בהצלחה.\n` +
+            `${mediaUploadResults.failedCount} קבצי מדיה נכשלו בהעלאה.\n\n` +
             `הקבצים שנכשלו עדיין נראים בעורך. תוכל לנסות להעלות אותם שוב על ידי לחיצה על "עדכן מתכון".`,
         );
       } else {
@@ -180,22 +91,16 @@ class EditRecipeComponent extends HTMLElement {
       spinner.removeAttribute('active');
 
       // Dispatch recipe-updated event for dashboard refresh
-      const event = new CustomEvent('recipe-updated', {
+      const updatedEvent = new CustomEvent('recipe-updated', {
         detail: { recipeId: this.recipeId },
         bubbles: true,
         composed: true,
       });
-      this.dispatchEvent(event);
+      this.dispatchEvent(updatedEvent);
     } catch (error) {
       spinner.removeAttribute('active');
       this.showErrorMessage(`שגיאה בעדכון המתכון: ${error}`);
     }
-  }
-
-  async updateRecipeInFirestore(recipeId, recipeData) {
-    // Remove the imageFile property before saving to Firestore
-    const { imageFile, ...recipeDataWithoutImage } = recipeData;
-    await FirestoreService.updateDocument('recipes', recipeId, recipeDataWithoutImage);
   }
 
   showSuccessMessage(message) {
@@ -221,7 +126,7 @@ class EditRecipeComponent extends HTMLElement {
     editRecipeModal.show(message);
   }
 
-  showErrorMessage(message, error) {
+  showErrorMessage(message) {
     const editRecipeModal = this.shadowRoot.querySelector('message-modal');
     editRecipeModal.show(message);
   }

--- a/src/lib/recipes/recipe_form_component/propose_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/propose_recipe_component.js
@@ -14,11 +14,7 @@
  *
  */
 
-import { FirestoreService } from '../../../js/services/firestore-service.js';
-import {
-  uploadAndBuildImageMetadata,
-  deleteImageFiles,
-} from '../../../js/utils/recipes/recipe-image-utils.js';
+import { RecipeService } from '../../../js/services/recipe-service.js';
 import { Timestamp } from 'firebase/firestore';
 import authService from '../../../js/services/auth-service.js';
 import { logError, getErrorMessage } from '../../../js/utils/error-handler.js';
@@ -46,7 +42,7 @@ class ProposeRecipeComponent extends HTMLElement {
   render() {
     this.shadowRoot.innerHTML = `
       <style>
-        
+
       </style>
       <loading-spinner overlay>
         <div class="propose-recipe-container">
@@ -59,99 +55,43 @@ class ProposeRecipeComponent extends HTMLElement {
   async handleRecipeData(event) {
     const recipeData = event.detail.recipeData;
     const spinner = this.shadowRoot.querySelector('loading-spinner');
-    let uploadedFilesToCleanup = [];
     try {
       spinner.setAttribute('active', '');
       const user = authService.getCurrentUser();
-      const imagesToUpload = recipeData.images || [];
-      const recipeDataForFirestore = { ...recipeData };
-      delete recipeDataForFirestore.images;
-      delete recipeDataForFirestore.mediaInstructions;
-      delete recipeDataForFirestore.toDelete;
-      recipeDataForFirestore.creationTime = Timestamp.now();
-      recipeDataForFirestore.userId = user?.uid || 'anonymous';
-      recipeDataForFirestore.approved = false;
-
-      Object.keys(recipeDataForFirestore).forEach((key) => {
-        const value = recipeDataForFirestore[key];
-        if (value === undefined) {
-          delete recipeDataForFirestore[key];
-        } else if (Array.isArray(value)) {
-          recipeDataForFirestore[key] = value.filter((item) => item !== undefined);
-        }
-      });
-
-      // Generate ID before uploading so we can use it for storage paths
-      const recipeId = FirestoreService.generateId('recipes');
-
-      // Upload images if provided
-      if (imagesToUpload.length > 0) {
-        const imageUploadResults = await this.uploadRecipeImages(
-          recipeId,
-          imagesToUpload,
-          recipeDataForFirestore.category,
-          user?.uid || 'anonymous',
-        );
-        recipeDataForFirestore.images = imageUploadResults;
-        recipeDataForFirestore.allowImageSuggestions = true;
-        uploadedFilesToCleanup.push(...imageUploadResults);
-      }
-
-      // Upload pending media instructions if any
+      const uploadedBy = user?.uid || 'anonymous';
       const formComponent = this.shadowRoot.querySelector('recipe-form-component');
-      let hasPartialFailure = false;
-      let successCount = 0;
-      let failedCount = 0;
 
-      if (formComponent && typeof formComponent.uploadPendingMediaInstructions === 'function') {
-        const allMedia = formComponent.getAllMediaInOrder();
-        const pendingCount = allMedia.filter((item) => item.file).length;
+      const {
+        images: formImages,
+        mediaInstructions: _m,
+        toDelete: _td,
+        ...baseFields
+      } = recipeData;
+      const imagesToUpload = (formImages || []).map(({ file, isPrimary }) => ({ file, isPrimary }));
 
-        if (pendingCount > 0) {
-          const uploadedMedia = await formComponent.uploadPendingMediaInstructions(
-            recipeId,
-            user?.uid || 'anonymous',
-          );
+      const recipeDataForFirestore = {
+        ...baseFields,
+        creationTime: Timestamp.now(),
+        userId: uploadedBy,
+        approved: false,
+      };
 
-          if (uploadedMedia && uploadedMedia.length > 0) {
-            successCount = uploadedMedia.length;
-            recipeDataForFirestore.mediaInstructions = uploadedMedia;
-            uploadedFilesToCleanup.push(...uploadedMedia);
+      const mediaItemsOrdered = formComponent?.getAllMediaInOrder?.() || [];
 
-            // Detect partial failure
-            if (uploadedMedia.length < pendingCount) {
-              hasPartialFailure = true;
-              failedCount = pendingCount - uploadedMedia.length;
-              console.warn(`${failedCount} of ${pendingCount} media file(s) failed to upload`);
-            }
-          } else {
-            // If there were pending files but none uploaded, count as failure
-            hasPartialFailure = true;
-            failedCount = pendingCount;
-            console.warn(`All ${pendingCount} media file(s) failed to upload`);
-          }
-        }
-      }
-
-      // Add recipe to Firestore — race against a timeout because Firestore buffers writes
-      // when offline instead of rejecting, which would leave the spinner frozen forever
-      await Promise.race([
-        FirestoreService.setDocument('recipes', recipeId, recipeDataForFirestore),
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error('אין חיבור לאינטרנט. אנא בדוק את החיבור ונסה שוב.')),
-            15000,
-          ),
-        ),
-      ]);
+      const { mediaUploadResults } = await RecipeService.create({
+        recipeData: recipeDataForFirestore,
+        imagesToUpload,
+        mediaItemsOrdered,
+        uploadedBy,
+      });
 
       this.clearForm();
 
-      if (hasPartialFailure) {
+      if (mediaUploadResults.failedCount > 0) {
         showToast(
           `המתכון נשלח בהצלחה!\n\n` +
-            `${successCount} קבצי מדיה הועלו בהצלחה.\n` +
-            `${failedCount} קבצי מדיה נכשלו.\n\n` +
+            `${mediaUploadResults.successCount} קבצי מדיה הועלו בהצלחה.\n` +
+            `${mediaUploadResults.failedCount} קבצי מדיה נכשלו.\n\n` +
             `ניתן לראות את המתכון בלוח הבקרה ולערוך אותו כדי לנסות שוב.`,
           'warn',
           0,
@@ -164,33 +104,8 @@ class ProposeRecipeComponent extends HTMLElement {
         new CustomEvent('recipe-proposed-success', { bubbles: true, composed: true }),
       );
     } catch (error) {
-      // Cleanup any successfully uploaded files to avoid orphans
-      if (uploadedFilesToCleanup.length > 0) {
-        uploadedFilesToCleanup.forEach((img) => {
-          deleteImageFiles(img).catch((e) => console.warn('Failed to cleanup file on error:', e));
-        });
-      }
       spinner.removeAttribute('active');
       this.showErrorMessage(error);
-    }
-  }
-
-  async uploadRecipeImages(recipeId, images, category, uploader) {
-    try {
-      // Upload all images in parallel for better performance
-      const uploadPromises = images.map(({ file, isPrimary }) =>
-        uploadAndBuildImageMetadata({
-          recipeId,
-          category,
-          file,
-          isPrimary,
-          uploadedBy: uploader,
-        }),
-      );
-      return await Promise.all(uploadPromises);
-    } catch (error) {
-      console.error('Error uploading images:', error);
-      throw error;
     }
   }
 

--- a/src/lib/recipes/recipe_form_component/recipe_form_component.js
+++ b/src/lib/recipes/recipe_form_component/recipe_form_component.js
@@ -1,5 +1,4 @@
-import { getFirestoreInstance } from '../../../js/services/firebase-service.js';
-import { doc, getDoc } from 'firebase/firestore';
+import { RecipeService } from '../../../js/services/recipe-service.js';
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { showErrorModal, logError } from '../../../js/utils/error-handler.js';
 import { validateRecipeForm } from '../../../js/utils/form/form-validation-utils.js';
@@ -391,29 +390,23 @@ class RecipeFormComponent extends HTMLElement {
 
   async setRecipeData(recipeId) {
     try {
-      const db = getFirestoreInstance();
-      const docSnap = await getDoc(doc(db, 'recipes', recipeId));
+      const data = await RecipeService.get(recipeId);
 
-      if (docSnap.exists()) {
-        const data = docSnap.data();
+      if (data) {
         this.recipeData = data;
         await this.populateFromData(data, recipeId);
-
-        // Re-collect from the form so the dirty-state baseline matches
-        // the shape produced by subsequent captures (Firestore-raw and
-        // form-collected shapes diverge — e.g. source:'existing' on
-        // images, instruction string normalization).
-        setTimeout(() => {
-          this.collectFormData();
-          this.enableFormProtection(this.recipeData);
-        }, 500);
       } else {
         console.warn('No such document!');
-        setTimeout(() => {
-          this.collectFormData();
-          this.enableFormProtection(this.recipeData);
-        }, 500);
       }
+
+      // Re-collect from the form so the dirty-state baseline matches
+      // the shape produced by subsequent captures (Firestore-raw and
+      // form-collected shapes diverge — e.g. source:'existing' on
+      // images, instruction string normalization).
+      setTimeout(() => {
+        this.collectFormData();
+        this.enableFormProtection(this.recipeData);
+      }, 500);
     } catch (error) {
       console.error('Error fetching recipe:', error);
       setTimeout(() => {
@@ -665,21 +658,6 @@ class RecipeFormComponent extends HTMLElement {
 
   setDisabled(isDisabled) {
     setFormDisabledState(this.shadowRoot, isDisabled);
-  }
-
-  /**
-   * Public API: Upload pending media instructions
-   * Delegates to the media-instructions-editor component without exposing internal structure
-   * @param {string} recipeId - Recipe ID for storage path
-   * @param {string} userId - User ID for metadata
-   * @returns {Promise<Array>} Array of uploaded media metadata objects
-   */
-  async uploadPendingMediaInstructions(recipeId, userId) {
-    const mediaEditor = this.shadowRoot.getElementById('media-instructions-editor');
-    if (!mediaEditor || typeof mediaEditor.uploadPendingFiles !== 'function') {
-      return [];
-    }
-    return await mediaEditor.uploadPendingFiles(recipeId, userId);
   }
 
   /**


### PR DESCRIPTION
Phase 1, PR-B of the service-layer refactor umbrella. Depends on #197 (already merged into umbrella).

## Scope

Migrate the propose / edit recipe submit handlers from manual Firestore + Storage + image/media orchestration to single \`RecipeService\` calls.

## Changes

- **\`propose_recipe_component\`** → \`RecipeService.create\`. Submit handler shrinks from ~80 to ~50 lines. Drops the inline image upload loop, media upload orchestration, partial-failure bookkeeping, Firestore-write timeout race, and cleanup-on-error.
- **\`edit_recipe_component\`** → \`RecipeService.update\` (explicit \`approved: true\`). Handler shrinks from ~130 to ~55 lines. Drops the inline existing-image migration, image rollback on failure, and media partial-failure assembly. Calls \`mediaEditor.applyUploadResults(...)\` after save so partial-failure retry UX still works (failed media stays pending, successful items get saved metadata).
- **\`recipe_form_component.setRecipeData\`** → \`RecipeService.get\`. Replaces a raw \`getDoc(doc(db, 'recipes', id))\` Firebase SDK call. Removes the now-unused \`uploadPendingMediaInstructions\` delegator method.
- **\`media-instructions-editor\`** — adds \`applyUploadResults(uploadResults)\` so the editor can sync with service-side upload results. Removes \`uploadPendingFiles\` (uploads are now owned by \`RecipeService\`).

## Diff stats

\`4 files changed, 115 insertions(+), 342 deletions(-)\` — net 227 lines removed.

## Verification

Manual smoke (dev server):

- [ ] Propose a new recipe with 2 images + 1 media instruction; appears in pending list with correct images and media.
- [ ] Edit an existing recipe; change category; upload one new image; remove one existing image. Confirm category-changed images migrated (storage path reflects new category) and old image files are gone.
- [ ] Force a media-upload failure (oversize file). Modal stays open; failed file remains pending in the editor for retry; successful items persisted to the doc.

Automated: full suite green (443 passing). Lint + build clean.

## Umbrella context

Part of \`refactor/service-layer\`. Subsequent PRs migrate delete, image proposal/approval, related-recipe search, self-heal, page list queries, and the AI image enhance flow.