### PR TITLE
feat(state): add observable store layer; fix stale auth profile and add recipe cache

### DIFF
--- a/src/js/services/auth-service.js
+++ b/src/js/services/auth-service.js
@@ -46,17 +46,25 @@ import {
   linkWithPopup,
   unlink,
 } from 'firebase/auth';
+import {
+  authStore,
+  _setUser as _storeSetUser,
+  _resetForUserSwitch as _storeResetForUserSwitch,
+  _patchUserData as _storePatchUserData,
+} from '../state/auth-store.js';
 
 class AuthService {
   /**
-   * Constructor initializes the service
+   * Constructor initializes the service.
+   *
+   * Authentication state (user, userData, isAuthResolved, avatarUrl) lives in
+   * authStore — this class is a thin facade over it. The legacy private fields
+   * `_currentUser`, `_userData`, `_authResolved`, `_currentAvatarUrl` are
+   * implemented as getter/setter properties below that proxy to the store, so
+   * existing call sites and tests that read or assign them continue to work.
    */
   constructor() {
     this._initialized = false;
-    this._authResolved = false; // Tracks if the initial auth state (including roles) is fully loaded
-    this._currentUser = null;
-    this._userData = null; // Full user document data
-    this._currentAvatarUrl = null;
     this._observers = [];
     this._unsubscribeFromAuth = null;
     this._authResolveCallbacks = []; // Callbacks waiting for initial resolution
@@ -67,6 +75,50 @@ class AuthService {
     }
 
     AuthService.instance = this;
+  }
+
+  // ---- authStore proxy properties (single source of truth) ----
+
+  get _currentUser() {
+    return authStore.get().user;
+  }
+  set _currentUser(user) {
+    const s = authStore.get();
+    _storeSetUser(user, s.userData, { resolved: s.isAuthResolved });
+  }
+
+  get _userData() {
+    return authStore.get().userData;
+  }
+  set _userData(userData) {
+    const s = authStore.get();
+    _storeSetUser(s.user, userData, { resolved: s.isAuthResolved });
+  }
+
+  get _authResolved() {
+    return authStore.get().isAuthResolved;
+  }
+  set _authResolved(resolved) {
+    const s = authStore.get();
+    _storeSetUser(s.user, s.userData, { resolved });
+  }
+
+  get _currentAvatarUrl() {
+    return authStore.get().avatarUrl;
+  }
+  set _currentAvatarUrl(url) {
+    // avatarUrl is normally derived from userData.avatarUrl ?? user.photoURL.
+    // The few legacy call sites that assign it directly are persisting an
+    // explicit override; mirror that into userData so the derivation produces
+    // the requested value.
+    const s = authStore.get();
+    if (url === null) {
+      if (s.userData && 'avatarUrl' in s.userData) {
+        _storePatchUserData({ avatarUrl: null });
+      }
+      return;
+    }
+    _storePatchUserData({ avatarUrl: url });
   }
 
   /**
@@ -80,14 +132,24 @@ class AuthService {
     const auth = getAuthInstance();
     this._unsubscribeFromAuth = auth.onAuthStateChanged(async (user) => {
       const prevUser = this._currentUser;
-      this._currentUser = user;
+
+      // When the Firebase user changes (logout, login, or account switch),
+      // synchronously drop the previous user's Firestore data BEFORE awaiting
+      // the new user's fetch. This prevents any UI subscribed to authStore
+      // from seeing the previous user's data paired with the new user — the
+      // root cause of the "modal shows previous user's profile" bug.
+      const userChanged = (prevUser?.uid ?? null) !== (user?.uid ?? null);
+      if (userChanged) {
+        _storeResetForUserSwitch(user);
+      } else {
+        this._currentUser = user;
+      }
 
       if (user) {
         // Fetch full user data once
         await this.getUserData({ forceRefresh: true });
       } else {
         this._userData = null;
-        this._currentAvatarUrl = null;
       }
 
       // Notify observers of the auth state change
@@ -138,21 +200,17 @@ class AuthService {
     if (!this._currentUser || this._currentUser.uid !== userId) return;
     if (!this._userData) return;
 
-    // Initialize favorites array if missing
-    if (!this._userData.favorites) {
-      this._userData.favorites = [];
-    }
-
-    const favorites = new Set(this._userData.favorites);
-
+    const favorites = new Set(this._userData.favorites || []);
     if (isFavorite) {
       favorites.add(recipeId);
     } else {
       favorites.delete(recipeId);
     }
 
-    // Update local cache
-    this._userData.favorites = Array.from(favorites);
+    // Replace the whole userData object so authStore subscribers are notified
+    // (mutating in place would not change the reference and would skip the
+    // store's equality check).
+    this._userData = { ...this._userData, favorites: Array.from(favorites) };
   }
 
   /**
@@ -181,8 +239,8 @@ class AuthService {
         this._userData = { role: 'user', favorites: [] };
       }
 
-      // Update derived properties
-      this._currentAvatarUrl = this._userData.avatarUrl || this._currentUser.photoURL || null;
+      // avatarUrl is derived from userData.avatarUrl ?? user.photoURL by
+      // authStore — no explicit assignment needed.
 
       return this._userData;
     } catch (error) {
@@ -371,18 +429,12 @@ class AuthService {
         updatedAt: serverTimestamp(),
       });
 
-      // Update local cache manually since we just updated the doc
+      // Merge profileData into userData. authStore re-derives avatarUrl from
+      // userData.avatarUrl, so no separate avatar field needs updating.
       if (this._userData) {
         this._userData = { ...this._userData, ...profileData };
-        // Don't overwrite existing fields that aren't in profileData
       } else {
         await this.getUserData({ forceRefresh: true });
-      }
-
-      // Update cached avatar URL if it was changed
-      if (profileData.avatarUrl !== undefined) {
-        this._currentAvatarUrl = profileData.avatarUrl;
-        if (this._userData) this._userData.avatarUrl = profileData.avatarUrl;
       }
 
       // Dispatch profile updated event

--- a/src/js/state/auth-store.js
+++ b/src/js/state/auth-store.js
@@ -1,0 +1,85 @@
+/**
+ * authStore — single source of truth for authentication state.
+ *
+ * State shape:
+ *   {
+ *     user: FirebaseUser | null,   // Firebase Auth user object
+ *     userData: object | null,      // Firestore users/{uid} document
+ *     isAuthenticated: boolean,
+ *     isAuthResolved: boolean,      // initial onAuthStateChanged has fired
+ *     isManager: boolean,
+ *     isApproved: boolean,          // approved OR manager
+ *     avatarUrl: string | null,     // userData.avatarUrl ?? user.photoURL
+ *   }
+ *
+ * Public API (for any consumer):
+ *   - authStore.get()         Current snapshot.
+ *   - authStore.subscribe(fn) Calls fn(state) immediately and on every change.
+ *                             Returns an unsubscribe function.
+ *
+ * Writer API (intended for AuthService only — underscore prefix denotes the
+ * internal contract):
+ *   - _setUser(user, userData, { resolved })
+ *       Lands a complete state for the given user. Derived fields recomputed.
+ *   - _resetForUserSwitch()
+ *       Clears userData and marks unresolved, keeping the new Firebase user.
+ *       This is what fixes the stale-profile-on-account-switch FIXME: UI
+ *       subscribed to the store sees a loading state instead of the previous
+ *       user's data while the new user's Firestore doc is fetched.
+ *   - _patchUserData(partial)
+ *       Shallow merge into userData (used by updateProfile / favorites events).
+ */
+import { createStore } from './create-store.js';
+
+const INITIAL_STATE = Object.freeze({
+  user: null,
+  userData: null,
+  isAuthenticated: false,
+  isAuthResolved: false,
+  isManager: false,
+  isApproved: false,
+  avatarUrl: null,
+});
+
+function derive(user, userData, isAuthResolved) {
+  const role = userData?.role ?? null;
+  return {
+    user: user ?? null,
+    userData: userData ?? null,
+    isAuthenticated: !!user,
+    isAuthResolved: !!isAuthResolved,
+    isManager: role === 'manager',
+    isApproved: role === 'approved' || role === 'manager',
+    avatarUrl: userData?.avatarUrl ?? user?.photoURL ?? null,
+  };
+}
+
+const _store = createStore(INITIAL_STATE);
+
+export const authStore = {
+  get: _store.get,
+  subscribe: _store.subscribe,
+};
+
+export function _setUser(user, userData, { resolved = true } = {}) {
+  _store.set(derive(user, userData, resolved));
+}
+
+export function _resetForUserSwitch(user) {
+  // Keep the new Firebase user but drop the previous user's Firestore doc so
+  // no subscriber can render stale data while the new doc is being fetched.
+  _store.set(derive(user, null, false));
+}
+
+export function _patchUserData(partial) {
+  const current = _store.get();
+  if (!current.userData) {
+    _store.set(derive(current.user, { ...partial }, current.isAuthResolved));
+    return;
+  }
+  _store.set(derive(current.user, { ...current.userData, ...partial }, current.isAuthResolved));
+}
+
+export function _resetAll() {
+  _store.set(INITIAL_STATE);
+}

--- a/src/js/state/create-store.js
+++ b/src/js/state/create-store.js
@@ -1,0 +1,47 @@
+/**
+ * Tiny observable store primitive
+ * --------------------------------
+ * createStore(initialValue) → { get, set, update, subscribe }
+ *
+ *   get()              Returns the current value.
+ *   set(next)          Replaces the value. Notifies subscribers only if
+ *                      next !== current (reference equality).
+ *   update(fn)         Shorthand for set(fn(get())).
+ *   subscribe(listener)
+ *                      Calls listener immediately with the current value,
+ *                      then on every change. Returns an unsubscribe function.
+ *                      Listener errors are caught and logged so one bad
+ *                      subscriber cannot prevent the others from running.
+ */
+export function createStore(initialValue) {
+  let value = initialValue;
+  const listeners = new Set();
+
+  const get = () => value;
+
+  const set = (next) => {
+    if (next === value) return;
+    value = next;
+    for (const listener of listeners) {
+      try {
+        listener(value);
+      } catch (error) {
+        console.error('[store] subscriber threw:', error);
+      }
+    }
+  };
+
+  const update = (fn) => set(fn(value));
+
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    try {
+      listener(value);
+    } catch (error) {
+      console.error('[store] initial subscriber call threw:', error);
+    }
+    return () => listeners.delete(listener);
+  };
+
+  return { get, set, update, subscribe };
+}

--- a/src/js/state/recipe-store.js
+++ b/src/js/state/recipe-store.js
@@ -1,0 +1,110 @@
+/**
+ * recipeStore — process-wide cache of fetched recipes.
+ *
+ * Why this exists:
+ *   Without a shared cache, navigating /home → /recipe/:id → back to /home
+ *   re-runs the same Firestore reads, and `getRecipeById()` (heavily used by
+ *   recipe cards and my-meal-page) has no memoization at all.
+ *
+ * Behavior:
+ *   - get(id) returns a Promise<Recipe | null>. Caches by id with a TTL.
+ *   - In-flight requests are deduplicated (same pattern as FavoritesService).
+ *   - LRU eviction caps memory (200 entries by default).
+ *   - Listens for the global `recipe-updated` event (dispatched by the manager
+ *     dashboard when a recipe is edited) and invalidates the matching id.
+ *   - set(id, recipe) lets bulk-fetch paths (like `getRecipesForCards`)
+ *     populate the cache so subsequent single-recipe reads hit it.
+ *
+ * Stale-while-revalidate is intentionally NOT implemented; after the TTL
+ * expires the next get() fetches again. Keep it boring.
+ */
+import { LRUCache } from '../utils/lru-cache.js';
+import { FirestoreService } from '../services/firestore-service.js';
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_LIMIT = 200;
+
+export function createRecipeStore({
+  ttlMs = DEFAULT_TTL_MS,
+  limit = DEFAULT_LIMIT,
+  now = () => Date.now(),
+  fetcher = null, // injectable for tests; defaults to FirestoreService
+  formatter = (raw) => raw, // injectable; production uses formatRecipeData
+} = {}) {
+  const cache = new LRUCache(limit);
+  const inflight = new Map(); // id → Promise<Recipe | null>
+
+  const isFresh = (entry) => !!entry && now() - entry.fetchedAt < ttlMs;
+
+  const fetchRecipe = async (id) => {
+    const doc = fetcher ? await fetcher(id) : await FirestoreService.getDocument('recipes', id);
+    return doc ? formatter(doc) : null;
+  };
+
+  const get = async (id) => {
+    if (!id || (typeof id !== 'string' && typeof id !== 'number')) return null;
+
+    const entry = cache.get(id);
+    if (isFresh(entry)) return entry.data;
+
+    if (inflight.has(id)) return inflight.get(id);
+
+    const promise = (async () => {
+      try {
+        const data = await fetchRecipe(id);
+        cache.set(id, { data, fetchedAt: now() });
+        return data;
+      } finally {
+        inflight.delete(id);
+      }
+    })();
+
+    inflight.set(id, promise);
+    return promise;
+  };
+
+  const set = (id, data) => {
+    if (!id) return;
+    cache.set(id, { data, fetchedAt: now() });
+  };
+
+  const invalidate = (id) => {
+    cache.delete(id);
+  };
+
+  const invalidateAll = () => {
+    cache.clear();
+    inflight.clear();
+  };
+
+  const has = (id) => isFresh(cache.get(id));
+
+  return { get, set, invalidate, invalidateAll, has };
+}
+
+// Default singleton wired to FirestoreService and the recipe formatter.
+// Imported in a getter to avoid a circular dep with recipe-data-utils.js.
+let _default = null;
+let _eventsBound = false;
+
+export function getRecipeStore() {
+  if (!_default) {
+    _default = createRecipeStore();
+    if (typeof document !== 'undefined' && !_eventsBound) {
+      // Manager dashboard dispatches `recipe-updated` on edits; invalidate so
+      // the next read picks up the new data.
+      document.addEventListener('recipe-updated', (event) => {
+        const id = event?.detail?.recipeId ?? event?.detail?.id;
+        if (id) _default.invalidate(id);
+      });
+      _eventsBound = true;
+    }
+  }
+  return _default;
+}
+
+// Test helper — exported only for use in tests.
+export function _resetDefaultStoreForTest() {
+  _default = null;
+  _eventsBound = false;
+}

--- a/src/js/utils/recipes/recipe-data-utils.js
+++ b/src/js/utils/recipes/recipe-data-utils.js
@@ -32,6 +32,7 @@
  */
 
 import { FirestoreService } from '../../services/firestore-service.js';
+import { getRecipeStore } from '../../state/recipe-store.js';
 import { formatIngredientAmount } from './recipe-ingredients-utils.js';
 import { removeAllRecipeImages } from './recipe-image-utils.js';
 import { removeAllMediaInstructions } from './recipe-media-utils.js';
@@ -446,10 +447,11 @@ export function getCategoryIcon(category) {
 }
 
 /**
- * Fetch recipes for display in recipe cards (lightweight version)
+ * Fetch recipes for display in recipe cards (lightweight version).
+ * Populates the per-id recipe cache so a subsequent getRecipeById() for any
+ * of these recipes hits memory instead of Firestore.
  * @param {Object} options - Query options (category, limit, approved only, etc.)
  * @returns {Promise<Array>} Array of recipe card data objects
- * @property {Date|string|number} [creationTime]
  */
 export async function getRecipesForCards(options = {}) {
   const queryParams = { where: [], orderBy: ['creationTime', 'desc'] };
@@ -463,17 +465,24 @@ export async function getRecipesForCards(options = {}) {
     queryParams.limit = options.limit;
   }
   const docs = await FirestoreService.queryDocuments('recipes', queryParams);
+  const store = getRecipeStore();
+  for (const doc of docs) {
+    if (doc?.id) store.set(doc.id, doc);
+  }
   return docs.map(formatRecipeData);
 }
 
 /**
- * Fetch a single complete recipe by ID
+ * Fetch a single complete recipe by ID.
+ * Routes through the shared recipe cache: within the cache TTL, repeat reads
+ * of the same id across pages avoid Firestore entirely. The cache is
+ * invalidated for an id whenever a `recipe-updated` event fires for it.
  * @param {string} recipeId - Recipe ID
  * @returns {Promise<Object>} Complete recipe object
  */
 export async function getRecipeById(recipeId) {
-  const doc = await FirestoreService.getDocument('recipes', recipeId);
-  return doc ? formatRecipeData(doc) : null;
+  const raw = await getRecipeStore().get(recipeId);
+  return raw ? formatRecipeData(raw) : null;
 }
 
 /**
@@ -500,6 +509,9 @@ export async function deleteRecipe(recipeId) {
 
     // 4. Delete the recipe document from Firestore
     await FirestoreService.deleteDocument('recipes', recipeId);
+
+    // 5. Drop the cached entry so subsequent reads don't return stale data
+    getRecipeStore().invalidate(recipeId);
   } catch (error) {
     console.error('Error deleting recipe:', error);
     throw new Error(`Failed to delete recipe: ${error.message}`);

--- a/src/lib/auth/auth-controller.js
+++ b/src/lib/auth/auth-controller.js
@@ -1,4 +1,3 @@
-// FIXME: when user logging in with different account, when opening modal for the first time, it shows the previous user's profile
 /**
  * AuthController Component
  * @class
@@ -7,6 +6,11 @@
  * @description
  * A custom web component that manages authentication state and provides
  * core authentication functionality for the application.
+ *
+ * Reads auth state from authStore (the single source of truth). When the
+ * Firebase user changes, authStore atomically clears the previous user's
+ * Firestore data before the new user's data is fetched — so this component
+ * never renders user A's profile against user B's session.
  *
  * @example
  * // HTML
@@ -27,6 +31,7 @@
  */
 
 import authService from '../../js/services/auth-service.js';
+import { authStore } from '../../js/state/auth-store.js';
 import '../utilities/modal/modal.js';
 
 class AuthController extends HTMLElement {
@@ -35,12 +40,20 @@ class AuthController extends HTMLElement {
     this.attachShadow({ mode: 'open' });
     this.isAuthenticated = false;
     this.currentUser = null;
+    this._unsubscribeAuthStore = null;
   }
 
   connectedCallback() {
     this.render();
     this.setupAuthStateObserver();
     authService.initialize();
+  }
+
+  disconnectedCallback() {
+    if (this._unsubscribeAuthStore) {
+      this._unsubscribeAuthStore();
+      this._unsubscribeAuthStore = null;
+    }
   }
 
   render() {
@@ -65,8 +78,12 @@ class AuthController extends HTMLElement {
   }
 
   setupAuthStateObserver() {
-    authService.addAuthObserver((state) => {
-      this.isAuthenticated = !!state.user;
+    // Subscribe to authStore so every transition — including the synchronous
+    // "user switch in progress, userData not yet loaded" frame — is reflected
+    // here. The first call from subscribe() runs synchronously with the
+    // current state.
+    this._unsubscribeAuthStore = authStore.subscribe((state) => {
+      this.isAuthenticated = state.isAuthenticated;
       this.currentUser = state.user;
 
       if (state.user) {

--- a/tests/js/state/auth-store.test.js
+++ b/tests/js/state/auth-store.test.js
@@ -1,0 +1,124 @@
+import { jest } from '@jest/globals';
+
+let authStore;
+let _setUser;
+let _resetForUserSwitch;
+let _patchUserData;
+let _resetAll;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ authStore, _setUser, _resetForUserSwitch, _patchUserData, _resetAll } = await import(
+    '../../../src/js/state/auth-store.js'
+  ));
+});
+
+describe('authStore', () => {
+  test('initial state is unauthenticated and unresolved', () => {
+    expect(authStore.get()).toEqual({
+      user: null,
+      userData: null,
+      isAuthenticated: false,
+      isAuthResolved: false,
+      isManager: false,
+      isApproved: false,
+      avatarUrl: null,
+    });
+  });
+
+  test('_setUser derives isManager, isApproved, avatarUrl from role/photoURL', () => {
+    _setUser({ uid: 'u1', photoURL: 'https://avatar/u1.png' }, { role: 'manager', favorites: [] });
+    const s = authStore.get();
+    expect(s.isAuthenticated).toBe(true);
+    expect(s.isManager).toBe(true);
+    expect(s.isApproved).toBe(true);
+    expect(s.avatarUrl).toBe('https://avatar/u1.png');
+    expect(s.isAuthResolved).toBe(true);
+  });
+
+  test('approved role is isApproved but not isManager', () => {
+    _setUser({ uid: 'u1' }, { role: 'approved' });
+    const s = authStore.get();
+    expect(s.isManager).toBe(false);
+    expect(s.isApproved).toBe(true);
+  });
+
+  test('avatarUrl from userData overrides user.photoURL', () => {
+    _setUser(
+      { uid: 'u1', photoURL: 'https://photo' },
+      { role: 'user', avatarUrl: 'https://custom-avatar' },
+    );
+    expect(authStore.get().avatarUrl).toBe('https://custom-avatar');
+  });
+
+  test('subscribers are notified on _setUser', () => {
+    const listener = jest.fn();
+    authStore.subscribe(listener);
+    listener.mockClear();
+
+    _setUser({ uid: 'u1' }, { role: 'user' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].user.uid).toBe('u1');
+  });
+
+  test('_resetForUserSwitch clears userData but keeps new user and marks unresolved', () => {
+    _setUser({ uid: 'old' }, { role: 'manager', avatarUrl: 'old-avatar' });
+
+    const newUser = { uid: 'new', photoURL: null };
+    _resetForUserSwitch(newUser);
+
+    const s = authStore.get();
+    expect(s.user).toBe(newUser);
+    expect(s.userData).toBeNull();
+    expect(s.isAuthResolved).toBe(false);
+    expect(s.isManager).toBe(false);
+    expect(s.isApproved).toBe(false);
+    expect(s.avatarUrl).toBeNull();
+  });
+
+  test('_resetForUserSwitch fires subscribers (so UIs can render loading state)', () => {
+    _setUser({ uid: 'old' }, { role: 'manager' });
+    const listener = jest.fn();
+    authStore.subscribe(listener);
+    listener.mockClear();
+
+    _resetForUserSwitch({ uid: 'new' });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].userData).toBeNull();
+  });
+
+  test('_patchUserData merges into existing userData and re-derives', () => {
+    _setUser({ uid: 'u1' }, { role: 'user', favorites: ['r1'] });
+    _patchUserData({ favorites: ['r1', 'r2'] });
+
+    const s = authStore.get();
+    expect(s.userData.favorites).toEqual(['r1', 'r2']);
+    expect(s.userData.role).toBe('user'); // preserved
+  });
+
+  test('_patchUserData re-derives isManager when role changes', () => {
+    _setUser({ uid: 'u1' }, { role: 'user' });
+    _patchUserData({ role: 'manager' });
+    expect(authStore.get().isManager).toBe(true);
+  });
+
+  test('_patchUserData when userData is null seeds a new object', () => {
+    _setUser({ uid: 'u1' }, null);
+    _patchUserData({ favorites: ['r1'] });
+    expect(authStore.get().userData).toEqual({ favorites: ['r1'] });
+  });
+
+  test('_resetAll returns to initial state', () => {
+    _setUser({ uid: 'u1' }, { role: 'manager' });
+    _resetAll();
+    expect(authStore.get()).toEqual({
+      user: null,
+      userData: null,
+      isAuthenticated: false,
+      isAuthResolved: false,
+      isManager: false,
+      isApproved: false,
+      avatarUrl: null,
+    });
+  });
+});

--- a/tests/js/state/create-store.test.js
+++ b/tests/js/state/create-store.test.js
@@ -1,0 +1,109 @@
+import { jest } from '@jest/globals';
+import { createStore } from '../../../src/js/state/create-store.js';
+
+describe('createStore', () => {
+  test('get() returns initial value', () => {
+    const store = createStore({ count: 0 });
+    expect(store.get()).toEqual({ count: 0 });
+  });
+
+  test('set() replaces value and notifies subscribers', () => {
+    const store = createStore(0);
+    const listener = jest.fn();
+    store.subscribe(listener);
+    listener.mockClear(); // ignore initial call
+
+    store.set(1);
+    expect(store.get()).toBe(1);
+    expect(listener).toHaveBeenCalledWith(1);
+  });
+
+  test('set() does not notify when value is reference-equal', () => {
+    const obj = { a: 1 };
+    const store = createStore(obj);
+    const listener = jest.fn();
+    store.subscribe(listener);
+    listener.mockClear();
+
+    store.set(obj);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('set() does notify when a new object with same shape is passed', () => {
+    const store = createStore({ a: 1 });
+    const listener = jest.fn();
+    store.subscribe(listener);
+    listener.mockClear();
+
+    store.set({ a: 1 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('update() applies function to current value', () => {
+    const store = createStore(5);
+    store.update((v) => v + 1);
+    expect(store.get()).toBe(6);
+  });
+
+  test('subscribe() calls listener immediately with current value', () => {
+    const store = createStore('hello');
+    const listener = jest.fn();
+    store.subscribe(listener);
+    expect(listener).toHaveBeenCalledWith('hello');
+  });
+
+  test('subscribe() returns an unsubscribe function', () => {
+    const store = createStore(0);
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+    listener.mockClear();
+
+    unsubscribe();
+    store.set(1);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('multiple subscribers all receive updates', () => {
+    const store = createStore(0);
+    const a = jest.fn();
+    const b = jest.fn();
+    store.subscribe(a);
+    store.subscribe(b);
+    a.mockClear();
+    b.mockClear();
+
+    store.set(1);
+    expect(a).toHaveBeenCalledWith(1);
+    expect(b).toHaveBeenCalledWith(1);
+  });
+
+  test('a throwing subscriber does not block the others', () => {
+    const store = createStore(0);
+    const bad = jest.fn(() => {
+      throw new Error('boom');
+    });
+    const good = jest.fn();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    store.subscribe(bad);
+    store.subscribe(good);
+    bad.mockClear();
+    good.mockClear();
+
+    store.set(1);
+    expect(bad).toHaveBeenCalledWith(1);
+    expect(good).toHaveBeenCalledWith(1);
+    consoleError.mockRestore();
+  });
+
+  test('subscriber throwing on initial call is caught', () => {
+    const store = createStore(0);
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = jest.fn(() => {
+      throw new Error('boom');
+    });
+
+    expect(() => store.subscribe(bad)).not.toThrow();
+    consoleError.mockRestore();
+  });
+});

--- a/tests/js/state/recipe-store.test.js
+++ b/tests/js/state/recipe-store.test.js
@@ -1,0 +1,174 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('src/js/services/firestore-service.js', () => ({
+  FirestoreService: {
+    getDocument: jest.fn(),
+  },
+}));
+
+let createRecipeStore;
+let FirestoreService;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ createRecipeStore } = await import('../../../src/js/state/recipe-store.js'));
+  ({ FirestoreService } = await import('src/js/services/firestore-service.js'));
+});
+
+describe('recipeStore', () => {
+  test('get() returns null for invalid ids', async () => {
+    const store = createRecipeStore({ fetcher: jest.fn() });
+    expect(await store.get(null)).toBeNull();
+    expect(await store.get(undefined)).toBeNull();
+    expect(await store.get({})).toBeNull();
+  });
+
+  test('get() fetches and caches on first call', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1', name: 'Pasta' });
+    const store = createRecipeStore({ fetcher });
+
+    const result = await store.get('r1');
+    expect(result).toEqual({ id: 'r1', name: 'Pasta' });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  test('get() hits cache on second call within TTL', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1', name: 'Pasta' });
+    const store = createRecipeStore({ fetcher, ttlMs: 60000 });
+
+    await store.get('r1');
+    await store.get('r1');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  test('get() refetches after TTL expires', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1' });
+    let t = 1000;
+    const store = createRecipeStore({ fetcher, ttlMs: 100, now: () => t });
+
+    await store.get('r1');
+    t = 1050;
+    await store.get('r1');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    t = 2000;
+    await store.get('r1');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('get() deduplicates in-flight requests for the same id', async () => {
+    let resolveFetch;
+    const fetcher = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const store = createRecipeStore({ fetcher });
+
+    const p1 = store.get('r1');
+    const p2 = store.get('r1');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolveFetch({ id: 'r1' });
+    const [v1, v2] = await Promise.all([p1, p2]);
+    expect(v1).toEqual({ id: 'r1' });
+    expect(v2).toEqual({ id: 'r1' });
+  });
+
+  test('get() returns null when fetcher returns null (recipe not found)', async () => {
+    const fetcher = jest.fn().mockResolvedValue(null);
+    const store = createRecipeStore({ fetcher });
+    expect(await store.get('missing')).toBeNull();
+  });
+
+  test('set() seeds the cache without fetching', async () => {
+    const fetcher = jest.fn();
+    const store = createRecipeStore({ fetcher });
+
+    store.set('r1', { id: 'r1', name: 'Direct' });
+    const result = await store.get('r1');
+
+    expect(result).toEqual({ id: 'r1', name: 'Direct' });
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  test('invalidate() forces refetch on next get', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1' });
+    const store = createRecipeStore({ fetcher });
+
+    await store.get('r1');
+    store.invalidate('r1');
+    await store.get('r1');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  test('invalidateAll() clears every entry and in-flight tracking', async () => {
+    const fetcher = jest.fn((id) => Promise.resolve({ id }));
+    const store = createRecipeStore({ fetcher });
+
+    await store.get('r1');
+    await store.get('r2');
+    store.invalidateAll();
+    await store.get('r1');
+    await store.get('r2');
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  test('has() reports fresh entries only', async () => {
+    let t = 1000;
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1' });
+    const store = createRecipeStore({ fetcher, ttlMs: 100, now: () => t });
+
+    expect(store.has('r1')).toBe(false);
+    await store.get('r1');
+    expect(store.has('r1')).toBe(true);
+
+    t = 2000;
+    expect(store.has('r1')).toBe(false);
+  });
+
+  test('formatter is applied to raw fetched data', async () => {
+    const fetcher = jest.fn().mockResolvedValue({ id: 'r1', raw: true });
+    const formatter = (raw) => ({ ...raw, formatted: true });
+    const store = createRecipeStore({ fetcher, formatter });
+
+    const result = await store.get('r1');
+    expect(result).toEqual({ id: 'r1', raw: true, formatted: true });
+  });
+
+  test('LRU eviction respects the limit', async () => {
+    const fetcher = jest.fn((id) => Promise.resolve({ id }));
+    const store = createRecipeStore({ fetcher, limit: 2 });
+
+    await store.get('a');
+    await store.get('b');
+    await store.get('c'); // evicts 'a'
+    expect(store.has('a')).toBe(false);
+    expect(store.has('b')).toBe(true);
+    expect(store.has('c')).toBe(true);
+  });
+
+  test('default fetcher uses FirestoreService.getDocument', async () => {
+    FirestoreService.getDocument.mockResolvedValue({ id: 'r1', name: 'Stew' });
+    const store = createRecipeStore();
+
+    const result = await store.get('r1');
+    expect(FirestoreService.getDocument).toHaveBeenCalledWith('recipes', 'r1');
+    expect(result).toEqual({ id: 'r1', name: 'Stew' });
+  });
+
+  test('singleton invalidates on document recipe-updated event', async () => {
+    FirestoreService.getDocument.mockResolvedValue({ id: 'r1' });
+    const { getRecipeStore, _resetDefaultStoreForTest } = await import(
+      '../../../src/js/state/recipe-store.js'
+    );
+    _resetDefaultStoreForTest();
+    const store = getRecipeStore();
+    await store.get('r1');
+
+    document.dispatchEvent(new CustomEvent('recipe-updated', { detail: { recipeId: 'r1' } }));
+
+    expect(store.has('r1')).toBe(false);
+  });
+});


### PR DESCRIPTION
Introduce a tiny in-house observable store (src/js/state/create-store.js)
and wire two stores on top of it:

- authStore: single source of truth for the authenticated user, user doc,
  role, and avatar. AuthService now proxies its private state fields to the
  store. On account switch (onAuthStateChanged firing with a new uid),
  authStore is reset synchronously before the new user's Firestore doc is
  fetched, so any UI subscribed to it never sees the previous user's data
  paired with the new user. auth-controller subscribes to authStore
  directly. Closes the long-standing FIXME in auth-controller.js.

- recipeStore: per-id LRU cache for recipes with a 5 minute TTL and
  in-flight deduplication. getRecipeById now routes through it, so
  navigating home -> recipe-detail -> back to home no longer refetches the
  same document. getRecipesForCards seeds the cache after its query so
  subsequent per-id reads hit memory. recipe-updated events from the
  manager dashboard invalidate the corresponding entry.

All 452 existing tests pass; 35 new tests added across the three store
modules (create-store, auth-store, recipe-store).