### PR TITLE
feat(dashboard): add loading state coordination with waitForReady()

### DIFF
--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -226,11 +226,22 @@ export default {
   },
 
   initializeDashboard() {
-    this.loadUserList();
-    this.loadAllRecipes();
-    this.loadPendingRecipes();
-    this.loadPendingImages();
-    this.loadFailedUrls();
+    // Capture the first-load promises so waitForReady() can hold the page
+    // spinner up until the sections have populated. Promise.allSettled keeps a
+    // single failed section from stranding the loading overlay.
+    this._dataReadyPromise = Promise.allSettled([
+      this.loadUserList(),
+      this.loadAllRecipes(),
+      this.loadPendingRecipes(),
+      this.loadPendingImages(),
+      this.loadFailedUrls(),
+    ]);
+  },
+
+  async waitForReady() {
+    if (this._dataReadyPromise) {
+      await this._dataReadyPromise;
+    }
   },
 
   /**


### PR DESCRIPTION
## Summary
Refactored the manager dashboard initialization to properly coordinate the loading overlay with data fetching. The dashboard now captures all initial data load promises and exposes a `waitForReady()` method that the page manager can await before hiding the loading spinner.

## Changes
- **Capture data load promises**: Modified `initializeDashboard()` to store the result of `Promise.allSettled()` on all five data load calls (`loadUserList`, `loadAllRecipes`, `loadPendingRecipes`, `loadPendingImages`, `loadFailedUrls`) in `this._dataReadyPromise`
- **Add `waitForReady()` method**: New async method that awaits `this._dataReadyPromise` if it exists, allowing the page manager to hold the loading overlay until all dashboard sections have populated
- **Resilient error handling**: Used `Promise.allSettled()` instead of `Promise.all()` to prevent a single failed data load from blocking the page ready state

## Implementation Details
This follows the page module contract pattern where `mount()` can initialize async operations and the page manager calls `waitForReady()` (if present) before hiding the loading state. The `allSettled` approach ensures that even if one data section fails to load, the dashboard becomes interactive rather than remaining stuck behind the spinner.

https://claude.ai/code/session_01HCHaE2wEAitBRs1p61UNKT