### PR TITLE
refactor(search): route recipe lookups through RecipeService.list (PR-E)

### DIFF
--- a/src/lib/recipes/recipe_form_component/parts/recipe-related-field.js
+++ b/src/lib/recipes/recipe_form_component/parts/recipe-related-field.js
@@ -1,4 +1,4 @@
-import { FirestoreService } from '../../../../js/services/firestore-service.js';
+import { RecipeService } from '../../../../js/services/recipe-service.js';
 import {
   getRecipeById,
   getLocalizedCategoryName,
@@ -186,7 +186,7 @@ class RecipeRelatedField extends HTMLElement {
     const searchTerms = term.toLowerCase().trim().split(/\s+/);
 
     try {
-      const results = await FirestoreService.queryDocuments('recipes', {
+      const results = await RecipeService.list({
         where: [['approved', '==', true]],
       });
 

--- a/src/lib/search/header-search-bar/header-search-bar.js
+++ b/src/lib/search/header-search-bar/header-search-bar.js
@@ -1,4 +1,4 @@
-import { FirestoreService } from '../../../js/services/firestore-service.js';
+import { RecipeService } from '../../../js/services/recipe-service.js';
 import { FilterUtils } from '../../../js/utils/filter-utils.js';
 import { showToast } from '../../notifications/toast-notification/toast-notification.js';
 import { debounce } from '../../../js/utils/common-utils.js';
@@ -159,8 +159,8 @@ class HeaderSearchBar extends HTMLElement {
     if (!searchText.trim()) return;
 
     try {
-      // Load all approved recipes from Firestore
-      const recipes = await FirestoreService.queryDocuments('recipes', {
+      // Load all approved recipes
+      const recipes = await RecipeService.list({
         where: [['approved', '==', true]],
       });
 


### PR DESCRIPTION
PR-E of the service-layer refactor umbrella (#211).

## Scope

No component outside the service layer issues \`FirestoreService.queryDocuments('recipes', ...)\` for search/dropdown purposes.

## Commits

| Commit | Change |
|---|---|
| \`961bb49\` | \`recipe-related-field.js\` — edit form's related-recipe dropdown → \`RecipeService.list\` |
| \`095fc43\` | \`header-search-bar.js\` — global header search recipe lookup → \`RecipeService.list\` |

## Behavior

Identical — \`RecipeService.list\` is a direct delegate to \`FirestoreService.queryDocuments('recipes', ...)\`. Both call sites pass the same \`{ where: [['approved','==',true]] }\` query and process results the same way.

## Goal grep

After this PR merges:

\`\`\`bash
grep -rn "queryDocuments('recipes'" src/
\`\`\`

Returns only:
- \`src/app/pages/home-page.js\`, \`categories-page.js\`, \`manager-dashboard-page.js\` (×3) — PR-G territory
- \`src/lib/media/ai-image-enhancer/ai-image-enhancer.js\` — PR-H territory
- \`src/lib/search/search-service/search-service.js\` — deferred pending aliveness check (separate from this umbrella)

## Verification

- Manual: edit modal related-recipe search dropdown populates correctly; global header search navigates correctly (single-match → direct nav; multi-match → search results).
- Automated: 486 tests passing; lint clean; build clean.