### PR TITLE
refactor(recipe-component): route relatedRecipes self-heal through RecipeService.update PATCH (PR-F)

### DIFF
--- a/src/lib/recipes/recipe_component/recipe_component.js
+++ b/src/lib/recipes/recipe_component/recipe_component.js
@@ -1,7 +1,7 @@
 import { icons } from '../../../js/icons.js';
 import authService from '../../../js/services/auth-service.js';
 import { AppConfig } from '../../../js/config/app-config.js';
-import { FirestoreService } from '../../../js/services/firestore-service.js';
+import { RecipeService } from '../../../js/services/recipe-service.js';
 import {
   getRecipeById,
   getLocalizedCategoryName,
@@ -1268,11 +1268,13 @@ class RecipeComponent extends HTMLElement {
     const fetched = await Promise.all(ids.map((id) => getRecipeById(id)));
     const valid = fetched.filter((r) => r && r.approved);
 
-    // Self-heal: remove stale IDs from Firestore (fire-and-forget)
+    // Self-heal: prune stale IDs from the recipe doc (fire-and-forget).
+    // RecipeService.update has PATCH semantics — only `changes` are written,
+    // so images / mediaInstructions / approved are left alone.
     const validIds = valid.map((r) => r.id);
     if (validIds.length !== ids.length && this.recipeId) {
-      FirestoreService.updateDocument('recipes', this.recipeId, {
-        relatedRecipes: validIds,
+      RecipeService.update(this.recipeId, {
+        changes: { relatedRecipes: validIds },
       }).catch(() => {});
     }
 


### PR DESCRIPTION
PR-F of the service-layer refactor umbrella (#211).

## Scope

The recipe detail page's relatedRecipes self-heal (\`recipe_component.js\` line ~1274) was writing the pruned list back via direct \`FirestoreService.updateDocument('recipes', id, { relatedRecipes })\`. Routes through \`RecipeService.update\` with PATCH semantics, so **only \`relatedRecipes\` is touched** — \`images\`, \`mediaInstructions\`, \`approved\` etc. are guaranteed untouched.

This is the exact regression PATCH semantics were designed to prevent.

## Diff

1 file, +6 −4. \`FirestoreService\` import dropped (was its only caller in this file).

## Verification

Manual:
- Recipe with a stale \`relatedRecipes\` ID loads → section renders without the stale entry → Firestore doc's \`relatedRecipes\` is pruned → **images / mediaInstructions / approved unchanged** (this is the critical PATCH guarantee).
- Recipe with all-valid \`relatedRecipes\` triggers no write.

Automated: 486 tests, lint, build all green.

## Goal grep after merge

\`\`\`bash
grep -rn "updateDocument('recipes'" src/
\`\`\`

Returns only:
- \`recipe_preview_modal.js:268\` — the narrow \`{approved: true}\` toggle (acknowledged borderline-OK in the plan).
- \`ai-image-enhance-modal.js:445\` — PR-H territory.

## Design note (not in scope)

The self-heal pattern itself (write-on-render) is a pragmatic choice for the only cross-doc reference field on recipes. Whether to replace it with cascade-on-delete is a separate design question worth its own issue, independent of this umbrella.