### PR TITLE
refactor(pages): route recipe list queries through RecipeService.list (PR-G)

### DIFF
--- a/src/app/pages/categories-page.js
+++ b/src/app/pages/categories-page.js
@@ -1,5 +1,5 @@
 import authService from '../../js/services/auth-service.js';
-import { FirestoreService } from '../../js/services/firestore-service.js';
+import { RecipeService } from '../../js/services/recipe-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import { FilterUtils } from '../../js/utils/filter-utils.js';
 import { getLocalizedCategoryName } from '../../js/utils/recipes/recipe-data-utils.js';
@@ -214,7 +214,7 @@ export default {
         queryParams.where.push(['category', '==', this.currentCategory]);
       }
 
-      this.allRecipes = await FirestoreService.queryDocuments('recipes', queryParams);
+      this.allRecipes = await RecipeService.list(queryParams);
 
       let filteredRecipes = [...this.allRecipes];
 

--- a/src/app/pages/home-page.js
+++ b/src/app/pages/home-page.js
@@ -1,4 +1,4 @@
-import { FirestoreService } from '../../js/services/firestore-service.js';
+import { RecipeService } from '../../js/services/recipe-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import '../../styles/pages/home-spa.css';
 
@@ -53,7 +53,7 @@ export default {
         orderBy: ['creationTime', 'desc'],
         limit: 4,
       };
-      const recipes = await FirestoreService.queryDocuments('recipes', queryParams);
+      const recipes = await RecipeService.list(queryParams);
 
       if (!recipes.length) return;
 

--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -321,7 +321,7 @@ export default {
     const filterSelect = document.getElementById('recipe-filter');
 
     try {
-      const recipes = await FirestoreService.queryDocuments('recipes', {
+      const recipes = await RecipeService.list({
         where: [['approved', '==', true]],
       });
       this.allRecipes = recipes;
@@ -484,7 +484,7 @@ export default {
     const noPendingMessage = pendingRecipeSection.querySelector('.no-pending-message');
 
     try {
-      const pendingRecipes = await FirestoreService.queryDocuments('recipes', {
+      const pendingRecipes = await RecipeService.list({
         where: [['approved', '==', false]],
       });
       const recipeItems = pendingRecipes.map((recipe) => ({
@@ -595,7 +595,7 @@ export default {
       //    where: [['pendingImages', '!=', []], ['approved', '==', true]]
       // See: https://firebase.google.com/docs/firestore/query-data/indexing
 
-      const allPendingRecipes = await FirestoreService.queryDocuments('recipes', {
+      const allPendingRecipes = await RecipeService.list({
         where: [['pendingImages', '!=', []]],
       });
 

--- a/src/app/pages/recipe-detail-page.js
+++ b/src/app/pages/recipe-detail-page.js
@@ -1,7 +1,6 @@
 import { AppConfig } from '../../js/config/app-config.js';
 import authService from '../../js/services/auth-service.js';
 import { firestoreService } from '../../js/services/firestore-service.js';
-import { arrayUnion, serverTimestamp } from 'firebase/firestore';
 import '../../styles/pages/recipe-detail-spa.css';
 
 export default {


### PR DESCRIPTION
PR-G of the service-layer refactor umbrella (#211).

## Scope

All five page-level \`FirestoreService.queryDocuments('recipes', ...)\` call sites + one dead import cleanup. Mechanical swap, no behavior change.

## Changes

| File | Change |
|---|---|
| \`home-page.js\` | home feed → \`RecipeService.list\`; FirestoreService import dropped |
| \`categories-page.js\` | categories grid → \`RecipeService.list\`; FirestoreService import dropped |
| \`manager-dashboard-page.js\` | 3 sites (all-recipes / pending-recipes / pending-images-recipes) → \`RecipeService.list\`. FirestoreService stays — still used for \`users\` and \`failed_url_extractions\` (Phase 2 / Phase 5) |
| \`recipe-detail-page.js\` | Remove unused \`import { arrayUnion, serverTimestamp } from 'firebase/firestore'\` |

## Goal grep

After this merges:

\`\`\`bash
grep -rn "queryDocuments('recipes'" src/
\`\`\`

Returns only:
- \`ai-image-enhancer.js:69\` — PR-H territory
- \`search-service.js:153\` — deferred aliveness check
- \`recipe-data-utils.js:396\` — utils-layer read wrapper, deferred utils-split

No page-level callers remain.

## Verification

Manual smoke:
- \`/home\` feed populates correctly.
- \`/categories\` grid populates; filter / search / favorites work.
- Manager dashboard: all-recipes, pending-recipes, pending-images sections all populate.
- Recipe detail page loads normally (dead import gone, no functional change).

Automated: 486 tests, lint, build all green.