### PR TITLE
refactor(recipes): RecipeImageService + migrate AI image enhance flow (PR-H)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -1,0 +1,37 @@
+// src/js/services/recipes/recipe-image-service.js
+
+import { setPrimaryImage as setPrimaryImageInternal } from '../../utils/recipes/recipe-image-utils.js';
+
+/**
+ * RecipeImageService — Image Lifecycle for Recipes
+ *
+ * Owns operations on the image files and image-entry metadata for a
+ * recipe. Separated from RecipeService (which owns recipe doc CRUD) so
+ * each service has a single responsibility: RecipeService manages the
+ * recipe document; RecipeImageService manages what lives at the
+ * Storage layer for a recipe's images plus the per-image entries
+ * inside `recipes/{id}.images[]`.
+ *
+ * Public API:
+ *   - setPrimaryImage(recipeId, imageId)
+ *
+ * Image proposal/moderation lives in RecipeImageProposalService.
+ */
+export class RecipeImageService {
+  /**
+   * Mark a single image on a recipe as the primary one. Clears `isPrimary`
+   * on the rest. Throws if the recipe has no images.
+   *
+   * Previously lived on RecipeService; moved here as part of the
+   * service-layer refactor (umbrella issue #211).
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @returns {Promise<void>}
+   */
+  static async setPrimaryImage(recipeId, imageId) {
+    return await setPrimaryImageInternal(recipeId, imageId);
+  }
+}
+
+export const recipeImageService = RecipeImageService;

--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -1,6 +1,23 @@
 // src/js/services/recipes/recipe-image-service.js
 
+import { FirestoreService } from '../_firebase/firestore-service.js';
+import { StorageService } from '../_firebase/storage-service.js';
 import { setPrimaryImage as setPrimaryImageInternal } from '../../utils/recipes/recipe-image-utils.js';
+
+const RECIPES_COLLECTION = 'recipes';
+
+function makeBackupPath(fullPath) {
+  return fullPath.replace(/(\.[^.]+)$/, '_original$1');
+}
+
+async function fileExists(path) {
+  try {
+    await StorageService.getMetadata(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * RecipeImageService — Image Lifecycle for Recipes
@@ -14,6 +31,7 @@ import { setPrimaryImage as setPrimaryImageInternal } from '../../utils/recipes/
  *
  * Public API:
  *   - setPrimaryImage(recipeId, imageId)
+ *   - replaceImage(recipeId, imageId, blob, options)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
  */
@@ -22,15 +40,115 @@ export class RecipeImageService {
    * Mark a single image on a recipe as the primary one. Clears `isPrimary`
    * on the rest. Throws if the recipe has no images.
    *
-   * Previously lived on RecipeService; moved here as part of the
-   * service-layer refactor (umbrella issue #211).
-   *
    * @param {string} recipeId
    * @param {string} imageId
    * @returns {Promise<void>}
    */
   static async setPrimaryImage(recipeId, imageId) {
     return await setPrimaryImageInternal(recipeId, imageId);
+  }
+
+  /**
+   * Replace an existing image's storage file with new bytes. Optionally
+   * preserves the current image as a backup at `<path>_original.<ext>`
+   * (idempotent — only written if the backup doesn't already exist).
+   * Optionally patches the matching image entry inside
+   * `recipes/{id}.images[]` with caller-supplied fields.
+   *
+   * Steps:
+   *   1. Look up the image entry on the recipe doc. Throws if recipe
+   *      or image not found.
+   *   2. If keepOriginalBackup (default true) and no backup exists:
+   *      fetch the current image bytes and write them at the backup path.
+   *   3. Upload `blob` to the original path (overwrites). The Storage
+   *      Resize extension regenerates WebP variants asynchronously.
+   *   4. Best-effort: delete the stale _400x400.webp / _1080x1080.webp
+   *      variants at the original path so consumers refresh promptly.
+   *   5. If `fieldUpdates` is provided: best-effort merge it into the
+   *      matching image entry. A failure here logs but does NOT throw —
+   *      the image bytes already changed; the flag is cosmetic.
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @param {Blob} blob - New image bytes (must be uploadable; e.g. from a fetch or canvas).
+   * @param {Object} [options]
+   * @param {boolean} [options.keepOriginalBackup=true]
+   * @param {Object} [options.fieldUpdates] - Patch merged into the matching image entry.
+   * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
+   */
+  static async replaceImage(recipeId, imageId, blob, options = {}) {
+    if (!recipeId) throw new Error('RecipeImageService.replaceImage: recipeId is required');
+    if (!imageId) throw new Error('RecipeImageService.replaceImage: imageId is required');
+    if (!blob) throw new Error('RecipeImageService.replaceImage: blob is required');
+
+    const { keepOriginalBackup = true, fieldUpdates } = options;
+
+    // 1. Look up the image entry.
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe) {
+      throw new Error(`RecipeImageService.replaceImage: recipe ${recipeId} not found`);
+    }
+    const images = Array.isArray(recipe.images) ? recipe.images : [];
+    const image = images.find((img) => img.id === imageId);
+    if (!image) {
+      throw new Error(
+        `RecipeImageService.replaceImage: image ${imageId} not found on recipe ${recipeId}`,
+      );
+    }
+
+    const originalPath = image.full;
+    const backupPath = makeBackupPath(originalPath);
+
+    // 2. Backup (idempotent).
+    let backupCreated = false;
+    if (keepOriginalBackup) {
+      if (!(await fileExists(backupPath))) {
+        const url = await StorageService.getFileUrl(originalPath);
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(
+            `RecipeImageService.replaceImage: failed to fetch original (${response.status})`,
+          );
+        }
+        await StorageService.uploadFile(await response.blob(), backupPath);
+        backupCreated = true;
+      }
+    }
+
+    // 3. Overwrite the original.
+    await StorageService.uploadFile(blob, originalPath);
+
+    // 4. Best-effort stale WebP variant cleanup so consumers refresh promptly.
+    await Promise.all([
+      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp')).catch(() => {}),
+      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp')).catch(
+        () => {},
+      ),
+    ]);
+
+    // 5. Best-effort image-entry patch.
+    if (fieldUpdates && Object.keys(fieldUpdates).length > 0) {
+      try {
+        const fresh = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+        if (fresh && Array.isArray(fresh.images)) {
+          const updatedImages = fresh.images.map((img) =>
+            img.id === imageId ? { ...img, ...fieldUpdates } : img,
+          );
+          await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, {
+            images: updatedImages,
+          });
+        }
+      } catch (err) {
+        // The image bytes have already changed; failing the whole op
+        // because a metadata patch didn't land would be misleading.
+        console.error(
+          `RecipeImageService.replaceImage: fieldUpdates patch failed for image ${imageId}:`,
+          err,
+        );
+      }
+    }
+
+    return { backupPath, backupCreated };
   }
 }
 

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -6,7 +6,6 @@ import {
   deleteImageFiles,
   migrateImageToCategory,
   removeAllRecipeImages,
-  setPrimaryImage as setPrimaryImageInternal,
 } from '../../utils/recipes/recipe-image-utils.js';
 import {
   uploadMediaInstructionFile,
@@ -358,17 +357,6 @@ export class RecipeService {
     await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, docPayload);
 
     return { mediaUploadResults, migrationWarnings };
-  }
-
-  /**
-   * Mark a single image on a recipe as the primary one. Clears `isPrimary`
-   * on the rest. Throws if the recipe has no images.
-   * @param {string} recipeId
-   * @param {string} imageId
-   * @returns {Promise<void>}
-   */
-  static async setPrimaryImage(recipeId, imageId) {
-    return await setPrimaryImageInternal(recipeId, imageId);
   }
 
   /**

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -11,7 +11,7 @@
  */
 
 import { enhanceFoodImage } from '../../../js/services/recipes/ai-enhancement-service.js';
-import { FirestoreService } from '../../../js/services/_firebase/firestore-service.js';
+import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
 import { StorageService } from '../../../js/services/_firebase/storage-service.js';
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { icons } from '../../../js/icons.js';
@@ -400,53 +400,12 @@ class AiImageEnhanceModal extends HTMLElement {
     this._setStatus('שומר את התמונה החדשה...');
 
     try {
-      const originalPath = this._image.full;
-      const backupPath = this._makeBackupPath(originalPath);
-
-      // Back up the original once (idempotent).
-      let backupExists = false;
-      try {
-        await StorageService.getMetadata(backupPath);
-        backupExists = true;
-      } catch {
-        backupExists = false;
-      }
-
-      if (!backupExists) {
-        const originalUrl = await StorageService.getFileUrl(originalPath);
-        const origResponse = await fetch(originalUrl);
-        if (!origResponse.ok) throw new Error(`Failed to fetch original (${origResponse.status})`);
-        await StorageService.uploadFile(await origResponse.blob(), backupPath);
-      }
-
-      // Overwrite original; Storage trigger regenerates WebP variants.
-      await StorageService.uploadFile(this._enhancedResult.blob, originalPath);
-
-      // Best-effort stale WebP cleanup so the carousel refreshes promptly.
-      await Promise.all([
-        StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp')).catch(
-          () => {},
-        ),
-        StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp')).catch(
-          () => {},
-        ),
-      ]);
-
-      // Mark this image as AI-enhanced in Firestore. Best-effort: the user-
-      // visible enhancement already succeeded above, so a write failure here
-      // shouldn't surface as a save error — it just means the badge signal
-      // is missing on this image until a future backfill.
-      try {
-        const fresh = await FirestoreService.getDocument('recipes', this._recipe.id);
-        if (fresh && Array.isArray(fresh.images)) {
-          const images = fresh.images.map((img) =>
-            img.id === this._image.id ? { ...img, aiEnhanced: true } : img,
-          );
-          await FirestoreService.updateDocument('recipes', this._recipe.id, { images });
-        }
-      } catch (err) {
-        console.error('Failed to mark image as AI-enhanced:', err);
-      }
+      const { backupPath, backupCreated } = await RecipeImageService.replaceImage(
+        this._recipe.id,
+        this._image.id,
+        this._enhancedResult.blob,
+        { fieldUpdates: { aiEnhanced: true } },
+      );
 
       this._setStatus('התמונה הוחלפה. התמונה המקורית נשמרה כגיבוי.');
 
@@ -458,7 +417,7 @@ class AiImageEnhanceModal extends HTMLElement {
             recipeId: this._recipe.id,
             imageId: this._image.id,
             backupPath,
-            backupCreated: !backupExists,
+            backupCreated,
           },
         }),
       );
@@ -488,10 +447,6 @@ class AiImageEnhanceModal extends HTMLElement {
     if (code === 'functions/unauthenticated') return 'יש להתחבר כדי להשתמש בתכונה זו.';
     if (code === 'functions/permission-denied') return 'אין הרשאה — תכונה זו זמינה למנהלים בלבד.';
     return error?.message ? `שגיאה: ${error.message}` : 'שגיאה בשיפור התמונה';
-  }
-
-  _makeBackupPath(fullPath) {
-    return fullPath.replace(/(\.[^.]+)$/, '_original$1');
   }
 
   // ---------------------------------------------------------------------------

--- a/src/lib/media/ai-image-enhancer/ai-image-enhancer.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhancer.js
@@ -11,7 +11,7 @@
  * recipe's image list without a full reload.
  */
 
-import { FirestoreService } from '../../../js/services/_firebase/firestore-service.js';
+import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 
 class AiImageEnhancer extends HTMLElement {
@@ -66,7 +66,7 @@ class AiImageEnhancer extends HTMLElement {
 
   async _loadRecipes() {
     try {
-      const all = await FirestoreService.queryDocuments('recipes', {
+      const all = await RecipeService.list({
         where: [['approved', '==', true]],
       });
       this._recipes = all
@@ -91,7 +91,7 @@ class AiImageEnhancer extends HTMLElement {
 
   async _refreshRecipe(recipeId) {
     try {
-      const fresh = await FirestoreService.getDocument('recipes', recipeId);
+      const fresh = await RecipeService.get(recipeId);
       if (!fresh) return;
       const idx = this._recipes.findIndex((r) => r.id === recipeId);
       if (idx !== -1) this._recipes[idx] = fresh;

--- a/src/lib/modals/image-approval-multi/image-approval-multi.js
+++ b/src/lib/modals/image-approval-multi/image-approval-multi.js
@@ -36,7 +36,7 @@
  */
 
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
-import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
+import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
 import { RecipeImageProposalService } from '../../../js/services/recipes/recipe-image-proposal-service.js';
 
 class ImageApprovalMulti extends HTMLElement {
@@ -476,14 +476,14 @@ class ImageApprovalMulti extends HTMLElement {
       if (this.primaryImageId) {
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = Array.from(this.selectedImageIds)[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {
@@ -570,14 +570,14 @@ class ImageApprovalMulti extends HTMLElement {
         // Admin explicitly selected a primary - honor their choice
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = visibleImageIds[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let RecipeImageService;
+
+const imageUtilMocks = {
+  setPrimaryImage: jest.fn(() => Promise.resolve()),
+};
+
+jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+
+beforeEach(async () => {
+  jest.resetModules();
+  imageUtilMocks.setPrimaryImage.mockReset();
+  imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
+
+  ({ RecipeImageService } = await import('src/js/services/recipes/recipe-image-service.js'));
+});
+
+describe('RecipeImageService', () => {
+  describe('setPrimaryImage', () => {
+    it('delegates to the recipe-image-utils helper', async () => {
+      await RecipeImageService.setPrimaryImage('recipe-x', 'img-1');
+      expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
+    });
+  });
+});

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -6,16 +6,44 @@ import '../../common/mocks/firebase-service.mock.js';
 
 let RecipeImageService;
 
+const firestoreMocks = {
+  getDocument: jest.fn(),
+  updateDocument: jest.fn(),
+};
+
+const storageMocks = {
+  getMetadata: jest.fn(),
+  getFileUrl: jest.fn(),
+  uploadFile: jest.fn(),
+  deleteFile: jest.fn(() => Promise.resolve()),
+};
+
 const imageUtilMocks = {
   setPrimaryImage: jest.fn(() => Promise.resolve()),
 };
 
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
+  StorageService: storageMocks,
+}));
 jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+
+beforeAll(() => {
+  // jsdom doesn't ship `fetch`; the service calls it during the backup-fetch path.
+  // Tests stub a Response-shaped object via this mock.
+  global.fetch = jest.fn();
+});
 
 beforeEach(async () => {
   jest.resetModules();
-  imageUtilMocks.setPrimaryImage.mockReset();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
+  Object.values(storageMocks).forEach((m) => m.mockReset?.());
+  storageMocks.deleteFile.mockImplementation(() => Promise.resolve());
+  Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
   imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
+  global.fetch.mockReset();
 
   ({ RecipeImageService } = await import('src/js/services/recipes/recipe-image-service.js'));
 });
@@ -25,6 +53,188 @@ describe('RecipeImageService', () => {
     it('delegates to the recipe-image-utils helper', async () => {
       await RecipeImageService.setPrimaryImage('recipe-x', 'img-1');
       expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
+    });
+  });
+
+  describe('replaceImage', () => {
+    const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
+
+    function setupRecipeWithImage() {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        images: [
+          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
+          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
+        ],
+      });
+    }
+
+    it('throws if recipeId / imageId / blob is missing', async () => {
+      await expect(RecipeImageService.replaceImage('', 'img-1', newBlob)).rejects.toThrow(
+        'recipeId is required',
+      );
+      await expect(RecipeImageService.replaceImage('r', '', newBlob)).rejects.toThrow(
+        'imageId is required',
+      );
+      await expect(RecipeImageService.replaceImage('r', 'i', null)).rejects.toThrow(
+        'blob is required',
+      );
+    });
+
+    it('throws if the recipe is not found', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      await expect(RecipeImageService.replaceImage('missing', 'img-1', newBlob)).rejects.toThrow(
+        'recipe missing not found',
+      );
+    });
+
+    it('throws if the image id is not on the recipe', async () => {
+      setupRecipeWithImage();
+      await expect(
+        RecipeImageService.replaceImage('recipe-9', 'no-such-img', newBlob),
+      ).rejects.toThrow('image no-such-img not found');
+    });
+
+    it('writes the backup when none exists, then overwrites the original', async () => {
+      setupRecipeWithImage();
+      // Backup missing → getMetadata rejects
+      storageMocks.getMetadata.mockRejectedValueOnce(new Error('not-found'));
+      storageMocks.getFileUrl.mockResolvedValue('https://storage/original-url');
+      const originalBytes = new Blob(['original'], { type: 'image/jpeg' });
+      global.fetch.mockResolvedValue({
+        ok: true,
+        blob: async () => originalBytes,
+      });
+
+      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+
+      expect(result.backupCreated).toBe(true);
+      expect(result.backupPath).toBe('img/recipes/full/desserts/recipe-9/img-1_original.jpg');
+      // 1st upload: backup
+      expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
+        1,
+        originalBytes,
+        'img/recipes/full/desserts/recipe-9/img-1_original.jpg',
+      );
+      // 2nd upload: enhanced overwrite at original path
+      expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
+        2,
+        newBlob,
+        'img/recipes/full/desserts/recipe-9/img-1.jpg',
+      );
+    });
+
+    it('skips the backup write when one already exists', async () => {
+      setupRecipeWithImage();
+      // Backup already there → getMetadata resolves
+      storageMocks.getMetadata.mockResolvedValue({ name: 'backup' });
+
+      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+
+      expect(result.backupCreated).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+      // Only one upload: the overwrite
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
+      expect(storageMocks.uploadFile).toHaveBeenCalledWith(
+        newBlob,
+        'img/recipes/full/desserts/recipe-9/img-1.jpg',
+      );
+    });
+
+    it('skips backup entirely when keepOriginalBackup is false', async () => {
+      setupRecipeWithImage();
+
+      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+        keepOriginalBackup: false,
+      });
+
+      expect(storageMocks.getMetadata).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+      // Only the overwrite upload
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('deletes stale 400 and 1080 WebP variants after overwrite (best-effort)', async () => {
+      setupRecipeWithImage();
+      storageMocks.getMetadata.mockResolvedValue({});
+
+      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/desserts/recipe-9/img-1_400x400.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/desserts/recipe-9/img-1_1080x1080.webp',
+      );
+    });
+
+    it('applies fieldUpdates to the matching image entry on the recipe doc', async () => {
+      setupRecipeWithImage();
+      storageMocks.getMetadata.mockResolvedValue({});
+      // 2nd getDocument (the fresh re-read for the patch) returns the same recipe
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        images: [
+          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
+          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
+        ],
+      });
+
+      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+        fieldUpdates: { aiEnhanced: true },
+      });
+
+      const updateCall = firestoreMocks.updateDocument.mock.calls[0];
+      expect(updateCall[0]).toBe('recipes');
+      expect(updateCall[1]).toBe('recipe-9');
+      const updatedImages = updateCall[2].images;
+      expect(updatedImages.find((i) => i.id === 'img-1').aiEnhanced).toBe(true);
+      // Untargeted images are unchanged
+      expect(updatedImages.find((i) => i.id === 'img-2').aiEnhanced).toBeUndefined();
+      expect(updatedImages.find((i) => i.id === 'img-1').isPrimary).toBe(true);
+    });
+
+    it('skips the doc patch when fieldUpdates is empty or missing', async () => {
+      setupRecipeWithImage();
+      storageMocks.getMetadata.mockResolvedValue({});
+
+      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+
+      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+        fieldUpdates: {},
+      });
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('treats a fieldUpdates write failure as best-effort (logs, does not throw)', async () => {
+      setupRecipeWithImage();
+      storageMocks.getMetadata.mockResolvedValue({});
+      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+          fieldUpdates: { aiEnhanced: true },
+        }),
+      ).resolves.toMatchObject({ backupCreated: false });
+
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('throws when fetching the original for backup fails', async () => {
+      setupRecipeWithImage();
+      storageMocks.getMetadata.mockRejectedValue(new Error('no backup yet'));
+      storageMocks.getFileUrl.mockResolvedValue('https://storage/url');
+      global.fetch.mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob)).rejects.toThrow(
+        'failed to fetch original (403)',
+      );
+
+      // Overwrite never happened
+      expect(storageMocks.uploadFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -21,7 +21,6 @@ const imageUtilMocks = {
   deleteImageFiles: jest.fn(() => Promise.resolve()),
   migrateImageToCategory: jest.fn(),
   removeAllRecipeImages: jest.fn(() => Promise.resolve()),
-  setPrimaryImage: jest.fn(() => Promise.resolve()),
 };
 
 const mediaUtilMocks = {
@@ -46,7 +45,6 @@ beforeEach(async () => {
   Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
   imageUtilMocks.deleteImageFiles.mockImplementation(() => Promise.resolve());
   imageUtilMocks.removeAllRecipeImages.mockImplementation(() => Promise.resolve());
-  imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
   Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
   mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
     Promise.resolve({ success: 0, failed: 0, errors: [] }),
@@ -341,13 +339,6 @@ describe('RecipeService', () => {
       });
       const payload = firestoreMocks.updateDocument.mock.calls[0][2];
       expect(payload.approved).toBe(false);
-    });
-  });
-
-  describe('setPrimaryImage', () => {
-    it('delegates to the image util', async () => {
-      await RecipeService.setPrimaryImage('recipe-x', 'img-1');
-      expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
     });
   });
 


### PR DESCRIPTION
Phase 1 closer of the service-layer refactor umbrella (#211).

## What lands

A new \`RecipeImageService\` sibling to \`RecipeService\`, plus the AI image enhance flow fully migrated to use it.

### Commits

| Commit | Scope |
|---|---|
| \`f186537\` | Introduce \`RecipeImageService\`; move \`setPrimaryImage\` from \`RecipeService\` → \`RecipeImageService\`; migrate the one caller (\`image-approval-multi.js\`) |
| \`48d431b\` | Add \`RecipeImageService.replaceImage\`; collapse the AI-enhance modal's \`_save()\` from ~60 lines of inline orchestration to one service call |
| \`eabeb01\` | Migrate \`ai-image-enhancer.js\` recipe reads (list + get) to \`RecipeService\` |

## Service surface (final)

\`\`\`
RecipeImageService.setPrimaryImage(recipeId, imageId)
RecipeImageService.replaceImage(recipeId, imageId, blob, {
  keepOriginalBackup = true,
  fieldUpdates,    // caller-shaped patch (e.g. { aiEnhanced: true })
}) → { backupPath, backupCreated }
\`\`\`

\`replaceImage\` behavior (matches the modal's previous inline flow):

1. Look up the image entry on the recipe doc; throw if recipe or image not found.
2. Backup current bytes to \`<path>_original.<ext>\` (idempotent — only written if missing; skipped when \`keepOriginalBackup: false\`).
3. Overwrite the original path with the new blob.
4. Best-effort delete stale \`_400x400.webp\` / \`_1080x1080.webp\` so consumers refresh promptly.
5. Best-effort merge \`fieldUpdates\` into the matching image entry inside \`recipes/{id}.images[]\`. A failure here logs but does not throw — the image bytes already changed.

## Behavioral improvements vs the inline code

1. **Stale-snapshot bug fixed.** \`originalPath\` is now resolved from the FRESH recipe doc at save time, not from the modal's open-time snapshot. If the recipe's category was changed in another session, the service uses the new path; the inline code would have orphaned files at the old path.
2. **Explicit error throws** for missing recipe / missing image / missing args. Used to silently misbehave or rely on a regex throwing on \`undefined\`.
3. **\`fieldUpdates\` is caller-shaped.** Modal passes \`{ aiEnhanced: true }\` today; future callers can pass richer shapes without service changes.

## Tests

\`tests/js/services/recipe-image-service.test.mjs\` — 12 cases covering:
- \`setPrimaryImage\` delegation
- backup-missing vs backup-exists paths for \`replaceImage\`
- \`keepOriginalBackup: false\` short-circuit
- stale WebP variant cleanup
- \`fieldUpdates\` targets only the right image entry
- empty / missing \`fieldUpdates\` skips the doc write
- doc-patch failure stays best-effort (logs, doesn't throw)
- recipe-not-found / image-not-found / missing-args throws
- backup-fetch failure aborts before overwrite

Full suite: **497 passing**. Lint + build green. Playwright not run on this branch (no UI templates changed).

## Goal grep

After this merges, in \`src/lib/media/ai-image-enhancer/\`:

\`\`\`bash
grep -rn "FirestoreService\\|StorageService" src/lib/media/ai-image-enhancer/
\`\`\`

Returns only \`ai-image-enhance-modal.js:340\` — \`StorageService.getFileUrl(this._image.full)\` for the pre-enhancement image fetch. That's the display-URL exemption tracked in #215.

## Out of scope

- Display-URL exemption decision (#215 tracks this for Phase 6).
- Removing the pre-enhancement \`StorageService.getFileUrl\` use — would require a new \`RecipeImageService.fetchImage\` verb or similar; out of scope unless we revive #215.

## Verification

Manual smoke (run by reviewer):

- [ ] AI enhance: select a recipe with an image → enhance → save. Image is overwritten; \`<path>_original.<ext>\` exists; doc has \`aiEnhanced: true\` on that image entry; sibling images on the same recipe are untouched.
- [ ] Idempotency: enhance the same image twice; the backup file isn't overwritten on the second save.
- [ ] Image approval modal (\`image-approval-multi\`): approve a pending image and set as primary; verify primary flag updates correctly (this exercises the moved \`setPrimaryImage\`).