### PR TITLE
refactor(services): introduce UserService API (PR-I)

### DIFF
--- a/src/js/services/users/user-service.js
+++ b/src/js/services/users/user-service.js
@@ -1,0 +1,138 @@
+// src/js/services/users/user-service.js
+
+import { arrayUnion, arrayRemove } from 'firebase/firestore';
+import { FirestoreService } from '../_firebase/firestore-service.js';
+
+const USERS_COLLECTION = 'users';
+
+/**
+ * UserService — The Single Owner of `users/{uid}`
+ *
+ * Public entry point for all reads and writes against the users
+ * collection. Field-scoped services (FavoritesService,
+ * NotificationService) compose on top — they delegate user-doc access
+ * here instead of touching the doc directly.
+ *
+ * AuthService owns Firebase Auth state ("who is signed in"); it does
+ * NOT own the users doc. After Phase 2 caller migrations, AuthService
+ * will read/write the users doc through UserService.
+ *
+ * Public API:
+ *   - get(uid)
+ *   - list(queryParams)
+ *   - create(uid, data)
+ *   - update(uid, changes)
+ *   - delete(uid)
+ *   - addToArrayField(uid, field, value)
+ *   - removeFromArrayField(uid, field, value)
+ *
+ * The array helpers wrap Firestore's `arrayUnion` / `arrayRemove`
+ * sentinels so domain services never need to import
+ * `firebase/firestore` directly.
+ */
+export class UserService {
+  /**
+   * Fetch a single user doc by uid. Returns null when not found.
+   * @param {string} uid
+   * @returns {Promise<Object|null>}
+   */
+  static async get(uid) {
+    if (!uid) throw new Error('UserService.get: uid is required');
+    return await FirestoreService.getDocument(USERS_COLLECTION, uid);
+  }
+
+  /**
+   * Query users with the same shape as FirestoreService.queryDocuments.
+   * @param {Object} [queryParams]
+   * @returns {Promise<Array<Object>>}
+   */
+  static async list(queryParams = {}) {
+    return await FirestoreService.queryDocuments(USERS_COLLECTION, queryParams);
+  }
+
+  /**
+   * Create a new user doc at `users/{uid}` with the given data. Last
+   * writer wins — calling this on an existing uid overwrites the doc.
+   * Caller is responsible for the doc shape.
+   *
+   * @param {string} uid
+   * @param {Object} data
+   * @returns {Promise<void>}
+   */
+  static async create(uid, data) {
+    if (!uid) throw new Error('UserService.create: uid is required');
+    if (!data || typeof data !== 'object') {
+      throw new Error('UserService.create: data is required');
+    }
+    return await FirestoreService.setDocument(USERS_COLLECTION, uid, data);
+  }
+
+  /**
+   * Patch fields on an existing user doc. Firestore's underlying
+   * updateDoc semantics are field-merge — only the keys you pass are
+   * touched; other fields are left alone.
+   *
+   * For atomic array operations, prefer `addToArrayField` /
+   * `removeFromArrayField` over passing array values directly.
+   *
+   * @param {string} uid
+   * @param {Object} changes - Field changes to apply.
+   * @returns {Promise<void>}
+   */
+  static async update(uid, changes) {
+    if (!uid) throw new Error('UserService.update: uid is required');
+    if (!changes || typeof changes !== 'object') {
+      throw new Error('UserService.update: changes is required');
+    }
+    return await FirestoreService.updateDocument(USERS_COLLECTION, uid, changes);
+  }
+
+  /**
+   * Delete a user doc.
+   * @param {string} uid
+   * @returns {Promise<void>}
+   */
+  static async delete(uid) {
+    if (!uid) throw new Error('UserService.delete: uid is required');
+    return await FirestoreService.deleteDocument(USERS_COLLECTION, uid);
+  }
+
+  /**
+   * Atomically add a value to an array field on the user doc. Wraps
+   * Firestore's `arrayUnion` sentinel so domain callers don't need to
+   * import the Firestore SDK. Idempotent — adding a value that's
+   * already in the array is a no-op.
+   *
+   * @param {string} uid
+   * @param {string} field - Name of the array field (e.g. 'favorites', 'fcmTokens').
+   * @param {*} value - Value to add.
+   * @returns {Promise<void>}
+   */
+  static async addToArrayField(uid, field, value) {
+    if (!uid) throw new Error('UserService.addToArrayField: uid is required');
+    if (!field) throw new Error('UserService.addToArrayField: field is required');
+    return await FirestoreService.updateDocument(USERS_COLLECTION, uid, {
+      [field]: arrayUnion(value),
+    });
+  }
+
+  /**
+   * Atomically remove a value from an array field on the user doc.
+   * Wraps Firestore's `arrayRemove` sentinel. No-op when the value
+   * isn't present.
+   *
+   * @param {string} uid
+   * @param {string} field
+   * @param {*} value
+   * @returns {Promise<void>}
+   */
+  static async removeFromArrayField(uid, field, value) {
+    if (!uid) throw new Error('UserService.removeFromArrayField: uid is required');
+    if (!field) throw new Error('UserService.removeFromArrayField: field is required');
+    return await FirestoreService.updateDocument(USERS_COLLECTION, uid, {
+      [field]: arrayRemove(value),
+    });
+  }
+}
+
+export const userService = UserService;

--- a/tests/common/mocks/firebase-firestore.mock.js
+++ b/tests/common/mocks/firebase-firestore.mock.js
@@ -35,6 +35,11 @@ jest.unstable_mockModule('firebase/firestore', () => ({
   setDoc: jest.fn(),
   updateDoc: jest.fn(),
   deleteDoc: jest.fn(),
+  // Field-value sentinels. Tests can compare against fresh `arrayUnion(x)` /
+  // `arrayRemove(x)` calls since the same value+args yield equal-by-`.toEqual`
+  // sentinel objects.
+  arrayUnion: jest.fn((...values) => ({ __op: 'arrayUnion', values })),
+  arrayRemove: jest.fn((...values) => ({ __op: 'arrayRemove', values })),
   getFirestore: jest.fn(() => 'mockFirestore'),
   getDocs: jest.fn(),
   addDoc: jest.fn(),

--- a/tests/js/services/user-service.test.mjs
+++ b/tests/js/services/user-service.test.mjs
@@ -1,0 +1,147 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let UserService;
+let arrayUnion, arrayRemove;
+
+const firestoreMocks = {
+  getDocument: jest.fn(),
+  queryDocuments: jest.fn(),
+  setDocument: jest.fn(),
+  updateDocument: jest.fn(),
+  deleteDocument: jest.fn(),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset());
+
+  ({ UserService } = await import('src/js/services/users/user-service.js'));
+  ({ arrayUnion, arrayRemove } = await import('firebase/firestore'));
+});
+
+describe('UserService', () => {
+  describe('get', () => {
+    it('delegates to FirestoreService.getDocument with the users collection', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'u1', role: 'manager' });
+      const result = await UserService.get('u1');
+      expect(firestoreMocks.getDocument).toHaveBeenCalledWith('users', 'u1');
+      expect(result).toEqual({ id: 'u1', role: 'manager' });
+    });
+
+    it('throws when uid is missing', async () => {
+      await expect(UserService.get('')).rejects.toThrow('uid is required');
+    });
+  });
+
+  describe('list', () => {
+    it('delegates to FirestoreService.queryDocuments with the users collection', async () => {
+      firestoreMocks.queryDocuments.mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+      const result = await UserService.list({ where: [['role', '==', 'manager']] });
+      expect(firestoreMocks.queryDocuments).toHaveBeenCalledWith('users', {
+        where: [['role', '==', 'manager']],
+      });
+      expect(result).toEqual([{ id: 'a' }, { id: 'b' }]);
+    });
+
+    it('passes an empty query object when no params given', async () => {
+      firestoreMocks.queryDocuments.mockResolvedValue([]);
+      await UserService.list();
+      expect(firestoreMocks.queryDocuments).toHaveBeenCalledWith('users', {});
+    });
+  });
+
+  describe('create', () => {
+    it('delegates to FirestoreService.setDocument', async () => {
+      firestoreMocks.setDocument.mockResolvedValue();
+      const data = { displayName: 'Ada', role: 'user', favorites: [] };
+      await UserService.create('u1', data);
+      expect(firestoreMocks.setDocument).toHaveBeenCalledWith('users', 'u1', data);
+    });
+
+    it('throws when uid is missing', async () => {
+      await expect(UserService.create('', { role: 'user' })).rejects.toThrow('uid is required');
+    });
+
+    it('throws when data is missing or not an object', async () => {
+      await expect(UserService.create('u1', null)).rejects.toThrow('data is required');
+      await expect(UserService.create('u1', 'not-an-object')).rejects.toThrow('data is required');
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to FirestoreService.updateDocument', async () => {
+      firestoreMocks.updateDocument.mockResolvedValue();
+      await UserService.update('u1', { role: 'manager' });
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledWith('users', 'u1', {
+        role: 'manager',
+      });
+    });
+
+    it('throws when uid is missing', async () => {
+      await expect(UserService.update('', { role: 'manager' })).rejects.toThrow('uid is required');
+    });
+
+    it('throws when changes is missing or not an object', async () => {
+      await expect(UserService.update('u1', null)).rejects.toThrow('changes is required');
+    });
+  });
+
+  describe('delete', () => {
+    it('delegates to FirestoreService.deleteDocument', async () => {
+      firestoreMocks.deleteDocument.mockResolvedValue();
+      await UserService.delete('u1');
+      expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('users', 'u1');
+    });
+
+    it('throws when uid is missing', async () => {
+      await expect(UserService.delete('')).rejects.toThrow('uid is required');
+    });
+  });
+
+  describe('addToArrayField', () => {
+    it('calls updateDocument with an arrayUnion sentinel for the requested field', async () => {
+      firestoreMocks.updateDocument.mockResolvedValue();
+      await UserService.addToArrayField('u1', 'favorites', 'recipe-7');
+      // arrayUnion(value) produces an opaque FieldValue sentinel. We check
+      // that it was wrapped in arrayUnion by comparing to a fresh call.
+      const expectedSentinel = arrayUnion('recipe-7');
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledWith('users', 'u1', {
+        favorites: expectedSentinel,
+      });
+    });
+
+    it('throws when uid or field is missing', async () => {
+      await expect(UserService.addToArrayField('', 'favorites', 'x')).rejects.toThrow(
+        'uid is required',
+      );
+      await expect(UserService.addToArrayField('u1', '', 'x')).rejects.toThrow('field is required');
+    });
+  });
+
+  describe('removeFromArrayField', () => {
+    it('calls updateDocument with an arrayRemove sentinel for the requested field', async () => {
+      firestoreMocks.updateDocument.mockResolvedValue();
+      await UserService.removeFromArrayField('u1', 'fcmTokens', 'token-abc');
+      const expectedSentinel = arrayRemove('token-abc');
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledWith('users', 'u1', {
+        fcmTokens: expectedSentinel,
+      });
+    });
+
+    it('throws when uid or field is missing', async () => {
+      await expect(UserService.removeFromArrayField('', 'fcmTokens', 'x')).rejects.toThrow(
+        'uid is required',
+      );
+      await expect(UserService.removeFromArrayField('u1', '', 'x')).rejects.toThrow(
+        'field is required',
+      );
+    });
+  });
+});


### PR DESCRIPTION
First sub-PR of Phase 2 in the service-layer refactor umbrella (#211). Adds the \`UserService\` API. **No callers migrated yet** — sequential PR-J1 / J2 / J3 / J4 will land migrations after this merges.

## API

\`\`\`js
UserService.get(uid)                            // → doc or null
UserService.list(queryParams = {})              // → array
UserService.create(uid, data)                   // setDoc — last writer wins
UserService.update(uid, changes)                // updateDoc — field merge
UserService.delete(uid)
UserService.addToArrayField(uid, field, value)  // wraps arrayUnion
UserService.removeFromArrayField(uid, field, value)  // wraps arrayRemove
\`\`\`

## Why these specific methods

Based on the auditor's caller inventory (#211 plan section "Phase 2 — Users"), the full set of operations needed across all bypass sites is: get-single, list, create, update fields, delete, atomic-add to favorites/fcmTokens arrays, atomic-remove from same. Each method maps directly to one or more existing call sites that will migrate in PR-J1 through PR-J4.

The two array helpers wrap Firestore's \`arrayUnion\` / \`arrayRemove\` sentinels internally, so domain services (FavoritesService, NotificationService) never need to import \`firebase/firestore\`. That alignment matters for Phase 6's ESLint rule.

## Caller-migration roadmap (after this merges)

| PR | Scope |
|---|---|
| **PR-J1** | \`manager-dashboard-page.js\` (3 sites: auth check, list users, role update) + \`documents-page.js\` (role check) |
| **PR-J2** | \`favorites-service.js\` (3 sites) + \`filter_modal.js:697\` route user-doc access through UserService |
| **PR-J3** | \`notification-service.js\` doc-level user-doc access via UserService (FCM SDK stays direct) |
| **PR-J4** | \`auth-service.js\` raw-SDK user-doc accesses (getUserData, signup, profile update, account deletion) — surfaced during PR-I audit |

## Tests

\`tests/js/services/user-service.test.mjs\` — 16 cases covering all 7 methods + input validation:
- get / list / create / update / delete with the right collection
- create + update + delete + addToArrayField + removeFromArrayField with missing args → throw
- Array helpers wrap arrayUnion / arrayRemove with the right field name + value

**Suite: 513 passing.** Lint + build clean.

## Central mock update

\`tests/common/mocks/firebase-firestore.mock.js\` gains \`arrayUnion\` / \`arrayRemove\` sentinel mocks (returning \`{ __op, values }\` objects) so tests can compare against fresh \`arrayUnion(v)\` calls via \`.toEqual\`. Additive — no existing tests affected.

## Verification

No manual smoke test applies (no callers yet). Automated gates green.