### PR TITLE
refactor(users): route manager admin + documents-page through UserService (PR-J1)

### DIFF
--- a/src/app/pages/documents-page.js
+++ b/src/app/pages/documents-page.js
@@ -1,4 +1,4 @@
-import { FirestoreService } from '../../js/services/_firebase/firestore-service.js';
+import { UserService } from '../../js/services/users/user-service.js';
 import authService from '../../js/services/auth/auth-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
 import '../../styles/pages/documents-spa.css';
@@ -56,7 +56,7 @@ export default {
 
   async checkDocumentAccessStatus(user) {
     try {
-      const userDoc = await FirestoreService.getDocument('users', user.uid);
+      const userDoc = await UserService.get(user.uid);
       if (userDoc) {
         const userRole = userDoc.role;
         return userRole === 'manager' || userRole === 'approved';

--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -1,5 +1,6 @@
 import { FirestoreService } from '../../js/services/_firebase/firestore-service.js';
 import { RecipeService } from '../../js/services/recipes/recipe-service.js';
+import { UserService } from '../../js/services/users/user-service.js';
 import authService from '../../js/services/auth/auth-service.js';
 import notificationService from '../../js/services/users/notification-service.js';
 import { AppConfig } from '../../js/config/app-config.js';
@@ -82,7 +83,7 @@ export default {
 
   async checkManagerStatus(user) {
     try {
-      const userDoc = await FirestoreService.getDocument('users', user.uid);
+      const userDoc = await UserService.get(user.uid);
       if (userDoc) {
         return userDoc.role === 'manager';
       }
@@ -239,7 +240,7 @@ export default {
     const userList = document.getElementById('user-list');
     userList.setItems([]); // Clear existing items first
     try {
-      const users = await FirestoreService.queryDocuments('users');
+      const users = await UserService.list();
       const userItems = users.map((user) => ({
         header: this.createHeader(user.email),
         content: this.createContent(user),
@@ -304,7 +305,7 @@ export default {
 
   async updateUserRole(userId, newRole) {
     try {
-      await FirestoreService.updateDocument('users', userId, { role: newRole });
+      await UserService.update(userId, { role: newRole });
       this.showSuccessMessage('תפקיד המשתמש עודכן בהצלחה');
     } catch (error) {
       this.handleError(error);


### PR DESCRIPTION
Phase 2 / sub-PR 1 in the service-layer refactor umbrella (#211). Migrates the page-level user-doc bypass sites.

## What changed

Single focused commit (\`3ffd056\`). 2 files, +6 −5.

| Site | Before | After |
|---|---|---|
| \`documents-page.js:59\` (role gate) | \`FirestoreService.getDocument('users', uid)\` | \`UserService.get(uid)\` |
| \`manager-dashboard-page.js:86\` (manager auth check) | \`FirestoreService.getDocument('users', uid)\` | \`UserService.get(uid)\` |
| \`manager-dashboard-page.js:243\` (list users) | \`FirestoreService.queryDocuments('users')\` | \`UserService.list()\` |
| \`manager-dashboard-page.js:308\` (update role) | \`FirestoreService.updateDocument('users', uid, {role})\` | \`UserService.update(uid, {role})\` |

\`FirestoreService\` import dropped from \`documents-page.js\` (was its only caller); kept in \`manager-dashboard-page.js\` for \`failed_url_extractions\` (Phase 5).

Behavior identical — UserService methods are thin wrappers over the same FirestoreService calls underneath.

## Goal grep after merge

\`\`\`bash
grep -rn "Document('users'\\|Document(\"users\"" src/app/pages/
\`\`\`

Returns nothing.

## Out of scope (later PRs)

- **PR-J2:** \`favorites-service.js\` (3 sites) + \`filter_modal.js:697\`
- **PR-J3:** \`notification-service.js\` doc-level access
- **PR-J4:** \`auth-service.js\` raw-SDK user-doc accesses (surfaced during PR-I audit)

## Adjacent issue filed during this PR

#221 — manager dashboard role-update success modal shows "המתכון נמחק" ("Recipe removed") as title regardless of action. Independent bug; not blocking this PR.

## Verification

Manual:

- [ ] Open \`/dashboard\` as manager → page loads (manager auth check via UserService.get).
- [ ] Open \`/dashboard\` as non-manager → redirected.
- [ ] Dashboard users section populates (UserService.list).
- [ ] Change a user's role from the dashboard → role updates in Firestore (UserService.update). Modal title bug per #221 is pre-existing.
- [ ] \`/grandmas-cooking\` loads with same role-gating behavior as before.

Automated: 513 tests, lint, build all green.