### PR TITLE
refactor(users): route favorites-service + filter_modal through user layer (PR-J2)

### DIFF
--- a/src/js/services/users/favorites-service.js
+++ b/src/js/services/users/favorites-service.js
@@ -4,9 +4,8 @@
  * Centralized service for managing user favorites with caching
  */
 
-import { arrayUnion, arrayRemove } from 'firebase/firestore';
 import authService from '../auth/auth-service.js';
-import { FirestoreService } from '../_firebase/firestore-service.js';
+import { UserService } from './user-service.js';
 
 class FavoritesService {
   constructor() {
@@ -39,7 +38,7 @@ class FavoritesService {
 
     this._fetchPromise = (async () => {
       try {
-        const userDoc = await FirestoreService.getDocument('users', user.uid);
+        const userDoc = await UserService.get(user.uid);
         const favoriteRecipeIds = userDoc?.favorites || [];
 
         this.cache = {
@@ -73,9 +72,7 @@ class FavoritesService {
       // Optimistic update
       this.updateCache(recipeId, true);
 
-      await FirestoreService.updateDocument('users', user.uid, {
-        favorites: arrayUnion(recipeId),
-      });
+      await UserService.addToArrayField(user.uid, 'favorites', recipeId);
     } catch (error) {
       console.error('Error adding favorite:', error);
       // Revert cache on error
@@ -97,9 +94,7 @@ class FavoritesService {
       // Optimistic update
       this.updateCache(recipeId, false);
 
-      await FirestoreService.updateDocument('users', user.uid, {
-        favorites: arrayRemove(recipeId),
-      });
+      await UserService.removeFromArrayField(user.uid, 'favorites', recipeId);
     } catch (error) {
       console.error('Error removing favorite:', error);
       // Revert cache on error

--- a/src/lib/modals/filter_modal/filter_modal.js
+++ b/src/lib/modals/filter_modal/filter_modal.js
@@ -55,7 +55,7 @@
  */
 
 import authService from '../../../js/services/auth/auth-service.js';
-import { FirestoreService } from '../../../js/services/_firebase/firestore-service.js';
+import favoritesService from '../../../js/services/users/favorites-service.js';
 import { FilterUtils } from '../../../js/utils/filter-utils.js';
 
 class RecipeFilterComponent extends HTMLElement {
@@ -685,23 +685,6 @@ class RecipeFilterComponent extends HTMLElement {
     this.updateUI();
   }
 
-  // Load user's favorite recipe IDs from Firestore
-  async loadUserFavorites() {
-    const user = authService.getCurrentUser();
-    if (!user) {
-      this.favoriteRecipeIds = [];
-      return;
-    }
-
-    try {
-      const userDoc = await FirestoreService.getDocument('users', user.uid);
-      this.favoriteRecipeIds = userDoc?.favorites || [];
-    } catch (error) {
-      console.error('Error loading user favorites:', error);
-      this.favoriteRecipeIds = [];
-    }
-  }
-
   handleFilterChange() {
     this.updateFilterState();
     // Use debouncing to prevent too many rapid updates
@@ -712,7 +695,7 @@ class RecipeFilterComponent extends HTMLElement {
     this._filterChangeTimeout = setTimeout(async () => {
       // If favorites filter is enabled, ensure we have favorites data
       if (this.filters.favoritesOnly && this.favoriteRecipeIds.length === 0) {
-        await this.loadUserFavorites();
+        this.favoriteRecipeIds = await favoritesService.getUserFavorites();
       }
       this.updateCounter();
     }, 300); // 300ms debounce
@@ -863,7 +846,7 @@ class RecipeFilterComponent extends HTMLElement {
   async open() {
     // If favorites filter is enabled, ensure we have favorites data
     if (this.filters.favoritesOnly) {
-      await this.loadUserFavorites();
+      this.favoriteRecipeIds = await favoritesService.getUserFavorites();
       this.updateUI(); // Update counter after loading favorites
     }
 


### PR DESCRIPTION
Phase 2 / sub-PR 2 in the service-layer refactor umbrella (#211).

## Scope

Two callers, single commit (\`188a4eb\`):

### \`favorites-service.js\`

3 bypass sites swap to \`UserService\`:

| Before | After |
|---|---|
| \`FirestoreService.getDocument('users', uid)\` | \`UserService.get(uid)\` |
| \`updateDocument('users', uid, { favorites: arrayUnion(id) })\` | \`UserService.addToArrayField(uid, 'favorites', id)\` |
| \`updateDocument('users', uid, { favorites: arrayRemove(id) })\` | \`UserService.removeFromArrayField(uid, 'favorites', id)\` |

\`arrayUnion\` / \`arrayRemove\` imports from \`firebase/firestore\` are dropped — those sentinels are now wrapped inside \`UserService\`. \`FirestoreService\` import dropped (was its only use).

### \`filter_modal.js\`

The \`loadUserFavorites()\` method was reading the user doc directly *and* duplicating what \`FavoritesService.getUserFavorites()\` already provides (caching + dedup).

Replaced with direct \`favoritesService.getUserFavorites()\` calls inline at the 2 call sites:

- Debounced filter-change handler (line ~698)
- \`open()\` method (line ~849)

The wrapper method is gone. \`FirestoreService\` import dropped; \`favoritesService\` import added. **Side benefit:** filter modal now reuses FavoritesService's cache on repeat opens.

## Diff stat

+7 −29 (net −22 lines).

## Goal grep

\`\`\`bash
grep -rn "Document('users'\\|arrayUnion\\|arrayRemove" src/ | grep -v src/js/services/users/
\`\`\`

Remaining hits (out of scope for PR-J2):

- \`src/js/services/auth/auth-service.js\` — raw-SDK user-doc accesses (PR-J4 territory)
- \`src/js/services/users/notification-service.js\` — uses raw SDK for FCM-token writes (PR-J3 territory)

## Verification

Manual:

- [ ] Add/remove favorites from any recipe card — works as before.
- [ ] \`/categories\` → open filter modal → "favorites only" filter shows your favorited recipes.
- [ ] Reopen the filter modal — second open is instant (cached via FavoritesService).
- [ ] Sign out/in as different user — that user's favorites correctly displayed (auth-state cache invalidation still fires).

Automated: 513 tests, lint, build all green.

## Adjacent issue

Considered filing a dedup follow-up for \`filter_modal\`, but applied the dedup in this PR instead (per request). The deeper dedup — removing \`this.favoriteRecipeIds\` field entirely and making \`FilterUtils.applyFilters\` async — is a larger refactor that wasn't bundled here.