### PR TITLE
refactor(users): route notification-service through UserService (PR-J3)

### DIFF
--- a/src/js/services/users/notification-service.js
+++ b/src/js/services/users/notification-service.js
@@ -20,8 +20,8 @@
  *       Called on sign-out.
  */
 import { getFirebaseApp } from '../_firebase/firebase-service.js';
-import { doc, updateDoc, arrayUnion, arrayRemove, Timestamp } from 'firebase/firestore';
-import { getFirestoreInstance } from '../_firebase/firebase-service.js';
+import { Timestamp } from 'firebase/firestore';
+import { UserService } from './user-service.js';
 
 const SW_PATH = '/firebase-messaging-sw.js';
 const TOKEN_CACHE_KEY = 'mcb_fcm_token_v1';
@@ -191,15 +191,13 @@ class NotificationService {
     const token = this._currentToken || localStorage.getItem(TOKEN_CACHE_KEY);
     if (!token || !uid) return;
     try {
-      const db = getFirestoreInstance();
-      const userRef = doc(db, 'users', uid);
       // We don't know the full token object shape on the server, so we remove
       // any entry with this token by writing back all-but-this-token. Cheaper:
-      // store the canonical entry locally and arrayRemove that exact object.
-      // We do the latter using the cached entry shape.
+      // store the canonical entry locally and remove that exact object via
+      // UserService (which wraps arrayRemove).
       const cachedEntry = this._readCachedEntry();
       if (cachedEntry) {
-        await updateDoc(userRef, { fcmTokens: arrayRemove(cachedEntry) });
+        await UserService.removeFromArrayField(uid, 'fcmTokens', cachedEntry);
       }
       // Best-effort: also delete the token from FCM itself.
       try {
@@ -218,14 +216,12 @@ class NotificationService {
   }
 
   async _storeToken(uid, token) {
-    const db = getFirestoreInstance();
-    const userRef = doc(db, 'users', uid);
     const entry = {
       token,
       ua: typeof navigator !== 'undefined' ? navigator.userAgent.slice(0, 200) : '',
       createdAt: Timestamp.now(),
     };
-    await updateDoc(userRef, { fcmTokens: arrayUnion(entry) });
+    await UserService.addToArrayField(uid, 'fcmTokens', entry);
     localStorage.setItem(`${TOKEN_CACHE_KEY}_entry`, JSON.stringify(entry));
   }
 


### PR DESCRIPTION
Phase 2 / sub-PR 3 in the service-layer refactor umbrella (#211).

## What changed

Single commit (\`465c185\`). 1 file, +6 −10.

\`notification-service.js\` previously read/wrote \`users/{uid}.fcmTokens\` via raw Firestore SDK. Routes both write sites through \`UserService\`:

| Site | Before | After |
|---|---|---|
| \`unregisterCurrentDevice\` (sign-out) | \`updateDoc(userRef, { fcmTokens: arrayRemove(cachedEntry) })\` | \`UserService.removeFromArrayField(uid, 'fcmTokens', cachedEntry)\` |
| \`_storeToken\` (enable notifications) | \`updateDoc(userRef, { fcmTokens: arrayUnion(entry) })\` | \`UserService.addToArrayField(uid, 'fcmTokens', entry)\` |

## Imports

Dropped:
- \`doc\`, \`updateDoc\`, \`arrayUnion\`, \`arrayRemove\` from \`firebase/firestore\`
- \`getFirestoreInstance\` from \`_firebase/firebase-service.js\`

Kept:
- \`getFirebaseApp\` — used by FCM messaging setup
- \`Timestamp\` from \`firebase/firestore\` — value type used to construct the token entry shape (\`createdAt: Timestamp.now()\`). Not a DB operation. Phase 6 ESLint rule should exempt value types; will be revisited there.

FCM messaging SDK access (\`firebase/messaging\` for \`getToken\` / \`deleteToken\`) stays direct — that's a different system from Firestore and outside the umbrella's "domain services don't touch Firestore SDK" convention.

## Verification

Manual:

- [ ] Enable notifications → permission prompt → grant. \`users/{uid}.fcmTokens\` gains a new entry.
- [ ] Sign out → the token entry for this device is removed from \`users/{uid}.fcmTokens\`.
- [ ] Sign back in and re-enable → fresh token entry appears.

Automated: 513 tests, lint, build all green.

## What's left in Phase 2

- **PR-J4** — \`auth-service.js\` raw-SDK user-doc accesses (4+ sites: getUserData, signup, profile update, account deletion). Last sub-PR of Phase 2 before moving to Phase 4.