### PR TITLE
refactor(users): route auth-service user-doc accesses through UserService (PR-J4)

### DIFF
--- a/src/js/services/auth/auth-service.js
+++ b/src/js/services/auth/auth-service.js
@@ -26,8 +26,9 @@
  *   - waitForAuth(timeout): Waits for authentication to initialize, returns authenticated user or null.
  *   - getCurrentAvatarUrl(): Returns the current user's avatar URL.
  */
-import { getAuthInstance, getFirestoreInstance } from '../_firebase/firebase-service.js';
-import { serverTimestamp, doc, getDoc, setDoc, updateDoc, deleteDoc } from 'firebase/firestore';
+import { getAuthInstance } from '../_firebase/firebase-service.js';
+import { serverTimestamp } from 'firebase/firestore';
+import { UserService } from '../users/user-service.js';
 import {
   browserLocalPersistence,
   browserSessionPersistence,
@@ -170,12 +171,10 @@ class AuthService {
     }
 
     try {
-      const db = getFirestoreInstance();
-      const userDocRef = doc(db, 'users', this._currentUser.uid);
-      const docSnap = await getDoc(userDocRef);
+      const data = await UserService.get(this._currentUser.uid);
 
-      if (docSnap.exists()) {
-        this._userData = docSnap.data();
+      if (data) {
+        this._userData = data;
       } else {
         // If document doesn't exist, use default structure
         this._userData = { role: 'user', favorites: [] };
@@ -251,14 +250,10 @@ class AuthService {
       const userCredential = await signInWithPopup(auth, provider, browserPopupRedirectResolver);
       const user = userCredential.user;
 
-      // Check if user document exists in Firestore
-      const db = getFirestoreInstance();
-      const userDocRef = doc(db, 'users', user.uid);
-      const userDoc = await getDoc(userDocRef);
-
-      // If user doesn't exist in Firestore, create a new document
-      if (!userDoc.exists()) {
-        await setDoc(userDocRef, {
+      // Check if user document exists; create one if not.
+      const existing = await UserService.get(user.uid);
+      if (!existing) {
+        await UserService.create(user.uid, {
           email: user.email,
           fullName: user.displayName,
           role: 'user',
@@ -283,7 +278,6 @@ class AuthService {
   async signup(email, password, fullName) {
     try {
       const auth = getAuthInstance();
-      const db = getFirestoreInstance();
       // Create user in Firebase Auth
       const userCredential = await createUserWithEmailAndPassword(auth, email, password);
       const user = userCredential.user;
@@ -292,8 +286,7 @@ class AuthService {
       await updateProfile(user, { displayName: fullName });
 
       // Create user document in Firestore
-      const userDocRef = doc(db, 'users', user.uid);
-      await setDoc(userDocRef, {
+      await UserService.create(user.uid, {
         email: email,
         fullName: fullName,
         role: 'user',
@@ -356,7 +349,6 @@ class AuthService {
     try {
       const user = this.getCurrentUser();
       if (!user) throw new Error('No user is signed in');
-      const db = getFirestoreInstance();
       // Update auth profile if displayName or photoURL provided
       if (profileData.displayName || profileData.photoURL) {
         await updateProfile(user, {
@@ -365,8 +357,7 @@ class AuthService {
         });
       }
       // Update user document in Firestore
-      const userDocRef = doc(db, 'users', user.uid);
-      await updateDoc(userDocRef, {
+      await UserService.update(user.uid, {
         ...profileData,
         updatedAt: serverTimestamp(),
       });
@@ -410,10 +401,8 @@ class AuthService {
     try {
       const user = this.getCurrentUser();
       if (!user) throw new Error('No user is signed in');
-      const db = getFirestoreInstance();
       // Delete user document from Firestore
-      const userDocRef = doc(db, 'users', user.uid);
-      await deleteDoc(userDocRef);
+      await UserService.delete(user.uid);
       // Delete user from Firebase Auth
       await user.delete();
     } catch (error) {
@@ -578,12 +567,8 @@ class AuthService {
     }
     // Fallback for direct calls with different user (shouldn't happen often)
     try {
-      const db = getFirestoreInstance();
-      const userDocRef = doc(db, 'users', user.uid);
-      const docSnap = await getDoc(userDocRef);
-      if (docSnap.exists()) {
-        return docSnap.data();
-      }
+      const data = await UserService.get(user.uid);
+      if (data) return data;
       return { role: 'user' };
     } catch (error) {
       console.error('Error fetching user roles:', error);
@@ -605,11 +590,8 @@ class AuthService {
     }
     // Fallback
     try {
-      const db = getFirestoreInstance();
-      const userDocRef = doc(db, 'users', user.uid);
-      const docSnap = await getDoc(userDocRef);
-      if (docSnap.exists()) {
-        const userData = docSnap.data();
+      const userData = await UserService.get(user.uid);
+      if (userData) {
         return userData.avatarUrl || user.photoURL || null;
       }
       return user.photoURL || null;

--- a/tests/js/services/auth-service.test.mjs
+++ b/tests/js/services/auth-service.test.mjs
@@ -374,9 +374,13 @@ describe('AuthService', () => {
       const userCredential = { user: mockUser };
       signInWithPopup.mockResolvedValue(userCredential);
 
-      // User exists in Firestore
+      // User exists in Firestore. The mock must shape a complete docSnap
+      // since the read goes through FirestoreService.getDocument, which
+      // calls docSnap.data() and reads docSnap.id.
       getDoc.mockResolvedValue({
         exists: () => true,
+        data: () => ({ role: 'user' }),
+        id: mockUser.uid,
       });
 
       await authService.loginWithGoogle();


### PR DESCRIPTION
Phase 2 / sub-PR 4 (final Phase 2 PR) in the service-layer refactor umbrella (#211).

## Scope

\`auth-service.js\` had **7 raw-SDK user-doc operations** across 5 methods. All migrated to \`UserService\`:

| Method | Operation | After |
|---|---|---|
| \`getUserData\` | read | \`UserService.get(uid)\` |
| \`loginWithGoogle\` | read + create-if-missing | \`UserService.get\` + \`UserService.create\` |
| \`signup\` | create | \`UserService.create(uid, data)\` |
| \`updateProfile\` | update | \`UserService.update(uid, changes)\` |
| \`deleteAccount\` | delete | \`UserService.delete(uid)\` |
| \`_fetchUserRoles\` (fallback) | read | \`UserService.get(uid)\` |
| \`_fetchAvatarUrl\` (fallback) | read | \`UserService.get(uid)\` |

## Imports

Dropped: \`doc\`, \`getDoc\`, \`setDoc\`, \`updateDoc\`, \`deleteDoc\` from \`firebase/firestore\`; \`getFirestoreInstance\` from \`_firebase/\`.

Kept: \`serverTimestamp\` (value-type sentinel for \`createdAt\`/\`updatedAt\`), \`getAuthInstance\` (Firebase Auth, different system).

## Diff

+22 −36 (net −14). Each old site previously had \`const db = ...; const userDocRef = doc(db, 'users', uid);\` boilerplate; each is now a single service call.

## Behavioral differences vs raw-SDK (reviewed, benign)

1. Reads now include an \`id\` field on returned objects (FirestoreService.getDocument spreads \`{ id, ...data }\`). \`this._userData\` and \`_fetchUserRoles\` fallback return shape now have an extra \`id\` field. All consumers read specific fields (\`role\`, \`favorites\`, \`avatarUrl\`), not whole-object shape; the extra is additive.

2. Errors are wrapped by FirestoreService into generic \`Failed to fetch document\` etc. Logs lose \`error.code\` detail; control flow unaffected (existing catch blocks just log + fall back).

3. Input guards added: \`UserService.*\` methods throw \`'uid is required'\` for empty uid. Pure improvement vs raw \`doc(db, 'users', undefined)\` which silently writes to a doc named \`'undefined'\`.

## Test fix

\`loginWithGoogle should not create document for existing users\` test was mocking \`getDoc\` with \`{ exists: () => true }\` only. The new read path calls \`docSnap.data()\` and reads \`docSnap.id\` via \`FirestoreService.getDocument\` — those needed to exist on the mock. Added them. Other tests in the file already had complete docSnap shapes.

## Phase 2 acceptance

After this merges:

\`\`\`bash
grep -rn "Document('users'\\|arrayUnion\\|arrayRemove" src/ \\
  | grep -v src/js/services/users/
\`\`\`

Returns nothing. **Every \`users\` collection access in \`src/\` is now via \`UserService\`.**

## Adjacent bug found during smoke

#225 — \`updatePassword\` / \`linkWithGoogle\` / \`unlinkProvider\` lack try/catch + \`_handleAuthError\`, so raw \`FirebaseError\` reaches the UI instead of a localized message. Pre-existing; surfaced during PR-J4 smoke when changing password with the wrong current password.

## Verification

Manual smoke (touches the whole auth surface):

- [ ] Sign up with email/password → user doc created
- [ ] Sign in with Google as new user → user doc created. Sign in again → no duplicate.
- [ ] Sign in existing user → \`getUserData\` populates correctly
- [ ] Update profile → auth + user doc updated
- [ ] Delete account → user doc + auth user removed
- [ ] Role-gated UI (manager dashboard, grandma's docs) → still gates correctly
- [ ] Avatar URL renders correctly

Automated: 513 tests, lint, build all green.