### PR TITLE
refactor(meals): introduce ActiveMealService API + tests (PR-L)

### DIFF
--- a/src/js/services/meals/active-meal-service.js
+++ b/src/js/services/meals/active-meal-service.js
@@ -1,0 +1,202 @@
+// src/js/services/meals/active-meal-service.js
+
+import {
+  onSnapshot,
+  doc,
+  arrayUnion,
+  arrayRemove,
+  serverTimestamp,
+  deleteField,
+} from 'firebase/firestore';
+import { FirestoreService } from '../_firebase/firestore-service.js';
+import { getFirestoreInstance } from '../_firebase/firebase-service.js';
+
+const ACTIVE_MEALS_COLLECTION = 'active_meals';
+
+/**
+ * ActiveMealService — The Single Owner of `active_meals/{uid}`
+ *
+ * Owns all data access for the active-meal document — both CRUD
+ * operations and the real-time subscription that the /my-meal page
+ * relies on for live updates across tabs and devices.
+ *
+ * Public API:
+ *
+ *   CRUD (preserves return shape from the legacy ActiveMealUtils for
+ *   minimal caller churn — `{ success, reason?, error? }`):
+ *     - addToMeal(uid, recipeId)
+ *     - removeFromMeal(uid, recipeId)
+ *     - clearMeal(uid)
+ *     - switchRecipe(uid, recipeId)
+ *     - updateRecipeState(uid, recipeId, updates)
+ *
+ *   Real-time subscription:
+ *     - subscribe(uid, callback) → unsubscribe
+ *       Callback fires once immediately with the current meal data (or
+ *       null if the doc doesn't exist), then again on every write to
+ *       `active_meals/{uid}` from any source (this tab, another tab,
+ *       another device, a Cloud Function, etc.). Caller MUST hold the
+ *       returned unsubscribe and call it on cleanup to avoid leaking
+ *       the underlying WebSocket subscription.
+ */
+export class ActiveMealService {
+  /**
+   * Add a recipe to the user's active meal. Idempotent — adding the
+   * same recipe twice is a no-op (returns `duplicate` on the second
+   * attempt before any write).
+   *
+   * @param {string} uid
+   * @param {string} recipeId
+   * @returns {Promise<{ success: boolean, reason?: string, error?: any }>}
+   */
+  static async addToMeal(uid, recipeId) {
+    if (!uid || !recipeId) {
+      console.error('ActiveMealService.addToMeal: uid and recipeId are required');
+      return { success: false, reason: 'invalid_input' };
+    }
+
+    try {
+      // 1. Check for duplicates against the current doc state.
+      const existing = await FirestoreService.getDocument(ACTIVE_MEALS_COLLECTION, uid);
+      if (existing && Array.isArray(existing.recipeIds) && existing.recipeIds.includes(recipeId)) {
+        return { success: false, reason: 'duplicate' };
+      }
+
+      // 2. Create-or-update. setDoc with merge handles both cases atomically.
+      await FirestoreService.batchWrite([
+        {
+          type: 'set',
+          collection: ACTIVE_MEALS_COLLECTION,
+          id: uid,
+          data: {
+            recipeIds: arrayUnion(recipeId),
+            lastUpdated: serverTimestamp(),
+          },
+          options: { merge: true },
+        },
+      ]);
+
+      return { success: true };
+    } catch (error) {
+      console.error('ActiveMealService.addToMeal failed:', error);
+      return { success: false, reason: 'error', error };
+    }
+  }
+
+  /**
+   * Remove a recipe from the meal and clean up its per-recipe state.
+   *
+   * @param {string} uid
+   * @param {string} recipeId
+   * @returns {Promise<{ success: boolean, error?: any }>}
+   */
+  static async removeFromMeal(uid, recipeId) {
+    if (!uid || !recipeId) return { success: false, error: 'invalid_inputs' };
+
+    try {
+      await FirestoreService.updateDocument(ACTIVE_MEALS_COLLECTION, uid, {
+        recipeIds: arrayRemove(recipeId),
+        lastUpdated: serverTimestamp(),
+        [`recipeStates.${recipeId}`]: deleteField(),
+      });
+      return { success: true };
+    } catch (error) {
+      console.error('ActiveMealService.removeFromMeal failed:', error);
+      return { success: false, error };
+    }
+  }
+
+  /**
+   * Delete the entire active-meal doc for this user.
+   *
+   * @param {string} uid
+   * @returns {Promise<{ success: boolean, error?: any }>}
+   */
+  static async clearMeal(uid) {
+    if (!uid) return { success: false, error: 'invalid_user' };
+
+    try {
+      await FirestoreService.deleteDocument(ACTIVE_MEALS_COLLECTION, uid);
+      return { success: true };
+    } catch (error) {
+      console.error('ActiveMealService.clearMeal failed:', error);
+      return { success: false, error };
+    }
+  }
+
+  /**
+   * Switch the active recipe tab in the meal.
+   *
+   * @param {string} uid
+   * @param {string} recipeId
+   * @returns {Promise<{ success: boolean, error?: any }>}
+   */
+  static async switchRecipe(uid, recipeId) {
+    try {
+      await FirestoreService.updateDocument(ACTIVE_MEALS_COLLECTION, uid, {
+        activeRecipeId: recipeId,
+        lastUpdated: serverTimestamp(),
+      });
+      return { success: true };
+    } catch (error) {
+      console.error('ActiveMealService.switchRecipe failed:', error);
+      return { success: false, error };
+    }
+  }
+
+  /**
+   * Patch fields on a specific recipe's state inside the meal doc.
+   * Uses Firestore dot-notation so concurrent writes to OTHER recipes
+   * don't clobber each other.
+   *
+   * @param {string} uid
+   * @param {string} recipeId
+   * @param {Object} updates - e.g. `{ servings: 4, currentStep: 2 }`
+   * @returns {Promise<{ success: boolean, error?: any }>}
+   */
+  static async updateRecipeState(uid, recipeId, updates) {
+    try {
+      const flat = {};
+      Object.entries(updates).forEach(([key, value]) => {
+        flat[`recipeStates.${recipeId}.${key}`] = value;
+      });
+      flat.lastUpdated = serverTimestamp();
+
+      await FirestoreService.updateDocument(ACTIVE_MEALS_COLLECTION, uid, flat);
+      return { success: true };
+    } catch (error) {
+      console.error('ActiveMealService.updateRecipeState failed:', error);
+      return { success: false, error };
+    }
+  }
+
+  /**
+   * Subscribe to real-time updates on the user's active-meal doc.
+   *
+   * The callback fires once immediately with the doc's current state,
+   * then again on every write to `active_meals/{uid}`. When the doc
+   * doesn't exist, the callback is invoked with `null`.
+   *
+   * Synchronously returns an unsubscribe function. Callers MUST call
+   * the unsubscribe on cleanup (e.g., page unmount) to release the
+   * underlying Firestore listener. Forgetting to unsubscribe leaks
+   * the WebSocket subscription.
+   *
+   * @param {string} uid
+   * @param {(mealData: Object|null) => void} callback
+   * @returns {() => void} unsubscribe
+   */
+  static subscribe(uid, callback) {
+    if (!uid) throw new Error('ActiveMealService.subscribe: uid is required');
+    if (typeof callback !== 'function') {
+      throw new Error('ActiveMealService.subscribe: callback must be a function');
+    }
+    const db = getFirestoreInstance();
+    const docRef = doc(db, ACTIVE_MEALS_COLLECTION, uid);
+    return onSnapshot(docRef, (docSnap) => {
+      callback(docSnap.exists() ? docSnap.data() : null);
+    });
+  }
+}
+
+export const activeMealService = ActiveMealService;

--- a/tests/common/mocks/firebase-firestore.mock.js
+++ b/tests/common/mocks/firebase-firestore.mock.js
@@ -40,6 +40,11 @@ jest.unstable_mockModule('firebase/firestore', () => ({
   // sentinel objects.
   arrayUnion: jest.fn((...values) => ({ __op: 'arrayUnion', values })),
   arrayRemove: jest.fn((...values) => ({ __op: 'arrayRemove', values })),
+  deleteField: jest.fn(() => ({ __op: 'deleteField' })),
+  // Real-time listener. Tests inject behavior via `onSnapshot.mockImplementation`
+  // — typically capturing the listener arg and invoking it manually to simulate
+  // snapshot events.
+  onSnapshot: jest.fn(),
   getFirestore: jest.fn(() => 'mockFirestore'),
   getDocs: jest.fn(),
   addDoc: jest.fn(),

--- a/tests/js/services/active-meal-service.test.mjs
+++ b/tests/js/services/active-meal-service.test.mjs
@@ -1,0 +1,252 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let ActiveMealService;
+let onSnapshot;
+
+const firestoreMocks = {
+  getDocument: jest.fn(),
+  updateDocument: jest.fn(),
+  deleteDocument: jest.fn(),
+  batchWrite: jest.fn(),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset());
+  firestoreMocks.batchWrite.mockResolvedValue();
+  firestoreMocks.updateDocument.mockResolvedValue();
+  firestoreMocks.deleteDocument.mockResolvedValue();
+
+  ({ ActiveMealService } = await import('src/js/services/meals/active-meal-service.js'));
+  ({ onSnapshot } = await import('firebase/firestore'));
+  onSnapshot.mockReset();
+});
+
+describe('ActiveMealService — CRUD', () => {
+  describe('addToMeal', () => {
+    it('returns invalid_input when uid or recipeId missing', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      expect(await ActiveMealService.addToMeal('', 'r1')).toEqual({
+        success: false,
+        reason: 'invalid_input',
+      });
+      expect(await ActiveMealService.addToMeal('u1', '')).toEqual({
+        success: false,
+        reason: 'invalid_input',
+      });
+      errSpy.mockRestore();
+    });
+
+    it('returns duplicate when recipe is already in the meal', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        recipeIds: ['r1', 'r2'],
+      });
+
+      const result = await ActiveMealService.addToMeal('u1', 'r2');
+      expect(result).toEqual({ success: false, reason: 'duplicate' });
+      expect(firestoreMocks.batchWrite).not.toHaveBeenCalled();
+    });
+
+    it('writes a merge-set batch when recipe is new (or doc is empty)', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null); // doc not yet created
+
+      const result = await ActiveMealService.addToMeal('u1', 'r1');
+      expect(result).toEqual({ success: true });
+      expect(firestoreMocks.batchWrite).toHaveBeenCalledTimes(1);
+      const op = firestoreMocks.batchWrite.mock.calls[0][0][0];
+      expect(op.type).toBe('set');
+      expect(op.collection).toBe('active_meals');
+      expect(op.id).toBe('u1');
+      expect(op.options).toEqual({ merge: true });
+    });
+
+    it('returns error reason if Firestore throws', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ recipeIds: [] });
+      firestoreMocks.batchWrite.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await ActiveMealService.addToMeal('u1', 'r1');
+      expect(result.success).toBe(false);
+      expect(result.reason).toBe('error');
+      expect(result.error.message).toBe('boom');
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('removeFromMeal', () => {
+    it('returns invalid_inputs when uid or recipeId missing', async () => {
+      expect(await ActiveMealService.removeFromMeal('', 'r1')).toEqual({
+        success: false,
+        error: 'invalid_inputs',
+      });
+      expect(await ActiveMealService.removeFromMeal('u1', '')).toEqual({
+        success: false,
+        error: 'invalid_inputs',
+      });
+    });
+
+    it('issues an updateDocument with arrayRemove on recipeIds AND deleteField on recipeStates[recipeId]', async () => {
+      const result = await ActiveMealService.removeFromMeal('u1', 'r-a');
+      expect(result).toEqual({ success: true });
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledTimes(1);
+      const [collection, id, updates] = firestoreMocks.updateDocument.mock.calls[0];
+      expect(collection).toBe('active_meals');
+      expect(id).toBe('u1');
+      // The dot-notation key for the per-recipe state cleanup
+      expect(Object.keys(updates)).toContain('recipeStates.r-a');
+      expect('recipeIds' in updates).toBe(true);
+      expect('lastUpdated' in updates).toBe(true);
+    });
+  });
+
+  describe('clearMeal', () => {
+    it('returns invalid_user when uid is missing', async () => {
+      expect(await ActiveMealService.clearMeal('')).toEqual({
+        success: false,
+        error: 'invalid_user',
+      });
+    });
+
+    it('delegates to FirestoreService.deleteDocument', async () => {
+      const result = await ActiveMealService.clearMeal('u1');
+      expect(result).toEqual({ success: true });
+      expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('active_meals', 'u1');
+    });
+  });
+
+  describe('switchRecipe', () => {
+    it('writes activeRecipeId + lastUpdated', async () => {
+      const result = await ActiveMealService.switchRecipe('u1', 'r1');
+      expect(result).toEqual({ success: true });
+      const [collection, id, updates] = firestoreMocks.updateDocument.mock.calls[0];
+      expect(collection).toBe('active_meals');
+      expect(id).toBe('u1');
+      expect(updates.activeRecipeId).toBe('r1');
+      expect('lastUpdated' in updates).toBe(true);
+    });
+  });
+
+  describe('updateRecipeState', () => {
+    it('flattens updates into Firestore dot-notation under the right recipeId', async () => {
+      const result = await ActiveMealService.updateRecipeState('u1', 'r1', {
+        servings: 4,
+        currentStep: 2,
+      });
+      expect(result).toEqual({ success: true });
+      const [, , updates] = firestoreMocks.updateDocument.mock.calls[0];
+      expect(updates['recipeStates.r1.servings']).toBe(4);
+      expect(updates['recipeStates.r1.currentStep']).toBe(2);
+      expect('lastUpdated' in updates).toBe(true);
+    });
+
+    it('returns error shape on Firestore failure', async () => {
+      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await ActiveMealService.updateRecipeState('u1', 'r1', { foo: 1 });
+      expect(result.success).toBe(false);
+      expect(result.error.message).toBe('boom');
+      errSpy.mockRestore();
+    });
+  });
+});
+
+describe('ActiveMealService — subscribe()', () => {
+  it('throws when uid is missing', () => {
+    expect(() => ActiveMealService.subscribe('', () => {})).toThrow('uid is required');
+  });
+
+  it('throws when callback is not a function', () => {
+    expect(() => ActiveMealService.subscribe('u1', null)).toThrow('callback must be a function');
+    expect(() => ActiveMealService.subscribe('u1', 'not-a-fn')).toThrow(
+      'callback must be a function',
+    );
+  });
+
+  it('returns the unsubscribe function from onSnapshot', () => {
+    const fakeUnsub = jest.fn();
+    onSnapshot.mockReturnValue(fakeUnsub);
+
+    const unsub = ActiveMealService.subscribe('u1', () => {});
+    expect(unsub).toBe(fakeUnsub);
+  });
+
+  it('passes docSnap.data() to the callback when the doc exists', () => {
+    let captured;
+    onSnapshot.mockImplementation((_ref, listener) => {
+      // Simulate Firestore firing the snapshot listener with an exists=true snapshot
+      listener({
+        exists: () => true,
+        data: () => ({ recipeIds: ['r1'], activeRecipeId: 'r1' }),
+      });
+      return jest.fn();
+    });
+
+    ActiveMealService.subscribe('u1', (data) => {
+      captured = data;
+    });
+
+    expect(captured).toEqual({ recipeIds: ['r1'], activeRecipeId: 'r1' });
+  });
+
+  it('passes null to the callback when the doc does not exist', () => {
+    let captured = 'not-set';
+    onSnapshot.mockImplementation((_ref, listener) => {
+      listener({ exists: () => false });
+      return jest.fn();
+    });
+
+    ActiveMealService.subscribe('u1', (data) => {
+      captured = data;
+    });
+
+    expect(captured).toBeNull();
+  });
+
+  it('forwards every snapshot update to the callback (multiple calls)', () => {
+    const calls = [];
+    let savedListener;
+    onSnapshot.mockImplementation((_ref, listener) => {
+      savedListener = listener;
+      return jest.fn();
+    });
+
+    ActiveMealService.subscribe('u1', (data) => calls.push(data));
+
+    // First snapshot — doc didn't exist yet
+    savedListener({ exists: () => false });
+    // Then doc gets created — recipeIds gets populated
+    savedListener({
+      exists: () => true,
+      data: () => ({ recipeIds: ['r1'] }),
+    });
+    // Then another recipe is added
+    savedListener({
+      exists: () => true,
+      data: () => ({ recipeIds: ['r1', 'r2'] }),
+    });
+
+    expect(calls).toEqual([null, { recipeIds: ['r1'] }, { recipeIds: ['r1', 'r2'] }]);
+  });
+
+  it('after unsubscribe(), simulated subsequent snapshots are no longer relayed', () => {
+    // We can't truly assert "onSnapshot's underlying connection is torn down"
+    // without integration tests against Firestore. What we CAN verify is that
+    // the unsubscribe function we hand back is the same opaque fn onSnapshot
+    // returned — so calling it triggers Firestore's actual teardown.
+    const fakeUnsub = jest.fn();
+    onSnapshot.mockReturnValue(fakeUnsub);
+
+    const unsub = ActiveMealService.subscribe('u1', () => {});
+    expect(fakeUnsub).not.toHaveBeenCalled();
+    unsub();
+    expect(fakeUnsub).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
First sub-PR of Phase 4 in the service-layer refactor umbrella (#211). Adds the \`ActiveMealService\` API as the single public entry point for \`active_meals/{uid}\` access — both CRUD and the real-time subscription.

**No callers migrated yet** — PR-M handles that.

## Public API

CRUD (names + \`{success, reason?, error?}\` return shapes mirror legacy \`ActiveMealUtils\` for clean PR-M migration):

\`\`\`js
ActiveMealService.addToMeal(uid, recipeId)
ActiveMealService.removeFromMeal(uid, recipeId)
ActiveMealService.clearMeal(uid)
ActiveMealService.switchRecipe(uid, recipeId)
ActiveMealService.updateRecipeState(uid, recipeId, updates)
\`\`\`

Real-time:

\`\`\`js
const unsubscribe = ActiveMealService.subscribe(uid, (mealData /* | null */) => { ... });
// later: unsubscribe();
\`\`\`

The subscribe wraps Firestore's \`onSnapshot\`. Fires once immediately with current state (or \`null\` if doc missing), then again on every write to \`active_meals/{uid}\` from any source (this tab, another tab, another device, Cloud Function).

**Caller MUST hold the returned unsubscribe and call it on cleanup** or the underlying WebSocket leaks.

Throws on missing uid / non-function callback.

## Tests (18 cases — \`tests/js/services/active-meal-service.test.mjs\`)

**CRUD coverage:**
- \`addToMeal\` — invalid input / duplicate / first-add merge-set / Firestore error
- \`removeFromMeal\` — invalid input / arrayRemove + deleteField composition
- \`clearMeal\` — invalid input / delete delegation
- \`switchRecipe\` — activeRecipeId + lastUpdated written
- \`updateRecipeState\` — dot-notation flattening / error-path

**Subscribe (the trickiest semantics):**
- Throws on missing uid / non-function callback
- Returns \`onSnapshot\`'s unsubscribe fn (ref-equality verified)
- Callback receives \`docSnap.data()\` when doc exists
- Callback receives \`null\` when doc doesn't exist
- Multiple snapshot updates all reach the callback in order
- Calling our unsubscribe invokes Firestore's underlying unsubscribe

## Central mock additions

\`tests/common/mocks/firebase-firestore.mock.js\` gains \`onSnapshot\` and \`deleteField\` (additive — no existing tests affected).

## Suite

531 passing. Lint + build clean.

## What's left in Phase 4

**PR-M** — migrate callers:
- \`my-meal-page.js\`: raw \`onSnapshot\` (line 80) → \`ActiveMealService.subscribe\`; 8 \`ActiveMealUtils\` dynamic-import call sites → direct \`ActiveMealService.*\` calls
- \`recipe-detail-page.js\`: \`ActiveMealUtils.addToMeal\` → \`ActiveMealService.addToMeal\`
- \`recipe-card.js\`: same pattern
- Delete \`src/js/utils/active-meal-utils.js\`