### PR TITLE
refactor(recipes): route preview-modal approval through RecipeService

### DIFF
--- a/src/app/pages/recipe-detail-page.js
+++ b/src/app/pages/recipe-detail-page.js
@@ -1,6 +1,5 @@
 import { AppConfig } from '../../js/config/app-config.js';
 import authService from '../../js/services/auth/auth-service.js';
-import { firestoreService } from '../../js/services/_firebase/firestore-service.js';
 import { ActiveMealService } from '../../js/services/meals/active-meal-service.js';
 import '../../styles/pages/recipe-detail-spa.css';
 

--- a/src/lib/recipes/recipe_preview_modal/recipe_preview_modal.js
+++ b/src/lib/recipes/recipe_preview_modal/recipe_preview_modal.js
@@ -47,7 +47,6 @@
  * Dependencies:
  * - This component relies on the `custom-modal` and `recipe-component` components.
  */
-import { FirestoreService } from '../../../js/services/_firebase/firestore-service.js';
 import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 
 import '../recipe_component/recipe_component.js';
@@ -265,7 +264,7 @@ class RecipePreviewModal extends HTMLElement {
   }
 
   async handleRecipeApproval(recipeId) {
-    await FirestoreService.updateDocument('recipes', recipeId, { approved: true });
+    await RecipeService.update(recipeId, { approved: true });
   }
 
   async handleRecipeRejection(recipeId) {


### PR DESCRIPTION
## Summary
- Migrate `recipe_preview_modal.handleRecipeApproval` from a direct `FirestoreService.updateDocument('recipes', recipeId, { approved: true })` call to `RecipeService.update(recipeId, { approved: true })`, leveraging the service's PATCH semantics (only the `approved` flag is written, images/media untouched).
- Drop a dead `firestoreService` import in `recipe-detail-page.js` left over from PR-J4.

This removes two of the few remaining non-service-layer touches of `FirestoreService` before Phase 6's ESLint rule lands.

## Test plan
- [ ] Open a pending recipe via manager dashboard preview modal; click "Approve" → recipe transitions to approved, images/media untouched
- [ ] Reject path still works (was already on `RecipeService.delete`)
- [ ] `npm run lint && npm test && npm run build` clean

Part of the service-layer refactor umbrella (#211).