### PR TITLE
refactor(admin): introduce FailedUrlExtractionService (PR-N)

### DIFF
--- a/src/app/pages/manager-dashboard-page.js
+++ b/src/app/pages/manager-dashboard-page.js
@@ -1,4 +1,4 @@
-import { FirestoreService } from '../../js/services/_firebase/firestore-service.js';
+import { FailedUrlExtractionService } from '../../js/services/admin/failed-url-extraction-service.js';
 import { RecipeService } from '../../js/services/recipes/recipe-service.js';
 import { UserService } from '../../js/services/users/user-service.js';
 import authService from '../../js/services/auth/auth-service.js';
@@ -717,9 +717,7 @@ export default {
     const noItemsMessage = failedUrlsSection.querySelector('.no-items-message');
 
     try {
-      const failedUrls = await FirestoreService.queryDocuments('failed_url_extractions', {
-        orderBy: ['lastAttempt', 'desc'],
-      });
+      const failedUrls = await FailedUrlExtractionService.list();
 
       const items = failedUrls.map((item) => ({
         header: this.createFailedUrlHeader(item),
@@ -878,7 +876,7 @@ export default {
       async () => {
         try {
           this.toggleLoading(true);
-          await FirestoreService.deleteDocument('failed_url_extractions', id);
+          await FailedUrlExtractionService.delete(id);
           this.loadFailedUrls();
           this.showSuccess('הרשומה נמחקה בהצלחה');
         } catch (error) {

--- a/src/js/services/admin/failed-url-extraction-service.js
+++ b/src/js/services/admin/failed-url-extraction-service.js
@@ -1,0 +1,45 @@
+// src/js/services/admin/failed-url-extraction-service.js
+
+import { FirestoreService } from '../_firebase/firestore-service.js';
+
+const FAILED_URL_EXTRACTIONS_COLLECTION = 'failed_url_extractions';
+
+/**
+ * FailedUrlExtractionService — The Single Owner of `failed_url_extractions`
+ *
+ * Owns frontend access to the `failed_url_extractions` collection. The
+ * collection itself is populated server-side by Cloud Functions when a
+ * recipe URL extraction fails (see `functions/index.js`); this service
+ * only handles the manager-dashboard read + delete surface.
+ *
+ * Public API:
+ *   - list() — most-recent first, by `lastAttempt` desc.
+ *   - delete(id)
+ */
+export class FailedUrlExtractionService {
+  /**
+   * List all failed URL extraction records, most recent first.
+   *
+   * @returns {Promise<Array<Object>>}
+   */
+  static async list() {
+    return FirestoreService.queryDocuments(FAILED_URL_EXTRACTIONS_COLLECTION, {
+      orderBy: ['lastAttempt', 'desc'],
+    });
+  }
+
+  /**
+   * Delete a single failed URL extraction record by ID.
+   *
+   * @param {string} id
+   * @returns {Promise<void>}
+   */
+  static async delete(id) {
+    if (!id) {
+      throw new Error('FailedUrlExtractionService.delete: id is required');
+    }
+    return FirestoreService.deleteDocument(FAILED_URL_EXTRACTIONS_COLLECTION, id);
+  }
+}
+
+export const failedUrlExtractionService = FailedUrlExtractionService;

--- a/tests/js/services/failed-url-extraction-service.test.mjs
+++ b/tests/js/services/failed-url-extraction-service.test.mjs
@@ -1,0 +1,77 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let FailedUrlExtractionService;
+
+const firestoreMocks = {
+  queryDocuments: jest.fn(),
+  deleteDocument: jest.fn(),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset());
+  firestoreMocks.deleteDocument.mockResolvedValue();
+
+  ({ FailedUrlExtractionService } = await import(
+    'src/js/services/admin/failed-url-extraction-service.js'
+  ));
+});
+
+describe('FailedUrlExtractionService.list', () => {
+  it('queries the failed_url_extractions collection ordered by lastAttempt desc', async () => {
+    firestoreMocks.queryDocuments.mockResolvedValue([
+      { id: 'a', url: 'https://example.com/1', lastAttempt: 100 },
+      { id: 'b', url: 'https://example.com/2', lastAttempt: 50 },
+    ]);
+
+    const result = await FailedUrlExtractionService.list();
+
+    expect(firestoreMocks.queryDocuments).toHaveBeenCalledTimes(1);
+    const [collection, params] = firestoreMocks.queryDocuments.mock.calls[0];
+    expect(collection).toBe('failed_url_extractions');
+    expect(params).toEqual({ orderBy: ['lastAttempt', 'desc'] });
+    expect(result).toEqual([
+      { id: 'a', url: 'https://example.com/1', lastAttempt: 100 },
+      { id: 'b', url: 'https://example.com/2', lastAttempt: 50 },
+    ]);
+  });
+
+  it('returns an empty array when no records exist', async () => {
+    firestoreMocks.queryDocuments.mockResolvedValue([]);
+    expect(await FailedUrlExtractionService.list()).toEqual([]);
+  });
+
+  it('propagates Firestore errors', async () => {
+    firestoreMocks.queryDocuments.mockRejectedValue(new Error('boom'));
+    await expect(FailedUrlExtractionService.list()).rejects.toThrow('boom');
+  });
+});
+
+describe('FailedUrlExtractionService.delete', () => {
+  it('throws when id is missing', async () => {
+    await expect(FailedUrlExtractionService.delete('')).rejects.toThrow('id is required');
+    await expect(FailedUrlExtractionService.delete(undefined)).rejects.toThrow('id is required');
+    expect(firestoreMocks.deleteDocument).not.toHaveBeenCalled();
+  });
+
+  it('delegates to FirestoreService.deleteDocument on the right collection + id', async () => {
+    await FailedUrlExtractionService.delete('record-123');
+    expect(firestoreMocks.deleteDocument).toHaveBeenCalledTimes(1);
+    expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith(
+      'failed_url_extractions',
+      'record-123',
+    );
+  });
+
+  it('propagates Firestore errors', async () => {
+    firestoreMocks.deleteDocument.mockRejectedValue(new Error('nope'));
+    await expect(FailedUrlExtractionService.delete('record-123')).rejects.toThrow('nope');
+  });
+});


### PR DESCRIPTION
## Summary
- New `FailedUrlExtractionService` (in `src/js/services/admin/`) owns frontend access to the `failed_url_extractions` collection. The collection is populated server-side by Cloud Functions on extraction failures; this service only handles the manager-dashboard read + delete surface.
- 6 tests, 100% coverage of the new service.
- `manager-dashboard-page.js` drops its `FirestoreService` import and routes both `failed_url_extractions` sites through the new service.

Closes Phase 5 of the umbrella (#211).

## Test plan
- [ ] Manager dashboard → "Failed URLs" section loads records ordered by `lastAttempt` desc
- [ ] Delete confirmation → record is removed from Firestore and the list refreshes
- [ ] `npm run lint && npm test && npm run build` clean