### PR TITLE
refactor(users): UserService.listAvatarOptions + component-storage cleanup (PR-O1)

### DIFF
--- a/docs/feature-plans/service-layer-umbrella-completion.md
+++ b/docs/feature-plans/service-layer-umbrella-completion.md
@@ -1,0 +1,330 @@
+# Plan: service-layer umbrella — completion (revised)
+
+This plan supersedes the earlier "Phase 7 follow-up umbrella" framing. All work below lands inside the current `refactor/service-layer` umbrella (#211) **before** the umbrella merges to `development`. There is no follow-up umbrella.
+
+## Why this revision
+
+After Phase 5 we identified that the planned ESLint exemption for `src/js/utils/recipes/**` would hide two structural problems we want eliminated, not deferred:
+
+1. **Three utils files mix pure helpers with data-access code.** Writes (uploads, deletes, Firestore updates) live alongside formatters and validators. The convention says writes belong in services.
+2. **One method has two homes.** `setPrimaryImage` exists on `RecipeImageService` (as a thin pass-through) and in `recipe-image-utils.js` (real implementation). The umbrella's stated goal is one canonical home per operation.
+
+The umbrella's premise has always been "services own all data access." Shipping with an exemption + a duplicate would undercut that promise. This revision finishes the job in the same umbrella.
+
+## Three goals (load-bearing for umbrella merge)
+
+1. **Service layer is the only data-access API.** No file outside `src/js/services/**` imports `_firebase/firestore-service.js`, `_firebase/storage-service.js`, or raw Firebase SDKs (`firebase/firestore`, `firebase/storage`, `firebase/auth`). Enforced by a strict ESLint rule with **no exemptions**.
+2. **Every operation has one canonical home.** No method exists on two services, and no service method is a thin pass-through to a utils function. The utils function either becomes the service method, or it goes away.
+3. **Utils contain only pure helpers.** Synchronous, no `await`, no service or SDK imports. Acceptable shapes: formatters, validators, ID generators, in-memory transformations, constants.
+
+## End state — acceptance criteria for umbrella merge
+
+- `npm run lint` passes with the strict `no-restricted-imports` rule (no exemptions, no `eslint-disable` overrides).
+- `grep -r "FirestoreService\|StorageService\|firebase/firestore\|firebase/storage\|firebase/auth" src/ --include="*.js"` shows imports only inside `src/js/services/**`.
+- `src/js/utils/recipes/recipe-image-utils.js`, `recipe-media-utils.js`, `recipe-data-utils.js` contain only pure helpers (no `await`, no service/SDK imports).
+- Every public service method is defined exactly once across the service layer (audit script in PR-Q0).
+- `gh issue close 215` (the read-helper exemption question is moot).
+- Full smoke walkthrough passes (list at the end of this plan).
+
+## Branching
+
+All sub-PRs land directly on `refactor/service-layer`. No nested sub-umbrella.
+
+```
+development
+└── refactor/service-layer (#211 umbrella, in-flight)
+    ├── refactor/component-storage-cleanup        (PR-O1 — currently staged, uncommitted)
+    ├── refactor/service-dedupe-audit             (PR-Q0)
+    ├── refactor/recipe-image-writes-into-service (PR-Q1a — recipe-image writes)
+    ├── refactor/recipe-image-proposal-inline     (PR-Q1b — proposal: inline existing pass-throughs)
+    ├── refactor/media-instruction-service        (PR-Q1c — new domain: writes + URL + caller)
+    ├── refactor/recipe-image-urls-into-service   (PR-Q2  — recipe-image URL helpers)
+    ├── refactor/recipe-service-passthroughs      (PR-Q3  — getRecipeById/getRecipesForCards)
+    └── refactor/service-layer-eslint             (PR-O2  — strict rule, no exemptions)
+```
+
+One sub-PR at a time. Each merges into `refactor/service-layer` before the next one branches off. After PR-O2, the umbrella merges to `development`.
+
+**Sub-PR sizing principle**: each PR touches one domain and one concern. Recipe-image writes (Q1a) is separate from recipe-image-proposal (Q1b) is separate from media-instructions (Q1c) is separate from recipe-image URL reads (Q2) — even though three of them touch the same utils file. Smaller PRs make review and rollback predictable.
+
+## Sub-PR sequence
+
+### PR-O1 — Component storage cleanup (currently staged, uncommitted)
+
+**What ships now (final-state code):**
+
+- `UserService.listAvatarOptions()` — new service method covering the avatar grid Storage read.
+- `user-profile.js` migrated to use it; drops direct `StorageService` + `firebase/storage` imports.
+- Test mocks updated (`auth-service.test.mjs`, `favorites-service.test.mjs`) for UserService's new StorageService dependency.
+
+**What is temporarily-routed-through-utils (will be unwound in PR-Q2):**
+
+- `ai-image-enhance-modal.js` and `image-carousel.js` switched from direct `StorageService.getFileUrl(path)` to the existing utils helper `getImageUrl(path)`. This moves the violation rather than fixing it — PR-Q2 will route both through `RecipeImageService` with proper domain typing.
+
+Ship as one commit, merge into umbrella, then proceed.
+
+---
+
+### PR-Q0 — Service de-duplication audit + canonical-home decisions
+
+A small, surgical PR that hardens the dedupe goal before the bigger moves.
+
+**Audit step:**
+
+- Enumerate every public static method across `src/js/services/**`.
+- Identify duplicates by name across services, AND service methods that are thin wrappers over a utils export (the `setPrimaryImage` shape).
+
+**Known going in (verified by reading the service files):**
+
+| Service method                           | Status today                                         | Resolution PR                             |
+| ---------------------------------------- | ---------------------------------------------------- | ----------------------------------------- |
+| `RecipeImageService.setPrimaryImage`     | thin pass-through to utils `setPrimaryImage`         | PR-Q1a (inline impl, delete utils export) |
+| `RecipeImageProposalService.propose`     | thin pass-through to utils `addPendingImages`        | PR-Q1b (inline)                           |
+| `RecipeImageProposalService.approve`     | thin pass-through to utils `approvePendingImageById` | PR-Q1b (inline)                           |
+| `RecipeImageProposalService.reject`      | thin pass-through to utils `rejectPendingImageById`  | PR-Q1b (inline)                           |
+| `RecipeImageProposalService.listPending` | thin pass-through to utils `getPendingImages`        | PR-Q1b (inline)                           |
+
+**Cross-service duplicates today: none.** Confirmed by inspecting all public static methods across `RecipeService`, `RecipeImageService`, `RecipeImageProposalService`. The five rows above are utils ↔ service pass-throughs, not service ↔ service duplicates.
+
+**Add to plan from audit:**
+
+- Any other duplicates surfaced go into either PR-Q0 (if simple) or are inlined as additional moves in PR-Q1a/b/c.
+
+**Acceptance:**
+
+- A single-method audit script (e.g. `scripts/audit-service-methods.sh`) committed for use in PR-O2's CI guard. The script prints every public service method; CI assertion: every name appears once. (Or: bake the assertion directly into the ESLint rule via `no-restricted-syntax` patterns — TBD in PR.)
+- Audit findings folded into PR-Q1a/b/c scope where applicable.
+
+---
+
+### PR-Q1a — Recipe-image writes leave utils → `RecipeImageService`
+
+Move every write-side function specific to **approved** recipe images from `recipe-image-utils.js` into `RecipeImageService`. Proposal-side writes are PR-Q1b. Media-instruction writes are PR-Q1c.
+
+**Functions to move:**
+
+| Utils export                                                        | Resolution                                                                                                                                                                                                  |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `setPrimaryImage(recipeId, imageId)`                                | Inline the body into `RecipeImageService.setPrimaryImage` (the existing pass-through is replaced with the real impl). Delete the utils export and the `setPrimaryImageInternal` import in the service file. |
+| `deleteImageFiles({ full })`                                        | Move into the service file. Default to public static `RecipeImageService.deleteFiles(image)`. If no external callers remain after PR-Q1a/b/c, downgrade to module-private.                                  |
+| `removeAllRecipeImages(recipeId)`                                   | → `RecipeImageService.removeAllForRecipe(recipeId)`                                                                                                                                                         |
+| `migrateImageToCategory(image, recipeId, oldCategory, newCategory)` | → `RecipeImageService.migrateToCategory(...)`                                                                                                                                                               |
+| `uploadAndBuildImageMetadata({...})`                                | → `RecipeImageService.uploadAndBuildMetadata(...)`                                                                                                                                                          |
+
+**No new methods added beyond `RecipeImageService.deleteFiles` / `removeAllForRecipe` / `migrateToCategory` / `uploadAndBuildMetadata`.** `setPrimaryImage` is consolidated, not added.
+
+**Caller updates:**
+
+- `recipe-service.js` — internal calls switch from utils to `RecipeImageService.*`.
+
+**Out of scope for Q1a:** proposal-side writes (Q1b), media-instructions (Q1c), URL helpers (Q2).
+
+**Acceptance:**
+
+- These 5 exports gone from `recipe-image-utils.js`.
+- `setPrimaryImage` exists once (in `RecipeImageService`).
+- Existing `recipe-service.test.mjs` covers `recipe-service.js` callers. Add tests for new public methods on `RecipeImageService` if not already covered by existing service tests.
+- All gates green.
+
+---
+
+### PR-Q1b — Recipe-image-proposal: inline the existing pass-throughs
+
+`RecipeImageProposalService` already has the full public API (`propose`, `approve`, `reject`, `listPending`). Each method today is a 1-line pass-through to a utils function. **This PR adds zero new methods.** It only inlines the implementations and deletes the utils exports.
+
+**Inlines:**
+
+| Service method (existing)                | Utils impl to inline + delete                           |
+| ---------------------------------------- | ------------------------------------------------------- |
+| `RecipeImageProposalService.propose`     | `addPendingImages(recipeId, files, category, uploader)` |
+| `RecipeImageProposalService.approve`     | `approvePendingImageById(recipeId, pendingImageId)`     |
+| `RecipeImageProposalService.reject`      | `rejectPendingImageById(recipeId, pendingImageId)`      |
+| `RecipeImageProposalService.listPending` | `getPendingImages(recipeId)`                            |
+
+**No public surface change.** No callers update. The utils file shrinks by 4 exports.
+
+**Out of scope:** anything beyond these 4 inlines. If one of the utils impls calls another utils function moved in Q1a, the service method imports from the new `RecipeImageService` location — straightforward dependency reshuffle inside the service folder.
+
+**Acceptance:**
+
+- 4 exports gone from `recipe-image-utils.js`.
+- `RecipeImageProposalService` has the same 4 public methods, now with inline bodies (no utils imports).
+- Existing tests still pass — surface didn't change.
+
+---
+
+### PR-Q1c — `MediaInstructionService`: whole new domain in one PR
+
+Media instructions are a self-contained domain (cooking-step videos/images attached to a recipe). The 4 writes + 1 URL read + the single lib-component caller all migrate together. Putting writes + URL + caller in one PR keeps the new service's birth coherent.
+
+**Create `src/js/services/recipes/media-instruction-service.js`:**
+
+| Method                                                               | Replaces utils function            |
+| -------------------------------------------------------------------- | ---------------------------------- |
+| `MediaInstructionService.upload(file, recipeId, userId, onProgress)` | `uploadMediaInstructionFile(...)`  |
+| `MediaInstructionService.delete(filePath)`                           | `deleteMediaInstructionFile(...)`  |
+| `MediaInstructionService.deleteMany(filePaths)`                      | `deleteMediaInstructionFiles(...)` |
+| `MediaInstructionService.removeAll(mediaInstructions)`               | `removeAllMediaInstructions(...)`  |
+| `MediaInstructionService.getUrl(storagePath)`                        | `getMediaInstructionUrl(...)`      |
+
+5 public methods total. `getUrl` takes a string — explicitly noted: media-instruction storage paths ARE the domain identifier (there's no richer object to type against, unlike `RecipeImage`); the input string is a typed domain reference, not a generic Storage path.
+
+**Caller updates:**
+
+- `src/js/services/recipes/recipe-service.js` — `recipe-service.js`'s internal `uploadMediaItems` helper currently calls the utils functions; swap to `MediaInstructionService.*`.
+- `src/lib/media/media-instructions-editor/media-instructions-editor.js` — only lib-component caller. Migrate to `MediaInstructionService` for both writes and the URL read.
+
+**Acceptance:**
+
+- All 5 media-instruction exports gone from `recipe-media-utils.js` → file now contains only its 3 pure helpers.
+- New `MediaInstructionService` ships with its own test file (`tests/js/services/media-instruction-service.test.mjs`).
+- All gates green.
+
+---
+
+### PR-Q2 — Recipe-image URL helpers → `RecipeImageService` (with domain typing)
+
+The component-callsite-heavy PR. Moves the 3 recipe-image URL helpers into `RecipeImageService`, with the load-bearing constraint that service methods take **recipe-image-typed inputs** (RecipeImage / recipe objects), not arbitrary storage paths.
+
+**Moves:**
+
+| Utils export                        | New service method                                | Notes                                           |
+| ----------------------------------- | ------------------------------------------------- | ----------------------------------------------- |
+| `getOptimizedImageUrl(image, size)` | `RecipeImageService.getOptimizedUrl(image, size)` | Already takes a `RecipeImage`; mechanical move. |
+| `getPrimaryImageUrl(recipe, size)`  | `RecipeImageService.getPrimaryUrl(recipe, size)`  | Already takes a recipe; mechanical move.        |
+| `getImageUrl(storagePath)`          | `RecipeImageService.getFullUrl(image)`            | **Signature change** — see below.               |
+
+**Signature change for `getImageUrl`:**
+The current `getImageUrl(string)` is a generic Storage URL resolver. Migrating as-is would erode `RecipeImageService`'s domain boundary (avatars / PDFs / etc. would creep onto a recipe-image service). The new method is `RecipeImageService.getFullUrl(image)` where `image: RecipeImage`; the method resolves `image.full` internally. Both current callers update:
+
+- `ai-image-enhance-modal.js`: already has `this._image`; passes the object instead of `this._image.full`. Also unwinds PR-O1's `getImageUrl` import.
+- `image-carousel.js`: the legacy `typeof image === 'string' && image.startsWith('img/recipes/')` branch normalizes `string → { full: string }` at the carousel level before the service call. Also unwinds PR-O1's `getImageUrl` import.
+
+**Caller updates (7 component/page files — recipe-image only):**
+
+- `src/lib/recipes/recipe-card/recipe-card.js`
+- `src/lib/recipes/recipe_component/recipe_component.js`
+- `src/lib/recipes/recipe_form_component/recipe_form_component.js`
+- `src/lib/media/image-carousel/image-carousel.js`
+- `src/lib/media/ai-image-enhancer/ai-image-enhancer.js`
+- `src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js`
+- `src/lib/modals/image-approval-multi/image-approval-multi.js`
+
+(Media-instruction URL caller is NOT in this PR — `media-instructions-editor.js`'s URL call already migrated to `MediaInstructionService.getUrl` in PR-Q1c.)
+
+**Acceptance:**
+
+- These 3 exports gone from `recipe-image-utils.js` → file now contains only its 6 pure helpers.
+- No method on `RecipeImageService` accepts an arbitrary storage-path string (audit by grep for `string.*path` in service signatures).
+- PR-O1's temporary `getImageUrl` import in `ai-image-enhance-modal.js` and `image-carousel.js` is unwound.
+- All gates green.
+
+---
+
+### PR-Q3 — Thin read passthroughs deleted
+
+`getRecipeById(id)` and `getRecipesForCards(opts)` in `recipe-data-utils.js` are thin duplicates of `RecipeService.get(id)` / `RecipeService.list(opts)`. **Pre-flight audit** confirms signature compatibility:
+
+```bash
+grep -rn "getRecipeById\|getRecipesForCards" src/ --include="*.js"
+```
+
+Any caller that relies on a utils-specific behavior (default sort, error swallow, field projection) gets that behavior pushed onto `RecipeService` first, then the passthrough is deleted.
+
+**Caller updates (5 files):**
+
+- `src/app/pages/my-meal-page.js`
+- `src/lib/recipes/recipe-card/recipe-card.js`
+- `src/lib/recipes/recipe_component/recipe_component.js`
+- `src/lib/recipes/recipe_form_component/parts/recipe-related-field.js`
+- `src/lib/media/image-proposal-modal/image-proposal-modal.js`
+
+**Acceptance:**
+
+- `recipe-data-utils.js` retains only its 10 pure helpers (constants, formatters, validators).
+- `RecipeService.get` / `RecipeService.list` are the only entry points to recipes-collection reads.
+- All gates green.
+
+---
+
+### PR-O2 — Strict ESLint rule, no exemptions
+
+The convention enforcer. Adds `no-restricted-imports` to the ESLint config with this shape:
+
+```js
+// .eslintrc — applied to all .js/.mjs files NOT under src/js/services/
+{
+  files: ['src/**/*.js', '!src/js/services/**/*.js'],
+  rules: {
+    'no-restricted-imports': ['error', {
+      patterns: [
+        { group: ['**/_firebase/firestore-service*'], message: 'Use a domain service.' },
+        { group: ['**/_firebase/storage-service*'],   message: 'Use a domain service.' },
+        { group: ['firebase/firestore', 'firebase/storage', 'firebase/auth'],
+          message: 'Raw Firebase SDKs only inside src/js/services/**.' },
+      ],
+    }],
+  },
+}
+```
+
+Optionally, also add a `no-restricted-syntax` rule (or a custom audit step) that fails CI if a service method name appears on two services (uses the audit script from PR-Q0).
+
+**Acceptance:**
+
+- `npm run lint` passes with zero exemptions and zero `eslint-disable` overrides.
+- `gh issue close 215` (the read-helper exemption question is resolved by elimination).
+- All gates green.
+
+---
+
+## Risks
+
+| PR  | Risk                                                                               | Mitigation                                                                                                                                                  |
+| --- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| O1  | Avatar grid breaks                                                                 | Manual smoke: open user profile, change avatar                                                                                                              |
+| Q0  | Audit misses a duplicate                                                           | Grep for static method names; run script in CI before umbrella merge                                                                                        |
+| Q1a | Behavior change in moved recipe-image writes                                       | Existing `recipe-service.test.mjs` covers most paths. Add inline tests for new public methods if not covered. Smoke recipe propose/edit/delete after merge. |
+| Q1a | `setPrimaryImage` consolidation breaks `image-approval-multi.js` calls             | That file already calls `RecipeImageService.setPrimaryImage` — only the impl changes. Smoke: manager approve+primary flow.                                  |
+| Q1b | Inline introduces subtle bug in propose/approve/reject flows                       | Proposal-service test should already exist (added in PR-A); rerun. Smoke: end-user propose → manager approve.                                               |
+| Q1c | New service breaks media-instructions editor                                       | New service tests + manual smoke: add a media instruction (video upload, image), delete one, edit category (triggers `removeAll`).                          |
+| Q2  | 7 components break simultaneously                                                  | Single squashed commit so revert is one-shot. Smoke list below.                                                                                             |
+| Q2  | `image-carousel` legacy string-path branch behaves differently after normalization | Carousel smoke specifically: recipes with old string-path images if any exist in dev data.                                                                  |
+| Q3  | A passthrough caller relied on a util-specific behavior                            | Pre-flight signature audit before opening the PR.                                                                                                           |
+| O2  | ESLint rule too aggressive, blocks legitimate service-internal call                | Service files explicitly excluded from the restriction by file pattern.                                                                                     |
+
+## Open questions (settle before opening the relevant PR)
+
+1. **PR-Q1a — public vs module-private moved helpers.** E.g. `migrateImageToCategory` is service-internal only — public static method (`RecipeImageService.migrateToCategory`) or module-scoped (`_migrateToCategory`)? Default: public for testability, unless truly private to one service.
+2. **PR-Q2 — image-carousel legacy string branch.** Normalize at the carousel callsite, normalize upstream in the data layer, or retire the branch entirely? Resolve in PR-Q2 by surveying whether any current data actually triggers that branch.
+3. **PR-Q3 — signature divergence check.** Pre-flight audit of every caller of `getRecipeById` / `getRecipesForCards` to confirm `RecipeService.get` / `list` is a drop-in replacement. If not, plan an extra PR.
+4. **PR-O2 — dedupe enforcement in lint or via script.** Whether the "one canonical home per method" rule lives in ESLint config (`no-restricted-syntax`) or as a standalone audit script run in pre-commit. Both work; pick one in PR-O2 design.
+
+The earlier "`addPendingImages` vs `propose` semantic split" question is removed — confirmed by reading the service that `propose` IS the `addPendingImages` pass-through, so PR-Q1b is purely inlining, no naming decision needed.
+
+## Service method naming convention
+
+All new methods follow **verb-first** naming to match existing services (`get`, `list`, `create`, `update`, `delete`, `addToArrayField`, `removeFromArrayField`, `listPending`, `subscribe`, `setPrimaryImage`, `replaceImage`):
+
+- URL reads: `getFullUrl`, `getOptimizedUrl`, `getPrimaryUrl`, `getUrl` (on `MediaInstructionService`)
+- Storage writes: `deleteFiles`, `removeAllForRecipe`, `migrateToCategory`, `uploadAndBuildMetadata`, `upload`, `delete`, `deleteMany`, `removeAll`
+- Proposal lifecycle: `add`, `approve`, `reject`, `listPending`, `propose`
+
+If a name collides with an existing method, rename the new one to something more specific rather than overload.
+
+## Final smoke walkthrough (before umbrella → development)
+
+Run on `refactor/service-layer` after PR-O2 merges, before opening the umbrella → development PR:
+
+1. **Recipe display**: home, categories, recipe-detail — images render (full, optimized, primary URL paths exercised)
+2. **My meal**: add recipes, switch tabs, change servings, remove, clear meal; cross-tab/device live sync
+3. **Recipe propose/edit/delete**: create with images + media instructions; edit (change category, replace image, remove media); delete
+4. **Image proposal flow** (manager): propose images as approved user → approve/reject as manager → primary image selection
+5. **AI image enhance**: open enhance modal → enhance → save (before-image URL via `getFullUrl`; after-image save)
+6. **Image carousel**: legacy string-path recipes (if any exist in dev data) — confirm normalization works
+7. **Manager dashboard**: pending recipes, user role admin, failed URL extractions
+8. **Auth + profile**: sign in (Google + email/password), open profile, change avatar, password reset
+9. **Favorites**: add/remove favorites; persists across reload
+10. `npm run lint && npm run format -- --check && npm test && npm run build`
+
+Open the umbrella PR with `Fixes #211` and `Fixes #215`.

--- a/src/js/services/users/user-service.js
+++ b/src/js/services/users/user-service.js
@@ -2,8 +2,10 @@
 
 import { arrayUnion, arrayRemove } from 'firebase/firestore';
 import { FirestoreService } from '../_firebase/firestore-service.js';
+import { StorageService } from '../_firebase/storage-service.js';
 
 const USERS_COLLECTION = 'users';
+const AVATAR_OPTIONS_PATH = 'Avatars';
 
 /**
  * UserService — The Single Owner of `users/{uid}`
@@ -25,6 +27,7 @@ const USERS_COLLECTION = 'users';
  *   - delete(uid)
  *   - addToArrayField(uid, field, value)
  *   - removeFromArrayField(uid, field, value)
+ *   - listAvatarOptions()
  *
  * The array helpers wrap Firestore's `arrayUnion` / `arrayRemove`
  * sentinels so domain services never need to import
@@ -132,6 +135,18 @@ export class UserService {
     return await FirestoreService.updateDocument(USERS_COLLECTION, uid, {
       [field]: arrayRemove(value),
     });
+  }
+
+  /**
+   * List the stock avatar options users can pick from the profile UI.
+   * Each entry is a resolved download URL. Static fixtures stored under
+   * the `Avatars/` Storage prefix.
+   *
+   * @returns {Promise<string[]>}
+   */
+  static async listAvatarOptions() {
+    const list = await StorageService.listFiles(AVATAR_OPTIONS_PATH);
+    return Promise.all(list.items.map((ref) => StorageService.getFileUrl(ref.fullPath)));
   }
 }
 

--- a/src/lib/auth/components/user-profile.js
+++ b/src/lib/auth/components/user-profile.js
@@ -1,8 +1,7 @@
 import './auth-content.js';
 import '../../modals/confirmation_modal/confirmation_modal.js';
-import { getDownloadURL } from 'firebase/storage';
-import { StorageService } from '../../../js/services/_firebase/storage-service.js';
 import authService from '../../../js/services/auth/auth-service.js';
+import { UserService } from '../../../js/services/users/user-service.js';
 
 let avatarCache = null;
 
@@ -383,8 +382,7 @@ class UserProfile extends HTMLElement {
       }
 
       if (!avatarCache) {
-        const list = await StorageService.listFiles('Avatars');
-        avatarCache = await Promise.all(list.items.map((ref) => getDownloadURL(ref)));
+        avatarCache = await UserService.listAvatarOptions();
       }
 
       const results = await Promise.all(

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -12,8 +12,7 @@
 
 import { enhanceFoodImage } from '../../../js/services/recipes/ai-enhancement-service.js';
 import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
-import { StorageService } from '../../../js/services/_firebase/storage-service.js';
-import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
+import { getImageUrl, getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { icons } from '../../../js/icons.js';
 import '../../utilities/modal/modal.js';
 
@@ -337,7 +336,7 @@ class AiImageEnhanceModal extends HTMLElement {
     this._setStatus('שולח לשיפור בעזרת AI...');
 
     try {
-      const downloadUrl = await StorageService.getFileUrl(this._image.full);
+      const downloadUrl = await getImageUrl(this._image.full);
       const response = await fetch(downloadUrl);
       if (!response.ok) throw new Error(`Failed to fetch image (${response.status})`);
       const sourceBlob = await response.blob();

--- a/src/lib/media/image-carousel/image-carousel.js
+++ b/src/lib/media/image-carousel/image-carousel.js
@@ -1,6 +1,5 @@
 import { icons } from '../../../js/icons.js';
-import { StorageService } from '../../../js/services/_firebase/storage-service.js';
-import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
+import { getImageUrl, getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 
 class ImageCarousel extends HTMLElement {
   constructor() {
@@ -87,7 +86,7 @@ class ImageCarousel extends HTMLElement {
           }
         } else if (typeof image === 'string' && image.startsWith('img/recipes/')) {
           try {
-            src = await StorageService.getFileUrl(image);
+            src = await getImageUrl(image);
           } catch (error) {
             console.error('Error loading Firebase image path:', error);
           }

--- a/tests/js/services/auth-service.test.mjs
+++ b/tests/js/services/auth-service.test.mjs
@@ -5,6 +5,7 @@ import { jest } from '@jest/globals';
 import '../../common/mocks/firebase-service.mock.js';
 import '../../common/mocks/firebase-auth.mock.js';
 import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
 import '../../common/mocks/document.mock.js';
 import { mockDocRef } from '../../common/mocks/firebase-firestore.mock.js';
 

--- a/tests/js/services/favorites-service.test.mjs
+++ b/tests/js/services/favorites-service.test.mjs
@@ -40,6 +40,12 @@ describe('FavoritesService', () => {
       arrayRemove: arrayRemoveMock,
     }));
 
+    // UserService (transitive dep) now imports StorageService for
+    // listAvatarOptions. Mock the wrapper so the SDK chain doesn't load.
+    jest.unstable_mockModule('../../../src/js/services/_firebase/storage-service.js', () => ({
+      StorageService: { listFiles: jest.fn(), getFileUrl: jest.fn() },
+    }));
+
     // Dynamically import the service under test
     const module = await import('../../../src/js/services/users/favorites-service.js');
     favoritesService = module.default;

--- a/tests/js/services/user-service.test.mjs
+++ b/tests/js/services/user-service.test.mjs
@@ -14,13 +14,23 @@ const firestoreMocks = {
   deleteDocument: jest.fn(),
 };
 
+const storageMocks = {
+  listFiles: jest.fn(),
+  getFileUrl: jest.fn(),
+};
+
 jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
   FirestoreService: firestoreMocks,
+}));
+
+jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
+  StorageService: storageMocks,
 }));
 
 beforeEach(async () => {
   jest.resetModules();
   Object.values(firestoreMocks).forEach((m) => m.mockReset());
+  Object.values(storageMocks).forEach((m) => m.mockReset());
 
   ({ UserService } = await import('src/js/services/users/user-service.js'));
   ({ arrayUnion, arrayRemove } = await import('firebase/firestore'));
@@ -142,6 +152,36 @@ describe('UserService', () => {
       await expect(UserService.removeFromArrayField('u1', '', 'x')).rejects.toThrow(
         'field is required',
       );
+    });
+  });
+
+  describe('listAvatarOptions', () => {
+    it('lists Avatars/ files and resolves each to a download URL', async () => {
+      storageMocks.listFiles.mockResolvedValue({
+        items: [{ fullPath: 'Avatars/a.png' }, { fullPath: 'Avatars/b.png' }],
+        prefixes: [],
+      });
+      storageMocks.getFileUrl.mockImplementation((path) => Promise.resolve(`https://cdn/${path}`));
+
+      const urls = await UserService.listAvatarOptions();
+
+      expect(storageMocks.listFiles).toHaveBeenCalledWith('Avatars');
+      expect(storageMocks.getFileUrl.mock.calls.map((c) => c[0])).toEqual([
+        'Avatars/a.png',
+        'Avatars/b.png',
+      ]);
+      expect(urls).toEqual(['https://cdn/Avatars/a.png', 'https://cdn/Avatars/b.png']);
+    });
+
+    it('returns an empty array when no avatars are present', async () => {
+      storageMocks.listFiles.mockResolvedValue({ items: [], prefixes: [] });
+      expect(await UserService.listAvatarOptions()).toEqual([]);
+      expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
+    });
+
+    it('propagates errors from StorageService.listFiles', async () => {
+      storageMocks.listFiles.mockRejectedValue(new Error('list-boom'));
+      await expect(UserService.listAvatarOptions()).rejects.toThrow('list-boom');
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `UserService.listAvatarOptions()` so the user-profile component no longer reaches into `StorageService` / `firebase/storage` directly. Drops the same imports from two other components by routing through the existing `getImageUrl` util — **temporarily**, to be unwound in PR-Q2 with the domain-typed `RecipeImageService.getFullUrl(image)`.

This is the first sub-PR of the unified umbrella-completion plan (see `docs/feature-plans/service-layer-umbrella-completion.md`).

## What ships

- `UserService.listAvatarOptions()` — new static method wrapping `StorageService.listFiles('Avatars')` + per-ref `getFileUrl`.
- `user-profile.js` — uses the new service method; drops `StorageService` + `firebase/storage` imports.
- `ai-image-enhance-modal.js`, `image-carousel.js` — **temporarily** route through utils `getImageUrl(path)` instead of `StorageService.getFileUrl(path)`. PR-Q2 will switch both to `RecipeImageService.getFullUrl(image)`.
- `auth-service.test.mjs` + `favorites-service.test.mjs` — add the missing storage mocks (UserService's transitive `firebase/storage` import would otherwise break those suites).
- 3 new tests for `listAvatarOptions`.
- `docs/feature-plans/service-layer-umbrella-completion.md` — the plan doc.

## Test plan

- [ ] Open the avatar picker in user profile; confirm avatars load; pick one and confirm it persists across reload
- [ ] Open a recipe with images as manager → AI enhance modal → "before" image loads
- [ ] Open a recipe with multiple images → carousel cycles through all of them
- [ ] `npm run lint && npm test && npm run build` clean

Part of #211.