### PR TITLE
refactor(recipes): RecipeImageService storage-only + doc-owner split (PR-Q1a)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -1,10 +1,14 @@
 // src/js/services/recipes/recipe-image-service.js
 
-import { FirestoreService } from '../_firebase/firestore-service.js';
 import { StorageService } from '../_firebase/storage-service.js';
-import { setPrimaryImage as setPrimaryImageInternal } from '../../utils/recipes/recipe-image-utils.js';
 
-const RECIPES_COLLECTION = 'recipes';
+function getImageStoragePath(recipeId, category, fileName, type = 'full') {
+  return `img/recipes/${type}/${category}/${recipeId}/${fileName}`;
+}
+
+function generateImageId() {
+  return 'img-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
+}
 
 function makeBackupPath(fullPath) {
   return fullPath.replace(/(\.[^.]+)$/, '_original$1');
@@ -20,86 +24,186 @@ async function fileExists(path) {
 }
 
 /**
- * RecipeImageService — Image Lifecycle for Recipes
+ * RecipeImageService — Storage-Only Image Operations for Recipes
  *
- * Owns operations on the image files and image-entry metadata for a
- * recipe. Separated from RecipeService (which owns recipe doc CRUD) so
- * each service has a single responsibility: RecipeService manages the
- * recipe document; RecipeImageService manages what lives at the
- * Storage layer for a recipe's images plus the per-image entries
- * inside `recipes/{id}.images[]`.
+ * Owns the Storage layer for a recipe's images: upload, delete,
+ * migrate, replace. Performs zero Firestore reads or writes — the
+ * recipe document (and its `images[]` entries) belong to RecipeService.
+ * Compose the two when a single operation needs both: RecipeService
+ * loads/writes the doc; RecipeImageService handles the bytes.
  *
  * Public API:
- *   - setPrimaryImage(recipeId, imageId)
- *   - replaceImage(recipeId, imageId, blob, options)
+ *   - uploadFiles(recipeId, category, file, uploadedBy, isPrimary)
+ *   - deleteFiles(image)
+ *   - migrateFilesToCategory(recipeId, image, newCategory)
+ *   - replaceFiles(recipeId, image, blob, options)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
  */
 export class RecipeImageService {
   /**
-   * Mark a single image on a recipe as the primary one. Clears `isPrimary`
-   * on the rest. Throws if the recipe has no images.
+   * Upload a single recipe image file and return its image-entry metadata.
+   * The caller persists the returned object on `recipes/{id}.images[]`.
    *
    * @param {string} recipeId
-   * @param {string} imageId
-   * @returns {Promise<void>}
+   * @param {string} category
+   * @param {File} file
+   * @param {string} uploadedBy
+   * @param {boolean} [isPrimary=false]
+   * @returns {Promise<Object>} image metadata (id, full, fileName, isPrimary, uploadedBy, access, uploadTimestamp)
    */
-  static async setPrimaryImage(recipeId, imageId) {
-    return await setPrimaryImageInternal(recipeId, imageId);
+  static async uploadFiles(recipeId, category, file, uploadedBy, isPrimary = false) {
+    const fileExtension = file.name.split('.').pop();
+    const fileName = isPrimary ? 'primary.jpg' : `${Date.now()}.${fileExtension}`;
+    const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
+    await StorageService.uploadFile(file, fullPath);
+
+    return {
+      id: generateImageId(),
+      full: fullPath,
+      fileName,
+      isPrimary,
+      uploadedBy,
+      access: 'public',
+      uploadTimestamp: new Date(),
+    };
   }
 
   /**
-   * Replace an existing image's storage file with new bytes. Optionally
-   * preserves the current image as a backup at `<path>_original.<ext>`
-   * (idempotent — only written if the backup doesn't already exist).
-   * Optionally patches the matching image entry inside
-   * `recipes/{id}.images[]` with caller-supplied fields.
+   * Delete all Storage files associated with a recipe image: the full
+   * original, both WebP variants, the `_original` backup (if any) and
+   * its WebP variants. The full-size deletion propagates errors;
+   * everything else is best-effort.
    *
-   * Steps:
-   *   1. Look up the image entry on the recipe doc. Throws if recipe
-   *      or image not found.
-   *   2. If keepOriginalBackup (default true) and no backup exists:
-   *      fetch the current image bytes and write them at the backup path.
-   *   3. Upload `blob` to the original path (overwrites). The Storage
-   *      Resize extension regenerates WebP variants asynchronously.
-   *   4. Best-effort: delete the stale _400x400.webp / _1080x1080.webp
-   *      variants at the original path so consumers refresh promptly.
-   *   5. If `fieldUpdates` is provided: best-effort merge it into the
-   *      matching image entry. A failure here logs but does NOT throw —
-   *      the image bytes already changed; the flag is cosmetic.
+   * @param {{ full: string }} image
+   * @returns {Promise<void>}
+   */
+  static async deleteFiles({ full }) {
+    const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
+    const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
+    const originalBackup = full.replace(/(\.[^.]+)$/, '_original$1');
+    // The Storage Resize extension also generates WebP variants for the
+    // `_original` backup file itself, so those need explicit cleanup too.
+    const originalOpt400 = originalBackup.replace(/\.[^.]+$/, '_400x400.webp');
+    const originalOpt1080 = originalBackup.replace(/\.[^.]+$/, '_1080x1080.webp');
+    await StorageService.deleteFile(full);
+    await Promise.all([
+      StorageService.deleteFile(optimized400).catch(() => {}),
+      StorageService.deleteFile(optimized1080).catch(() => {}),
+      StorageService.deleteFile(originalBackup).catch(() => {}),
+      StorageService.deleteFile(originalOpt400).catch(() => {}),
+      StorageService.deleteFile(originalOpt1080).catch(() => {}),
+    ]);
+  }
+
+  /**
+   * Move an image's Storage files from its current category path to a
+   * new one. Returns an updated image object with the new `full` path.
+   * The caller is responsible for persisting the returned object back
+   * onto the recipe document.
    *
    * @param {string} recipeId
-   * @param {string} imageId
-   * @param {Blob} blob - New image bytes (must be uploadable; e.g. from a fetch or canvas).
-   * @param {Object} [options]
-   * @param {boolean} [options.keepOriginalBackup=true]
-   * @param {Object} [options.fieldUpdates] - Patch merged into the matching image entry.
-   * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
+   * @param {Object} image - Image object with current paths.
+   * @param {string} newCategory
+   * @returns {Promise<Object>} Updated image with new `full` path.
    */
-  static async replaceImage(recipeId, imageId, blob, options = {}) {
-    if (!recipeId) throw new Error('RecipeImageService.replaceImage: recipeId is required');
-    if (!imageId) throw new Error('RecipeImageService.replaceImage: imageId is required');
-    if (!blob) throw new Error('RecipeImageService.replaceImage: blob is required');
-
-    const { keepOriginalBackup = true, fieldUpdates } = options;
-
-    // 1. Look up the image entry.
-    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
-    if (!recipe) {
-      throw new Error(`RecipeImageService.replaceImage: recipe ${recipeId} not found`);
-    }
-    const images = Array.isArray(recipe.images) ? recipe.images : [];
-    const image = images.find((img) => img.id === imageId);
-    if (!image) {
+  // TODO: Consider migrating images to be category agnostic.
+  static async migrateFilesToCategory(recipeId, image, newCategory) {
+    if (!image || !image.full) {
       throw new Error(
-        `RecipeImageService.replaceImage: image ${imageId} not found on recipe ${recipeId}`,
+        'RecipeImageService.migrateFilesToCategory: image with `full` path is required',
       );
     }
 
+    try {
+      const fileName = image.full.split('/').pop();
+      const newFullPath = getImageStoragePath(recipeId, newCategory, fileName, 'full');
+
+      const fullUrl = await StorageService.getFileUrl(image.full);
+      const fullResponse = await fetch(fullUrl);
+
+      if (!fullResponse.ok) {
+        throw new Error(`Failed to fetch images: full=${fullResponse.status}`);
+      }
+
+      const fullBlob = await fullResponse.blob();
+      await StorageService.uploadFile(fullBlob, newFullPath);
+      await StorageService.deleteFile(image.full);
+
+      // The new full upload triggers the Storage Resize extension to regenerate
+      // WebP variants at the new path, so the old variants just need to be
+      // deleted. We don't conditionally check existence — deleteFile is best
+      // effort and harmless if the file is missing.
+      const oldOpt400 = image.full.replace(/\.[^.]+$/, '_400x400.webp');
+      const oldOpt1080 = image.full.replace(/\.[^.]+$/, '_1080x1080.webp');
+      await Promise.all([
+        StorageService.deleteFile(oldOpt400).catch(() => {}),
+        StorageService.deleteFile(oldOpt1080).catch(() => {}),
+      ]);
+
+      // The AI-enhancement `_original` backup is NOT auto-generated, so it must
+      // be actively copied to the new path (best effort — most images won't have
+      // one). Its WebP variants ARE auto-generated by the extension, so the old
+      // ones at the source path need explicit cleanup just like the full's.
+      const oldOriginal = image.full.replace(/(\.[^.]+)$/, '_original$1');
+      const newOriginal = newFullPath.replace(/(\.[^.]+)$/, '_original$1');
+      const oldOriginalOpt400 = oldOriginal.replace(/\.[^.]+$/, '_400x400.webp');
+      const oldOriginalOpt1080 = oldOriginal.replace(/\.[^.]+$/, '_1080x1080.webp');
+      try {
+        const url = await StorageService.getFileUrl(oldOriginal);
+        const response = await fetch(url);
+        if (response.ok) {
+          const blob = await response.blob();
+          await StorageService.uploadFile(blob, newOriginal);
+          await StorageService.deleteFile(oldOriginal).catch(() => {});
+        }
+      } catch {
+        // No `_original` backup at the old path — nothing to migrate.
+      }
+      await Promise.all([
+        StorageService.deleteFile(oldOriginalOpt400).catch(() => {}),
+        StorageService.deleteFile(oldOriginalOpt1080).catch(() => {}),
+      ]);
+
+      return {
+        ...image,
+        full: newFullPath,
+      };
+    } catch (error) {
+      console.error(`Failed to migrate image ${image.id} to ${newCategory}:`, error);
+      throw new Error(`Failed to migrate image ${image.id}: ${error.message}`);
+    }
+  }
+
+  /**
+   * Overwrite an image's Storage bytes with new content. Optionally
+   * preserves the current image as a backup at `<path>_original.<ext>`
+   * (idempotent — only written if the backup doesn't already exist).
+   * Best-effort: deletes the stale _400x400.webp / _1080x1080.webp
+   * variants so consumers refresh promptly.
+   *
+   * This is the pure-Storage half of replacement. For composed
+   * doc-aware replacement (lookup image by id, patch image-entry fields
+   * after replace) use `RecipeService.replaceImage`.
+   *
+   * @param {string} recipeId - Reserved for future path-aware logic; not currently used in the body.
+   * @param {Object} image - Image entry with `full` path.
+   * @param {Blob} blob - New bytes (e.g. from a fetch or canvas).
+   * @param {Object} [options]
+   * @param {boolean} [options.keepOriginalBackup=true]
+   * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
+   */
+  static async replaceFiles(recipeId, image, blob, options = {}) {
+    if (!image || !image.full) {
+      throw new Error('RecipeImageService.replaceFiles: image with `full` path is required');
+    }
+    if (!blob) throw new Error('RecipeImageService.replaceFiles: blob is required');
+
+    const { keepOriginalBackup = true } = options;
     const originalPath = image.full;
     const backupPath = makeBackupPath(originalPath);
 
-    // 2. Backup (idempotent).
+    // Backup (idempotent).
     let backupCreated = false;
     if (keepOriginalBackup) {
       if (!(await fileExists(backupPath))) {
@@ -107,7 +211,7 @@ export class RecipeImageService {
         const response = await fetch(url);
         if (!response.ok) {
           throw new Error(
-            `RecipeImageService.replaceImage: failed to fetch original (${response.status})`,
+            `RecipeImageService.replaceFiles: failed to fetch original (${response.status})`,
           );
         }
         await StorageService.uploadFile(await response.blob(), backupPath);
@@ -115,38 +219,16 @@ export class RecipeImageService {
       }
     }
 
-    // 3. Overwrite the original.
+    // Overwrite the original.
     await StorageService.uploadFile(blob, originalPath);
 
-    // 4. Best-effort stale WebP variant cleanup so consumers refresh promptly.
+    // Best-effort stale WebP variant cleanup so consumers refresh promptly.
     await Promise.all([
       StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp')).catch(() => {}),
       StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp')).catch(
         () => {},
       ),
     ]);
-
-    // 5. Best-effort image-entry patch.
-    if (fieldUpdates && Object.keys(fieldUpdates).length > 0) {
-      try {
-        const fresh = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
-        if (fresh && Array.isArray(fresh.images)) {
-          const updatedImages = fresh.images.map((img) =>
-            img.id === imageId ? { ...img, ...fieldUpdates } : img,
-          );
-          await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, {
-            images: updatedImages,
-          });
-        }
-      } catch (err) {
-        // The image bytes have already changed; failing the whole op
-        // because a metadata patch didn't land would be misleading.
-        console.error(
-          `RecipeImageService.replaceImage: fieldUpdates patch failed for image ${imageId}:`,
-          err,
-        );
-      }
-    }
 
     return { backupPath, backupCreated };
   }

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -1,23 +1,18 @@
 // src/js/services/recipes/recipe-service.js
 
 import { FirestoreService } from '../_firebase/firestore-service.js';
-import {
-  uploadAndBuildImageMetadata,
-  deleteImageFiles,
-  migrateImageToCategory,
-  removeAllRecipeImages,
-} from '../../utils/recipes/recipe-image-utils.js';
+import { RecipeImageService } from './recipe-image-service.js';
 import {
   uploadMediaInstructionFile,
   removeAllMediaInstructions,
 } from '../../utils/recipes/recipe-media-utils.js';
 
 /**
- * RecipeService — Recipe-Aware Service Layer
+ * RecipeService — Recipe Document Owner
  *
- * Single entry point for all recipe owner CRUD. Internalizes image
- * upload/delete/migration and media-instruction upload so callers no longer
- * orchestrate Storage + Firestore manually.
+ * Single entry point for all recipe owner CRUD. Owns every read and
+ * write of `recipes/{id}` and composes storage-only operations from
+ * RecipeImageService when a flow needs both bytes and document state.
  *
  * Public API:
  *   - get(recipeId)
@@ -26,6 +21,8 @@ import {
  *   - create({ recipeData, imagesToUpload, mediaItemsOrdered, uploadedBy })
  *   - update(recipeId, { changes, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved })
  *   - delete(recipeId)
+ *   - setPrimaryImage(recipeId, imageId)
+ *   - replaceImage(recipeId, imageId, blob, options)
  *
  * Image proposal/moderation (the pending-images workflow) lives in
  * RecipeImageProposalService.
@@ -38,13 +35,13 @@ async function uploadImagesAtomic(recipeId, category, imagesToUpload, uploadedBy
   // rejects — Promise.all leaves us blind to which uploads actually landed.
   const settled = await Promise.allSettled(
     imagesToUpload.map(({ file, isPrimary }) =>
-      uploadAndBuildImageMetadata({
+      RecipeImageService.uploadFiles(
         recipeId,
         category,
         file,
-        isPrimary: !!isPrimary,
-        uploadedBy: uploadedBy || 'anonymous',
-      }),
+        uploadedBy || 'anonymous',
+        !!isPrimary,
+      ),
     ),
   );
   const uploaded = settled.filter((s) => s.status === 'fulfilled').map((s) => s.value);
@@ -52,7 +49,7 @@ async function uploadImagesAtomic(recipeId, category, imagesToUpload, uploadedBy
   if (firstRejection) {
     await Promise.all(
       uploaded.map((img) =>
-        deleteImageFiles(img).catch((e) =>
+        RecipeImageService.deleteFiles(img).catch((e) =>
           console.warn('Failed to cleanup partially-uploaded image:', e),
         ),
       ),
@@ -224,7 +221,7 @@ export class RecipeService {
     } catch (error) {
       await Promise.all(
         uploadedImages.map((img) =>
-          deleteImageFiles(img).catch((e) =>
+          RecipeImageService.deleteFiles(img).catch((e) =>
             console.warn('Failed to cleanup uploaded image on error:', e),
           ),
         ),
@@ -282,7 +279,7 @@ export class RecipeService {
     if (Array.isArray(imagesToDelete)) {
       for (const img of imagesToDelete) {
         if (img && img.full) {
-          await deleteImageFiles(img).catch((e) =>
+          await RecipeImageService.deleteFiles(img).catch((e) =>
             console.warn(`Failed to delete removed image ${img.id}:`, e),
           );
         }
@@ -297,13 +294,13 @@ export class RecipeService {
       try {
         for (const img of images) {
           if (img.source === 'new' && img.file) {
-            const meta = await uploadAndBuildImageMetadata({
+            const meta = await RecipeImageService.uploadFiles(
               recipeId,
-              category: newCategory,
-              file: img.file,
-              isPrimary: !!img.isPrimary,
-              uploadedBy: img.uploadedBy || uploadedBy || 'anonymous',
-            });
+              newCategory,
+              img.file,
+              img.uploadedBy || uploadedBy || 'anonymous',
+              !!img.isPrimary,
+            );
             uploadedThisCall.push(meta);
             newImages.push(meta);
           } else if (img.source === 'existing') {
@@ -315,10 +312,9 @@ export class RecipeService {
             );
             if (categoryChanged) {
               try {
-                existingImage = await migrateImageToCategory(
-                  existingImage,
+                existingImage = await RecipeImageService.migrateFilesToCategory(
                   recipeId,
-                  originalRecipe.category,
+                  existingImage,
                   newCategory,
                 );
               } catch (error) {
@@ -331,7 +327,7 @@ export class RecipeService {
       } catch (error) {
         await Promise.all(
           uploadedThisCall.map((img) =>
-            deleteImageFiles(img).catch((e) =>
+            RecipeImageService.deleteFiles(img).catch((e) =>
               console.warn('Failed to cleanup uploaded image on update error:', e),
             ),
           ),
@@ -375,13 +371,124 @@ export class RecipeService {
       return;
     }
 
-    await removeAllRecipeImages(recipeId);
+    const fileDeletions = [];
+    if (Array.isArray(recipe.images)) {
+      for (const image of recipe.images) {
+        if (image?.full) {
+          fileDeletions.push(
+            RecipeImageService.deleteFiles(image).catch((e) =>
+              console.warn(`Failed to delete files for image ${image.id}:`, e),
+            ),
+          );
+        }
+      }
+    }
+    if (Array.isArray(recipe.pendingImages)) {
+      for (const image of recipe.pendingImages) {
+        if (image?.full) {
+          fileDeletions.push(
+            RecipeImageService.deleteFiles(image).catch((e) =>
+              console.warn(`Failed to delete files for pending image ${image.id}:`, e),
+            ),
+          );
+        }
+      }
+    }
+    await Promise.all(fileDeletions);
 
     if (Array.isArray(recipe.mediaInstructions) && recipe.mediaInstructions.length > 0) {
       await removeAllMediaInstructions(recipe.mediaInstructions);
     }
 
     await FirestoreService.deleteDocument(RECIPES_COLLECTION, recipeId);
+  }
+
+  /**
+   * Mark a single image on a recipe as primary; clears `isPrimary` on
+   * the rest. Throws if the recipe has no images.
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @returns {Promise<void>}
+   */
+  static async setPrimaryImage(recipeId, imageId) {
+    if (!recipeId) throw new Error('RecipeService.setPrimaryImage: recipeId is required');
+    if (!imageId) throw new Error('RecipeService.setPrimaryImage: imageId is required');
+
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe || !Array.isArray(recipe.images)) {
+      throw new Error('RecipeService.setPrimaryImage: no images to update');
+    }
+    const images = recipe.images.map((img) => ({ ...img, isPrimary: img.id === imageId }));
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { images });
+  }
+
+  /**
+   * Replace an existing image's bytes via RecipeImageService and
+   * (optionally) patch the matching image entry on the recipe doc.
+   *
+   * Steps:
+   *   1. Look up the image entry on the recipe. Throws if recipe or
+   *      image not found.
+   *   2. Delegate the Storage work to RecipeImageService.replaceFiles
+   *      (overwrite + backup management + stale-variant cleanup).
+   *   3. If `fieldUpdates` is provided: best-effort merge into the
+   *      matching image entry. The image bytes already changed; a
+   *      metadata patch failure is logged, not thrown.
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @param {Blob} blob
+   * @param {Object} [options]
+   * @param {boolean} [options.keepOriginalBackup=true]
+   * @param {Object} [options.fieldUpdates] - Patch merged into the matching image entry.
+   * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
+   */
+  static async replaceImage(recipeId, imageId, blob, options = {}) {
+    if (!recipeId) throw new Error('RecipeService.replaceImage: recipeId is required');
+    if (!imageId) throw new Error('RecipeService.replaceImage: imageId is required');
+    if (!blob) throw new Error('RecipeService.replaceImage: blob is required');
+
+    const { keepOriginalBackup = true, fieldUpdates } = options;
+
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe) {
+      throw new Error(`RecipeService.replaceImage: recipe ${recipeId} not found`);
+    }
+    const images = Array.isArray(recipe.images) ? recipe.images : [];
+    const image = images.find((img) => img.id === imageId);
+    if (!image) {
+      throw new Error(
+        `RecipeService.replaceImage: image ${imageId} not found on recipe ${recipeId}`,
+      );
+    }
+
+    const result = await RecipeImageService.replaceFiles(recipeId, image, blob, {
+      keepOriginalBackup,
+    });
+
+    if (fieldUpdates && Object.keys(fieldUpdates).length > 0) {
+      try {
+        const fresh = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+        if (fresh && Array.isArray(fresh.images)) {
+          const updatedImages = fresh.images.map((img) =>
+            img.id === imageId ? { ...img, ...fieldUpdates } : img,
+          );
+          await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, {
+            images: updatedImages,
+          });
+        }
+      } catch (err) {
+        // The image bytes have already changed; failing the whole op
+        // because a metadata patch didn't land would be misleading.
+        console.error(
+          `RecipeService.replaceImage: fieldUpdates patch failed for image ${imageId}:`,
+          err,
+        );
+      }
+    }
+
+    return result;
   }
 }
 

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -12,9 +12,6 @@
  *   - getImageStoragePath(recipeId, category, fileName, type): Get storage path for image.
  *   - generateImageId(): Generate a unique image ID.
  *
- * Image File Deletion:
- *   - deleteImageFiles(image): Delete all storage files for an image (full + WebP variants).
- *
  * Multi Pending Images:
  *   - addPendingImages(recipeId, files, category, uploader): Upload multiple pending images.
  *   - approvePendingImageById(recipeId, pendingImageId): Approve a specific pending image by ID.
@@ -22,16 +19,12 @@
  *   - getPendingImages(recipeId): Get all pending images for a recipe.
  *
  * Approved Images:
- *   - setPrimaryImage(recipeId, imageId): Set the primary image for a recipe.
  *   - getRecipeImages(recipe, userRole): Get accessible images for a user role.
  *   - getPrimaryImage(recipe): Get the primary image object.
  *   - getPrimaryImageUrl(recipe, size): Get the download URL for the primary image (optimized) or placeholder.
  *   - getImageUrl(storagePath): Get the download URL for a storage path.
  *   - getOptimizedImageUrl(image, size): Get the download URL for an optimized version of an image with fallback.
  *   - getPlaceholderImageUrl(): Get the placeholder image URL.
- *   - removeAllRecipeImages(recipeId): Remove all images (approved and pending) for a recipe.
- *   - migrateImageToCategory(image, recipeId, oldCategory, newCategory): Migrate image to new category path.
- *   - uploadAndBuildImageMetadata({ recipeId, category, file, isPrimary, uploadedBy }): Upload and return metadata for an image.
  */
 
 /**
@@ -100,19 +93,15 @@ export function generateImageId() {
   return 'img-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
 }
 
-// --- Image File Deletion ---
-/**
- * Deletes all storage files for an image: full original and WebP variants.
- * The full-size deletion propagates errors; variant deletions are best-effort.
- * @param {Object} image - Image object with `full` path
- * @returns {Promise<void>}
- */
-export async function deleteImageFiles({ full }) {
+// --- Internal: Image File Deletion ---
+// Storage-only delete kept here to support the proposal helpers below
+// (rejectPendingImageById). NOT exported — public storage-side image
+// ops live on RecipeImageService.deleteFiles. Will be inlined into
+// RecipeImageProposalService along with the proposal helpers in PR-Q2.
+async function deleteImageFiles({ full }) {
   const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
   const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
   const originalBackup = full.replace(/(\.[^.]+)$/, '_original$1');
-  // The Storage Resize extension also generates WebP variants for the
-  // `_original` backup file itself, so those need explicit cleanup too.
   const originalOpt400 = originalBackup.replace(/\.[^.]+$/, '_400x400.webp');
   const originalOpt1080 = originalBackup.replace(/\.[^.]+$/, '_1080x1080.webp');
   await StorageService.deleteFile(full);
@@ -123,19 +112,6 @@ export async function deleteImageFiles({ full }) {
     StorageService.deleteFile(originalOpt400).catch(() => {}),
     StorageService.deleteFile(originalOpt1080).catch(() => {}),
   ]);
-}
-
-/**
- * Sets the primary image for a recipe
- * @param {string} recipeId
- * @param {string} imageId
- * @returns {Promise<void>}
- */
-export async function setPrimaryImage(recipeId, imageId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe || !Array.isArray(recipe.images)) throw new Error('No images to update');
-  const images = recipe.images.map((img) => ({ ...img, isPrimary: img.id === imageId }));
-  await updateRecipeDoc(recipeId, { images });
 }
 
 // --- Retrieval ---
@@ -228,153 +204,6 @@ export async function getPrimaryImageUrl(recipe, size = '400x400') {
     return await getOptimizedImageUrl(primary, size);
   }
   return getPlaceholderImageUrl();
-}
-
-/**
- * Removes all images (approved and pending) for a recipe
- * @param {string} recipeId
- * @returns {Promise<void>}
- */
-export async function removeAllRecipeImages(recipeId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe) {
-    console.warn('Recipe not found for image removal:', recipeId);
-    return;
-  }
-  const deletePromises = [];
-  if (recipe.images && Array.isArray(recipe.images)) {
-    recipe.images.forEach((image) => {
-      if (image.full)
-        deletePromises.push(
-          deleteImageFiles(image).catch((err) =>
-            console.warn(`Failed to delete files for image ${image.id}:`, err),
-          ),
-        );
-    });
-  }
-  if (recipe.pendingImages && Array.isArray(recipe.pendingImages)) {
-    recipe.pendingImages.forEach((image) => {
-      if (image.full)
-        deletePromises.push(
-          deleteImageFiles(image).catch((err) =>
-            console.warn(`Failed to delete files for pending image ${image.id}:`, err),
-          ),
-        );
-    });
-  }
-  await Promise.all(deletePromises);
-  // Remove images and pendingImages from Firestore
-  await updateRecipeDoc(recipeId, { images: [], pendingImages: [] });
-}
-
-// TODO: Consider migrating images to be category agnostic
-/**
- * Migrates an image from old category path to new category path
- * @param {RecipeImage} image - Image object with old category paths
- * @param {string} recipeId
- * @param {string} oldCategory
- * @param {string} newCategory
- * @returns {Promise<RecipeImage>} Updated image object with new paths
- */
-export async function migrateImageToCategory(image, recipeId, oldCategory, newCategory) {
-  if (!image || !image.full) {
-    throw new Error('Invalid image object for migration');
-  }
-
-  try {
-    const fileName = image.full.split('/').pop();
-    const newFullPath = getImageStoragePath(recipeId, newCategory, fileName, 'full');
-
-    const fullUrl = await StorageService.getFileUrl(image.full);
-    const fullResponse = await fetch(fullUrl);
-
-    if (!fullResponse.ok) {
-      throw new Error(`Failed to fetch images: full=${fullResponse.status}`);
-    }
-
-    const fullBlob = await fullResponse.blob();
-    await StorageService.uploadFile(fullBlob, newFullPath);
-    await StorageService.deleteFile(image.full);
-
-    // The new full upload triggers the Storage Resize extension to regenerate
-    // WebP variants at the new path, so the old variants just need to be
-    // deleted. We don't conditionally check existence — deleteFile is best
-    // effort and harmless if the file is missing.
-    const oldOpt400 = image.full.replace(/\.[^.]+$/, '_400x400.webp');
-    const oldOpt1080 = image.full.replace(/\.[^.]+$/, '_1080x1080.webp');
-    await Promise.all([
-      StorageService.deleteFile(oldOpt400).catch(() => {}),
-      StorageService.deleteFile(oldOpt1080).catch(() => {}),
-    ]);
-
-    // The AI-enhancement `_original` backup is NOT auto-generated, so it must
-    // be actively copied to the new path (best effort — most images won't have
-    // one). Its WebP variants ARE auto-generated by the extension, so the old
-    // ones at the source path need explicit cleanup just like the full's.
-    const oldOriginal = image.full.replace(/(\.[^.]+)$/, '_original$1');
-    const newOriginal = newFullPath.replace(/(\.[^.]+)$/, '_original$1');
-    const oldOriginalOpt400 = oldOriginal.replace(/\.[^.]+$/, '_400x400.webp');
-    const oldOriginalOpt1080 = oldOriginal.replace(/\.[^.]+$/, '_1080x1080.webp');
-    try {
-      const url = await StorageService.getFileUrl(oldOriginal);
-      const response = await fetch(url);
-      if (response.ok) {
-        const blob = await response.blob();
-        await StorageService.uploadFile(blob, newOriginal);
-        await StorageService.deleteFile(oldOriginal).catch(() => {});
-      }
-    } catch {
-      // No `_original` backup at the old path — nothing to migrate.
-    }
-    await Promise.all([
-      StorageService.deleteFile(oldOriginalOpt400).catch(() => {}),
-      StorageService.deleteFile(oldOriginalOpt1080).catch(() => {}),
-    ]);
-
-    return {
-      ...image,
-      full: newFullPath,
-    };
-  } catch (error) {
-    console.error(
-      `Failed to migrate image ${image.id} from ${oldCategory} to ${newCategory}:`,
-      error,
-    );
-    throw new Error(`Failed to migrate image ${image.id}: ${error.message}`);
-  }
-}
-
-/**
- * Uploads a recipe image (full only) and returns metadata
- * @param {Object} params
- * @param {string} recipeId
- * @param {string} category
- * @param {File} file
- * @param {boolean} isPrimary
- * @param {string} uploadedBy
- * @returns {Promise<Object>} image metadata
- */
-export async function uploadAndBuildImageMetadata({
-  recipeId,
-  category,
-  file,
-  isPrimary,
-  uploadedBy,
-}) {
-  const fileExtension = file.name.split('.').pop();
-  const fileName = isPrimary ? 'primary.jpg' : `${Date.now()}.${fileExtension}`;
-  const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
-  await StorageService.uploadFile(file, fullPath);
-
-  return {
-    id: generateImageId(),
-    full: fullPath,
-    fileName,
-    isPrimary,
-    uploadedBy,
-    access: 'public',
-    uploadTimestamp: new Date(),
-  };
 }
 
 /**

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -11,7 +11,7 @@
  */
 
 import { enhanceFoodImage } from '../../../js/services/recipes/ai-enhancement-service.js';
-import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
+import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { getImageUrl, getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { icons } from '../../../js/icons.js';
 import '../../utilities/modal/modal.js';
@@ -399,7 +399,7 @@ class AiImageEnhanceModal extends HTMLElement {
     this._setStatus('שומר את התמונה החדשה...');
 
     try {
-      const { backupPath, backupCreated } = await RecipeImageService.replaceImage(
+      const { backupPath, backupCreated } = await RecipeService.replaceImage(
         this._recipe.id,
         this._image.id,
         this._enhancedResult.blob,

--- a/src/lib/modals/image-approval-multi/image-approval-multi.js
+++ b/src/lib/modals/image-approval-multi/image-approval-multi.js
@@ -36,7 +36,7 @@
  */
 
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
-import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
+import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { RecipeImageProposalService } from '../../../js/services/recipes/recipe-image-proposal-service.js';
 
 class ImageApprovalMulti extends HTMLElement {
@@ -476,14 +476,14 @@ class ImageApprovalMulti extends HTMLElement {
       if (this.primaryImageId) {
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = Array.from(this.selectedImageIds)[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {
@@ -570,14 +570,14 @@ class ImageApprovalMulti extends HTMLElement {
         // Admin explicitly selected a primary - honor their choice
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = visibleImageIds[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -6,11 +6,6 @@ import '../../common/mocks/firebase-service.mock.js';
 
 let RecipeImageService;
 
-const firestoreMocks = {
-  getDocument: jest.fn(),
-  updateDocument: jest.fn(),
-};
-
 const storageMocks = {
   getMetadata: jest.fn(),
   getFileUrl: jest.fn(),
@@ -18,86 +13,189 @@ const storageMocks = {
   deleteFile: jest.fn(() => Promise.resolve()),
 };
 
-const imageUtilMocks = {
-  setPrimaryImage: jest.fn(() => Promise.resolve()),
-};
-
-jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
-  FirestoreService: firestoreMocks,
-}));
 jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
   StorageService: storageMocks,
 }));
-jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
 
 beforeAll(() => {
-  // jsdom doesn't ship `fetch`; the service calls it during the backup-fetch path.
-  // Tests stub a Response-shaped object via this mock.
+  // jsdom doesn't ship `fetch`; tests stub a Response-shaped object via this mock.
   global.fetch = jest.fn();
 });
 
 beforeEach(async () => {
   jest.resetModules();
-  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   Object.values(storageMocks).forEach((m) => m.mockReset?.());
   storageMocks.deleteFile.mockImplementation(() => Promise.resolve());
-  Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
-  imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
   global.fetch.mockReset();
 
   ({ RecipeImageService } = await import('src/js/services/recipes/recipe-image-service.js'));
 });
 
+function makeFile(name = 'a.jpg', type = 'image/jpeg') {
+  return new File([new Blob(['a'], { type })], name, { type });
+}
+
 describe('RecipeImageService', () => {
-  describe('setPrimaryImage', () => {
-    it('delegates to the recipe-image-utils helper', async () => {
-      await RecipeImageService.setPrimaryImage('recipe-x', 'img-1');
-      expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
+  describe('uploadFiles', () => {
+    it('uploads to the per-category full path and returns image metadata', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('test.jpg');
+
+      const meta = await RecipeImageService.uploadFiles('rid', 'cat', file, 'user-1', true);
+
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
+      const [uploadedFile, uploadedPath] = storageMocks.uploadFile.mock.calls[0];
+      expect(uploadedFile).toBe(file);
+      expect(uploadedPath).toBe('img/recipes/full/cat/rid/primary.jpg');
+      expect(meta).toMatchObject({
+        full: 'img/recipes/full/cat/rid/primary.jpg',
+        fileName: 'primary.jpg',
+        isPrimary: true,
+        uploadedBy: 'user-1',
+        access: 'public',
+      });
+      expect(meta.id).toMatch(/^img-/);
+      expect(meta.uploadTimestamp).toBeInstanceOf(Date);
+    });
+
+    it('uses a timestamped fileName for non-primary uploads', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('photo.png', 'image/png');
+
+      const meta = await RecipeImageService.uploadFiles('rid', 'cat', file, 'user-2');
+
+      expect(meta.isPrimary).toBe(false);
+      expect(meta.fileName).toMatch(/\.png$/);
+      expect(meta.fileName).not.toBe('primary.jpg');
     });
   });
 
-  describe('replaceImage', () => {
+  describe('deleteFiles', () => {
+    it('deletes the full file, both WebP variants, the backup, and its variants', async () => {
+      await RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' });
+
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_400x400.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_1080x1080.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_original.jpg',
+      );
+    });
+
+    it('propagates an error from the full-file delete', async () => {
+      storageMocks.deleteFile.mockRejectedValueOnce(new Error('permission denied'));
+      await expect(
+        RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
+      ).rejects.toThrow('permission denied');
+    });
+
+    it('treats variant failures as best-effort', async () => {
+      storageMocks.deleteFile
+        .mockResolvedValueOnce(undefined) // full
+        .mockRejectedValueOnce(new Error('missing')) // 400 variant
+        .mockRejectedValueOnce(new Error('missing')) // 1080 variant
+        .mockRejectedValueOnce(new Error('missing')) // backup
+        .mockRejectedValueOnce(new Error('missing')) // backup 400
+        .mockRejectedValueOnce(new Error('missing')); // backup 1080
+      await expect(
+        RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe('migrateFilesToCategory', () => {
+    it('throws when the image has no `full` path', async () => {
+      await expect(
+        RecipeImageService.migrateFilesToCategory('rid', { id: 'img-1' }, 'newcat'),
+      ).rejects.toThrow('image with `full` path is required');
+    });
+
+    it('copies the full file to the new category path and removes the source', async () => {
+      const image = { id: 'img-1', full: 'img/recipes/full/oldcat/rid/photo.jpg' };
+      storageMocks.getFileUrl.mockResolvedValue('https://storage/photo.jpg');
+      const fullBytes = new Blob(['original'], { type: 'image/jpeg' });
+      global.fetch
+        .mockResolvedValueOnce({ ok: true, blob: async () => fullBytes }) // full fetch
+        .mockResolvedValueOnce({ ok: false, status: 404 }); // _original backup fetch — none
+
+      const result = await RecipeImageService.migrateFilesToCategory('rid', image, 'newcat');
+
+      expect(result.full).toBe('img/recipes/full/newcat/rid/photo.jpg');
+      // 1st upload = full bytes to new path
+      expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
+        1,
+        fullBytes,
+        'img/recipes/full/newcat/rid/photo.jpg',
+      );
+      // Source full deleted
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith('img/recipes/full/oldcat/rid/photo.jpg');
+      // Stale source variants cleaned up
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/oldcat/rid/photo_400x400.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/oldcat/rid/photo_1080x1080.webp',
+      );
+    });
+
+    it('also copies the _original backup when present', async () => {
+      const image = { id: 'img-1', full: 'img/recipes/full/oldcat/rid/photo.jpg' };
+      storageMocks.getFileUrl.mockResolvedValue('https://storage/url');
+      const fullBytes = new Blob(['orig']);
+      const backupBytes = new Blob(['backup']);
+      global.fetch
+        .mockResolvedValueOnce({ ok: true, blob: async () => fullBytes }) // full
+        .mockResolvedValueOnce({ ok: true, blob: async () => backupBytes }); // backup present
+
+      await RecipeImageService.migrateFilesToCategory('rid', image, 'newcat');
+
+      // 2nd upload = backup bytes to new backup path
+      expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
+        2,
+        backupBytes,
+        'img/recipes/full/newcat/rid/photo_original.jpg',
+      );
+      // Source backup is deleted
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/oldcat/rid/photo_original.jpg',
+      );
+    });
+
+    it('wraps and rethrows when the full-file fetch fails', async () => {
+      const image = { id: 'img-1', full: 'img/recipes/full/oldcat/rid/photo.jpg' };
+      storageMocks.getFileUrl.mockResolvedValue('https://storage/url');
+      global.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        RecipeImageService.migrateFilesToCategory('rid', image, 'newcat'),
+      ).rejects.toThrow('Failed to migrate image img-1:');
+
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('replaceFiles', () => {
     const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
 
-    function setupRecipeWithImage() {
-      firestoreMocks.getDocument.mockResolvedValue({
-        id: 'recipe-9',
-        images: [
-          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
-          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
-        ],
-      });
+    function makeImage() {
+      return { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg' };
     }
 
-    it('throws if recipeId / imageId / blob is missing', async () => {
-      await expect(RecipeImageService.replaceImage('', 'img-1', newBlob)).rejects.toThrow(
-        'recipeId is required',
+    it('throws if image / blob is missing', async () => {
+      await expect(RecipeImageService.replaceFiles('r', { id: 'i' }, newBlob)).rejects.toThrow(
+        'image with `full` path is required',
       );
-      await expect(RecipeImageService.replaceImage('r', '', newBlob)).rejects.toThrow(
-        'imageId is required',
-      );
-      await expect(RecipeImageService.replaceImage('r', 'i', null)).rejects.toThrow(
+      await expect(RecipeImageService.replaceFiles('r', makeImage(), null)).rejects.toThrow(
         'blob is required',
       );
     });
 
-    it('throws if the recipe is not found', async () => {
-      firestoreMocks.getDocument.mockResolvedValue(null);
-      await expect(RecipeImageService.replaceImage('missing', 'img-1', newBlob)).rejects.toThrow(
-        'recipe missing not found',
-      );
-    });
-
-    it('throws if the image id is not on the recipe', async () => {
-      setupRecipeWithImage();
-      await expect(
-        RecipeImageService.replaceImage('recipe-9', 'no-such-img', newBlob),
-      ).rejects.toThrow('image no-such-img not found');
-    });
-
     it('writes the backup when none exists, then overwrites the original', async () => {
-      setupRecipeWithImage();
-      // Backup missing → getMetadata rejects
       storageMocks.getMetadata.mockRejectedValueOnce(new Error('not-found'));
       storageMocks.getFileUrl.mockResolvedValue('https://storage/original-url');
       const originalBytes = new Blob(['original'], { type: 'image/jpeg' });
@@ -106,7 +204,7 @@ describe('RecipeImageService', () => {
         blob: async () => originalBytes,
       });
 
-      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      const result = await RecipeImageService.replaceFiles('recipe-9', makeImage(), newBlob);
 
       expect(result.backupCreated).toBe(true);
       expect(result.backupPath).toBe('img/recipes/full/desserts/recipe-9/img-1_original.jpg');
@@ -125,15 +223,12 @@ describe('RecipeImageService', () => {
     });
 
     it('skips the backup write when one already exists', async () => {
-      setupRecipeWithImage();
-      // Backup already there → getMetadata resolves
       storageMocks.getMetadata.mockResolvedValue({ name: 'backup' });
 
-      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      const result = await RecipeImageService.replaceFiles('recipe-9', makeImage(), newBlob);
 
       expect(result.backupCreated).toBe(false);
       expect(global.fetch).not.toHaveBeenCalled();
-      // Only one upload: the overwrite
       expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
       expect(storageMocks.uploadFile).toHaveBeenCalledWith(
         newBlob,
@@ -142,23 +237,19 @@ describe('RecipeImageService', () => {
     });
 
     it('skips backup entirely when keepOriginalBackup is false', async () => {
-      setupRecipeWithImage();
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+      await RecipeImageService.replaceFiles('recipe-9', makeImage(), newBlob, {
         keepOriginalBackup: false,
       });
 
       expect(storageMocks.getMetadata).not.toHaveBeenCalled();
       expect(global.fetch).not.toHaveBeenCalled();
-      // Only the overwrite upload
       expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
     });
 
     it('deletes stale 400 and 1080 WebP variants after overwrite (best-effort)', async () => {
-      setupRecipeWithImage();
       storageMocks.getMetadata.mockResolvedValue({});
 
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      await RecipeImageService.replaceFiles('recipe-9', makeImage(), newBlob);
 
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/img-1_400x400.webp',
@@ -168,70 +259,14 @@ describe('RecipeImageService', () => {
       );
     });
 
-    it('applies fieldUpdates to the matching image entry on the recipe doc', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-      // 2nd getDocument (the fresh re-read for the patch) returns the same recipe
-      firestoreMocks.getDocument.mockResolvedValue({
-        id: 'recipe-9',
-        images: [
-          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
-          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
-        ],
-      });
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-        fieldUpdates: { aiEnhanced: true },
-      });
-
-      const updateCall = firestoreMocks.updateDocument.mock.calls[0];
-      expect(updateCall[0]).toBe('recipes');
-      expect(updateCall[1]).toBe('recipe-9');
-      const updatedImages = updateCall[2].images;
-      expect(updatedImages.find((i) => i.id === 'img-1').aiEnhanced).toBe(true);
-      // Untargeted images are unchanged
-      expect(updatedImages.find((i) => i.id === 'img-2').aiEnhanced).toBeUndefined();
-      expect(updatedImages.find((i) => i.id === 'img-1').isPrimary).toBe(true);
-    });
-
-    it('skips the doc patch when fieldUpdates is empty or missing', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
-      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-        fieldUpdates: {},
-      });
-      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
-    });
-
-    it('treats a fieldUpdates write failure as best-effort (logs, does not throw)', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      await expect(
-        RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-          fieldUpdates: { aiEnhanced: true },
-        }),
-      ).resolves.toMatchObject({ backupCreated: false });
-
-      expect(errSpy).toHaveBeenCalled();
-      errSpy.mockRestore();
-    });
-
     it('throws when fetching the original for backup fails', async () => {
-      setupRecipeWithImage();
       storageMocks.getMetadata.mockRejectedValue(new Error('no backup yet'));
       storageMocks.getFileUrl.mockResolvedValue('https://storage/url');
       global.fetch.mockResolvedValue({ ok: false, status: 403 });
 
-      await expect(RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob)).rejects.toThrow(
-        'failed to fetch original (403)',
-      );
+      await expect(
+        RecipeImageService.replaceFiles('recipe-9', makeImage(), newBlob),
+      ).rejects.toThrow('failed to fetch original (403)');
 
       // Overwrite never happened
       expect(storageMocks.uploadFile).not.toHaveBeenCalled();

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -16,11 +16,13 @@ const firestoreMocks = {
   generateId: jest.fn(() => 'recipe-123'),
 };
 
-const imageUtilMocks = {
-  uploadAndBuildImageMetadata: jest.fn(),
-  deleteImageFiles: jest.fn(() => Promise.resolve()),
-  migrateImageToCategory: jest.fn(),
-  removeAllRecipeImages: jest.fn(() => Promise.resolve()),
+const recipeImageServiceMocks = {
+  uploadFiles: jest.fn(),
+  deleteFiles: jest.fn(() => Promise.resolve()),
+  migrateFilesToCategory: jest.fn(),
+  replaceFiles: jest.fn(() =>
+    Promise.resolve({ backupPath: 'p_original.jpg', backupCreated: true }),
+  ),
 };
 
 const mediaUtilMocks = {
@@ -31,7 +33,10 @@ const mediaUtilMocks = {
 jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
   FirestoreService: firestoreMocks,
 }));
-jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+jest.unstable_mockModule('src/js/services/recipes/recipe-image-service.js', () => ({
+  RecipeImageService: recipeImageServiceMocks,
+  recipeImageService: recipeImageServiceMocks,
+}));
 jest.unstable_mockModule('src/js/utils/recipes/recipe-media-utils.js', () => mediaUtilMocks);
 
 function makeFile(name = 'a.jpg', type = 'image/jpeg') {
@@ -42,9 +47,11 @@ beforeEach(async () => {
   jest.resetModules();
   Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   firestoreMocks.generateId.mockImplementation(() => 'recipe-123');
-  Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
-  imageUtilMocks.deleteImageFiles.mockImplementation(() => Promise.resolve());
-  imageUtilMocks.removeAllRecipeImages.mockImplementation(() => Promise.resolve());
+  Object.values(recipeImageServiceMocks).forEach((m) => m.mockReset?.());
+  recipeImageServiceMocks.deleteFiles.mockImplementation(() => Promise.resolve());
+  recipeImageServiceMocks.replaceFiles.mockImplementation(() =>
+    Promise.resolve({ backupPath: 'p_original.jpg', backupCreated: true }),
+  );
   Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
   mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
     Promise.resolve({ success: 0, failed: 0, errors: [] }),
@@ -77,7 +84,7 @@ describe('RecipeService', () => {
 
   describe('create', () => {
     it('uploads images, writes doc, returns id and media result', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFiles
         .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
         .mockResolvedValueOnce({ id: 'img-2', full: 'p/2.jpg' });
       firestoreMocks.setDocument.mockResolvedValue();
@@ -100,7 +107,15 @@ describe('RecipeService', () => {
         successCount: 0,
         failedCount: 0,
       });
-      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(2);
+      expect(recipeImageServiceMocks.uploadFiles).toHaveBeenCalledTimes(2);
+      expect(recipeImageServiceMocks.uploadFiles).toHaveBeenNthCalledWith(
+        1,
+        'recipe-123',
+        'desserts',
+        expect.any(File),
+        'user-1',
+        true,
+      );
       expect(firestoreMocks.setDocument).toHaveBeenCalledWith(
         'recipes',
         'recipe-123',
@@ -128,7 +143,7 @@ describe('RecipeService', () => {
     });
 
     it('cleans up uploaded images if a later image fails', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFiles
         .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
         .mockRejectedValueOnce(new Error('upload failed'));
 
@@ -143,7 +158,7 @@ describe('RecipeService', () => {
         }),
       ).rejects.toThrow('upload failed');
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'img-1',
         full: 'p/1.jpg',
       });
@@ -231,7 +246,7 @@ describe('RecipeService', () => {
     });
 
     it('deletes removed images, uploads new ones, keeps existing', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata.mockResolvedValueOnce({
+      recipeImageServiceMocks.uploadFiles.mockResolvedValueOnce({
         id: 'img-new',
         full: 'p/new.jpg',
       });
@@ -247,11 +262,11 @@ describe('RecipeService', () => {
         approved: true,
       });
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'img-rm',
         full: 'p/rm.jpg',
       });
-      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(1);
+      expect(recipeImageServiceMocks.uploadFiles).toHaveBeenCalledTimes(1);
       const payload = firestoreMocks.updateDocument.mock.calls[0][2];
       expect(payload.approved).toBe(true);
       expect(payload.images.map((i) => i.id)).toEqual(['img-old', 'img-new']);
@@ -269,7 +284,7 @@ describe('RecipeService', () => {
     });
 
     it('migrates existing images on category change', async () => {
-      imageUtilMocks.migrateImageToCategory.mockResolvedValueOnce({
+      recipeImageServiceMocks.migrateFilesToCategory.mockResolvedValueOnce({
         id: 'img-keep',
         full: 'img/recipes/full/mains/recipe-9/keep.jpg',
       });
@@ -286,16 +301,17 @@ describe('RecipeService', () => {
         uploadedBy: 'user-1',
       });
 
-      expect(imageUtilMocks.migrateImageToCategory).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'img-keep' }),
+      expect(recipeImageServiceMocks.migrateFilesToCategory).toHaveBeenCalledWith(
         'recipe-9',
-        'desserts',
+        expect.objectContaining({ id: 'img-keep' }),
         'mains',
       );
     });
 
     it('collects migration warnings when migration fails', async () => {
-      imageUtilMocks.migrateImageToCategory.mockRejectedValueOnce(new Error('migrate failed'));
+      recipeImageServiceMocks.migrateFilesToCategory.mockRejectedValueOnce(
+        new Error('migrate failed'),
+      );
 
       const result = await RecipeService.update('recipe-9', {
         changes: { category: 'mains' },
@@ -309,7 +325,7 @@ describe('RecipeService', () => {
     });
 
     it('rolls back uploaded images when an image upload throws mid-loop', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFiles
         .mockResolvedValueOnce({ id: 'new-1', full: 'p/n1.jpg' })
         .mockRejectedValueOnce(new Error('upload boom'));
 
@@ -324,7 +340,7 @@ describe('RecipeService', () => {
         }),
       ).rejects.toThrow('upload boom');
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'new-1',
         full: 'p/n1.jpg',
       });
@@ -343,13 +359,31 @@ describe('RecipeService', () => {
   });
 
   describe('delete', () => {
-    it('removes images, media, and the document', async () => {
+    it('deletes image files, pending image files, media, and the document', async () => {
       firestoreMocks.getDocument.mockResolvedValue({
         id: 'recipe-x',
+        images: [
+          { id: 'a', full: 'img/a.jpg' },
+          { id: 'b', full: 'img/b.jpg' },
+        ],
+        pendingImages: [{ id: 'p1', full: 'img/p1.jpg' }],
         mediaInstructions: [{ path: 'mp/1' }],
       });
+
       await RecipeService.delete('recipe-x');
-      expect(imageUtilMocks.removeAllRecipeImages).toHaveBeenCalledWith('recipe-x');
+
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
+        id: 'a',
+        full: 'img/a.jpg',
+      });
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
+        id: 'b',
+        full: 'img/b.jpg',
+      });
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
+        id: 'p1',
+        full: 'img/p1.jpg',
+      });
       expect(mediaUtilMocks.removeAllMediaInstructions).toHaveBeenCalledWith([{ path: 'mp/1' }]);
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-x');
     });
@@ -358,7 +392,7 @@ describe('RecipeService', () => {
       firestoreMocks.getDocument.mockResolvedValue(null);
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       await RecipeService.delete('missing');
-      expect(imageUtilMocks.removeAllRecipeImages).not.toHaveBeenCalled();
+      expect(recipeImageServiceMocks.deleteFiles).not.toHaveBeenCalled();
       expect(firestoreMocks.deleteDocument).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
@@ -368,6 +402,139 @@ describe('RecipeService', () => {
       await RecipeService.delete('recipe-y');
       expect(mediaUtilMocks.removeAllMediaInstructions).not.toHaveBeenCalled();
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-y');
+    });
+  });
+
+  describe('setPrimaryImage', () => {
+    it('updates isPrimary on the matching image and clears the rest', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        images: [
+          { id: 'a', isPrimary: true },
+          { id: 'b', isPrimary: false },
+        ],
+      });
+      firestoreMocks.updateDocument.mockResolvedValue();
+
+      await RecipeService.setPrimaryImage('recipe-9', 'b');
+
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledWith('recipes', 'recipe-9', {
+        images: [
+          { id: 'a', isPrimary: false },
+          { id: 'b', isPrimary: true },
+        ],
+      });
+    });
+
+    it('throws if the recipe has no images', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'recipe-9' });
+      await expect(RecipeService.setPrimaryImage('recipe-9', 'b')).rejects.toThrow(
+        'no images to update',
+      );
+    });
+
+    it('throws on missing recipeId / imageId', async () => {
+      await expect(RecipeService.setPrimaryImage('', 'b')).rejects.toThrow('recipeId is required');
+      await expect(RecipeService.setPrimaryImage('r', '')).rejects.toThrow('imageId is required');
+    });
+  });
+
+  describe('replaceImage', () => {
+    const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
+
+    function recipeWithImages() {
+      return {
+        id: 'recipe-9',
+        images: [
+          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
+          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
+        ],
+      };
+    }
+
+    it('throws on missing recipeId / imageId / blob', async () => {
+      await expect(RecipeService.replaceImage('', 'i', newBlob)).rejects.toThrow(
+        'recipeId is required',
+      );
+      await expect(RecipeService.replaceImage('r', '', newBlob)).rejects.toThrow(
+        'imageId is required',
+      );
+      await expect(RecipeService.replaceImage('r', 'i', null)).rejects.toThrow('blob is required');
+    });
+
+    it('throws when the recipe is not found', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      await expect(RecipeService.replaceImage('missing', 'img-1', newBlob)).rejects.toThrow(
+        'recipe missing not found',
+      );
+    });
+
+    it('throws when the image id is not on the recipe', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(recipeWithImages());
+      await expect(RecipeService.replaceImage('recipe-9', 'no-such-img', newBlob)).rejects.toThrow(
+        'image no-such-img not found',
+      );
+    });
+
+    it('delegates bytes to RecipeImageService.replaceFiles', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(recipeWithImages());
+
+      const result = await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+        keepOriginalBackup: false,
+      });
+
+      expect(recipeImageServiceMocks.replaceFiles).toHaveBeenCalledWith(
+        'recipe-9',
+        expect.objectContaining({ id: 'img-1' }),
+        newBlob,
+        { keepOriginalBackup: false },
+      );
+      expect(result).toMatchObject({ backupCreated: true });
+    });
+
+    it('applies fieldUpdates to the matching image entry after replace', async () => {
+      // 1st getDocument = lookup; 2nd = fresh re-read before patch.
+      firestoreMocks.getDocument
+        .mockResolvedValueOnce(recipeWithImages())
+        .mockResolvedValueOnce(recipeWithImages());
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+        fieldUpdates: { aiEnhanced: true },
+      });
+
+      const updateCall = firestoreMocks.updateDocument.mock.calls[0];
+      expect(updateCall[0]).toBe('recipes');
+      expect(updateCall[1]).toBe('recipe-9');
+      const updatedImages = updateCall[2].images;
+      expect(updatedImages.find((i) => i.id === 'img-1').aiEnhanced).toBe(true);
+      expect(updatedImages.find((i) => i.id === 'img-2').aiEnhanced).toBeUndefined();
+    });
+
+    it('skips the doc patch when fieldUpdates is empty or missing', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(recipeWithImages());
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob);
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+        fieldUpdates: {},
+      });
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('treats a fieldUpdates write failure as best-effort (logs, does not throw)', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(recipeWithImages());
+      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+          fieldUpdates: { aiEnhanced: true },
+        }),
+      ).resolves.toMatchObject({ backupCreated: true });
+
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
     });
   });
 });

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -7,16 +7,12 @@ import '../../../common/mocks/firebase-service.mock.js';
 
 let validateImageFile,
   getImageStoragePath,
-  deleteImageFiles,
-  setPrimaryImage,
   getRecipeImages,
   getImageUrl,
   getPlaceholderImageUrl,
   getOptimizedImageUrl,
   getPrimaryImage,
   getPrimaryImageUrl,
-  removeAllRecipeImages,
-  uploadAndBuildImageMetadata,
   addPendingImages,
   approvePendingImageById,
   rejectPendingImageById,
@@ -65,16 +61,12 @@ describe('recipe-image-utils', () => {
     const utils = await import('src/js/utils/recipes/recipe-image-utils.js');
     validateImageFile = utils.validateImageFile;
     getImageStoragePath = utils.getImageStoragePath;
-    deleteImageFiles = utils.deleteImageFiles;
-    setPrimaryImage = utils.setPrimaryImage;
     getRecipeImages = utils.getRecipeImages;
     getImageUrl = utils.getImageUrl;
     getPlaceholderImageUrl = utils.getPlaceholderImageUrl;
     getOptimizedImageUrl = utils.getOptimizedImageUrl;
     getPrimaryImage = utils.getPrimaryImage;
     getPrimaryImageUrl = utils.getPrimaryImageUrl;
-    removeAllRecipeImages = utils.removeAllRecipeImages;
-    uploadAndBuildImageMetadata = utils.uploadAndBuildImageMetadata;
     addPendingImages = utils.addPendingImages;
     approvePendingImageById = utils.approvePendingImageById;
     rejectPendingImageById = utils.rejectPendingImageById;
@@ -104,48 +96,6 @@ describe('recipe-image-utils', () => {
       expect(getImageStoragePath('id1', 'cat', 'file.jpg', 'full')).toBe(
         'img/recipes/full/cat/id1/file.jpg',
       );
-    });
-  });
-
-  describe('deleteImageFiles', () => {
-    it('deletes full and WebP variants', async () => {
-      await deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' });
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_1080x1080.webp');
-    });
-    it('silently ignores errors on variant deletion', async () => {
-      deleteFileMock
-        .mockResolvedValueOnce(undefined) // full OK
-        .mockRejectedValueOnce(new Error('not found')) // 400 variant missing
-        .mockRejectedValueOnce(new Error('not found')); // 1080 variant missing
-      await expect(
-        deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
-      ).resolves.not.toThrow();
-    });
-    it('propagates errors from full file deletion', async () => {
-      deleteFileMock.mockRejectedValueOnce(new Error('permission denied'));
-      await expect(
-        deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
-      ).rejects.toThrow('permission denied');
-    });
-  });
-
-  describe('setPrimaryImage', () => {
-    it('sets isPrimary on correct image', async () => {
-      getDocumentMock.mockResolvedValue({ images: [{ id: 'a' }, { id: 'b' }] });
-      updateDocumentMock.mockResolvedValue();
-      await setPrimaryImage('rid', 'b');
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [
-          { id: 'a', isPrimary: false },
-          { id: 'b', isPrimary: true },
-        ],
-      });
-    });
-    it('throws if no images', async () => {
-      getDocumentMock.mockResolvedValue({});
-      await expect(setPrimaryImage('rid', 'b')).rejects.toThrow();
     });
   });
 
@@ -262,87 +212,6 @@ describe('recipe-image-utils', () => {
       await expect(getPrimaryImageUrl({ images: [] })).resolves.toBeNull();
       await expect(getPrimaryImageUrl({})).resolves.toBeNull();
       await expect(getPrimaryImageUrl(null)).resolves.toBeNull();
-    });
-  });
-
-  describe('removeAllRecipeImages', () => {
-    it('removes all approved and pending images and updates Firestore', async () => {
-      getDocumentMock.mockResolvedValue({
-        images: [
-          { id: 'a', full: 'img/recipes/full/cat/rid/a.jpg' },
-          { id: 'b', full: 'img/recipes/full/cat/rid/b.jpg' },
-        ],
-        pendingImages: [
-          { id: 'p1', full: 'img/recipes/full/cat/rid/p1.jpg' },
-          { id: 'p2', full: 'img/recipes/full/cat/rid/p2.jpg' },
-        ],
-      });
-      updateDocumentMock.mockResolvedValue();
-      await removeAllRecipeImages('rid');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/a.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/a_400x400.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/b.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/p1.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/p2.jpg');
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [],
-        pendingImages: [],
-      });
-    });
-    it('handles missing recipe gracefully', async () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      getDocumentMock.mockResolvedValue(null);
-      await expect(removeAllRecipeImages('rid')).resolves.toBeUndefined();
-      expect(deleteFileMock).not.toHaveBeenCalled();
-      expect(updateDocumentMock).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith('Recipe not found for image removal:', 'rid');
-      consoleSpy.mockRestore();
-    });
-    it('handles empty images and pendingImages arrays', async () => {
-      getDocumentMock.mockResolvedValue({ images: [], pendingImages: [] });
-      updateDocumentMock.mockResolvedValue();
-      await removeAllRecipeImages('rid');
-      expect(deleteFileMock).not.toHaveBeenCalled();
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [],
-        pendingImages: [],
-      });
-    });
-  });
-
-  describe('uploadAndBuildImageMetadata', () => {
-    it('uploads full image and returns correct metadata', async () => {
-      uploadFileMock.mockResolvedValue('url');
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1234);
-      const meta = await uploadAndBuildImageMetadata({
-        recipeId: 'rid',
-        category: 'cat',
-        file,
-        isPrimary: true,
-        uploadedBy: 'user1',
-      });
-      expect(uploadFileMock).toHaveBeenCalledTimes(1);
-      expect(meta).toHaveProperty('id');
-      expect(meta.full).toContain('img/recipes/full/cat/rid/');
-      expect(meta.fileName).toBe('primary.jpg');
-      expect(meta.isPrimary).toBe(true);
-      expect(meta.uploadedBy).toBe('user1');
-      expect(meta.access).toBe('public');
-      expect(meta.uploadTimestamp).toBeDefined();
-    });
-    it('uses a timestamped fileName for non-primary', async () => {
-      uploadFileMock.mockResolvedValue('url');
-      const file = createFakeFile('test2.jpg', 'image/jpeg', 1234);
-      const meta = await uploadAndBuildImageMetadata({
-        recipeId: 'rid',
-        category: 'cat',
-        file,
-        isPrimary: false,
-        uploadedBy: 'user2',
-      });
-      expect(meta.fileName).toMatch(/\.jpg$/);
-      expect(meta.isPrimary).toBe(false);
-      expect(meta.uploadedBy).toBe('user2');
     });
   });
 


### PR DESCRIPTION
Part of #211 (and prerequisite for #215).

## What
Cleanly split the recipe image domain into **storage-only** and **doc-aware** halves so the umbrella's "one owner per Firestore doc" rule holds:

- **`RecipeImageService`** becomes Firestore-free. New API:
  - `uploadFiles(recipeId, category, file, uploadedBy, isPrimary = false)`
  - `deleteFiles(image)`
  - `migrateFilesToCategory(recipeId, image, newCategory)`
  - `replaceFiles(recipeId, image, blob, options)`
- **`RecipeService`** gains the doc-aware composites:
  - `setPrimaryImage(recipeId, imageId)` — pure doc patch on `images[].isPrimary`
  - `replaceImage(recipeId, imageId, blob, options)` — looks up the image, delegates bytes to `RecipeImageService.replaceFiles`, optionally patches the matching image entry
- `removeAllRecipeImages` is **inlined into `RecipeService.delete`** using the already-fetched recipe doc (no separate public method, no double-read).
- **5 write exports gone** from `src/js/utils/recipes/recipe-image-utils.js`: `deleteImageFiles`, `setPrimaryImage`, `removeAllRecipeImages`, `migrateImageToCategory`, `uploadAndBuildImageMetadata`. `deleteImageFiles` stays as an unexported helper used only by `rejectPendingImageById` — Q2 will inline it.
- Callers updated:
  - `image-approval-multi.js`: 4× `RecipeImageService.setPrimaryImage` → `RecipeService.setPrimaryImage`
  - `ai-image-enhance-modal.js`: 1× `RecipeImageService.replaceImage` → `RecipeService.replaceImage`

## Verify
- `grep -E "^export (async )?function (deleteImageFiles|setPrimaryImage|removeAllRecipeImages|migrateImageToCategory|uploadAndBuildImageMetadata)" src/js/utils/recipes/recipe-image-utils.js` → empty
- `grep "FirestoreService\." src/js/services/recipes/recipe-image-service.js` → empty
- `grep -rn "RecipeImageService\.\(setPrimaryImage\|replaceImage\)" src/ --include="*.js"` → empty
- `npm run lint` — 0 errors (pre-existing warning in `functions/recipe-transfer.js` unrelated)
- `npm test` — 529/529 pass
- `npm run build` — green

## Smoke (manual after merge)
- Propose recipe with images → verify image upload still lands at `img/recipes/full/<cat>/<id>/...`
- Edit recipe with category change → verify image migration to new path
- Delete recipe → verify image + pending-image files cleaned up
- Image approval (manager) → approve / reject / set primary
- AI image enhance → save → verify `_original` backup written

Acceptance criteria from the plan all hit:
- 5 write exports gone from `recipe-image-utils.js` ✓
- `RecipeImageService` has zero `FirestoreService.*` calls in its write surface ✓
- All gates green ✓