### PR TITLE
refactor(recipes): move setPrimaryImage to RecipeService (PR-Q1a-1)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -2,7 +2,6 @@
 
 import { FirestoreService } from '../_firebase/firestore-service.js';
 import { StorageService } from '../_firebase/storage-service.js';
-import { setPrimaryImage as setPrimaryImageInternal } from '../../utils/recipes/recipe-image-utils.js';
 
 const RECIPES_COLLECTION = 'recipes';
 
@@ -30,24 +29,12 @@ async function fileExists(path) {
  * inside `recipes/{id}.images[]`.
  *
  * Public API:
- *   - setPrimaryImage(recipeId, imageId)
  *   - replaceImage(recipeId, imageId, blob, options)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
+ * Primary-image selection now lives on RecipeService.
  */
 export class RecipeImageService {
-  /**
-   * Mark a single image on a recipe as the primary one. Clears `isPrimary`
-   * on the rest. Throws if the recipe has no images.
-   *
-   * @param {string} recipeId
-   * @param {string} imageId
-   * @returns {Promise<void>}
-   */
-  static async setPrimaryImage(recipeId, imageId) {
-    return await setPrimaryImageInternal(recipeId, imageId);
-  }
-
   /**
    * Replace an existing image's storage file with new bytes. Optionally
    * preserves the current image as a backup at `<path>_original.<ext>`

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -26,6 +26,7 @@ import {
  *   - create({ recipeData, imagesToUpload, mediaItemsOrdered, uploadedBy })
  *   - update(recipeId, { changes, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved })
  *   - delete(recipeId)
+ *   - setPrimaryImage(recipeId, imageId)
  *
  * Image proposal/moderation (the pending-images workflow) lives in
  * RecipeImageProposalService.
@@ -382,6 +383,26 @@ export class RecipeService {
     }
 
     await FirestoreService.deleteDocument(RECIPES_COLLECTION, recipeId);
+  }
+
+  /**
+   * Mark a single image on a recipe as primary; clears `isPrimary` on
+   * the rest. Throws if the recipe has no images.
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @returns {Promise<void>}
+   */
+  static async setPrimaryImage(recipeId, imageId) {
+    if (!recipeId) throw new Error('RecipeService.setPrimaryImage: recipeId is required');
+    if (!imageId) throw new Error('RecipeService.setPrimaryImage: imageId is required');
+
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe || !Array.isArray(recipe.images)) {
+      throw new Error('RecipeService.setPrimaryImage: no images to update');
+    }
+    const images = recipe.images.map((img) => ({ ...img, isPrimary: img.id === imageId }));
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { images });
   }
 }
 

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -22,7 +22,6 @@
  *   - getPendingImages(recipeId): Get all pending images for a recipe.
  *
  * Approved Images:
- *   - setPrimaryImage(recipeId, imageId): Set the primary image for a recipe.
  *   - getRecipeImages(recipe, userRole): Get accessible images for a user role.
  *   - getPrimaryImage(recipe): Get the primary image object.
  *   - getPrimaryImageUrl(recipe, size): Get the download URL for the primary image (optimized) or placeholder.
@@ -123,19 +122,6 @@ export async function deleteImageFiles({ full }) {
     StorageService.deleteFile(originalOpt400).catch(() => {}),
     StorageService.deleteFile(originalOpt1080).catch(() => {}),
   ]);
-}
-
-/**
- * Sets the primary image for a recipe
- * @param {string} recipeId
- * @param {string} imageId
- * @returns {Promise<void>}
- */
-export async function setPrimaryImage(recipeId, imageId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe || !Array.isArray(recipe.images)) throw new Error('No images to update');
-  const images = recipe.images.map((img) => ({ ...img, isPrimary: img.id === imageId }));
-  await updateRecipeDoc(recipeId, { images });
 }
 
 // --- Retrieval ---

--- a/src/lib/modals/image-approval-multi/image-approval-multi.js
+++ b/src/lib/modals/image-approval-multi/image-approval-multi.js
@@ -36,7 +36,7 @@
  */
 
 import { getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
-import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
+import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { RecipeImageProposalService } from '../../../js/services/recipes/recipe-image-proposal-service.js';
 
 class ImageApprovalMulti extends HTMLElement {
@@ -476,14 +476,14 @@ class ImageApprovalMulti extends HTMLElement {
       if (this.primaryImageId) {
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = Array.from(this.selectedImageIds)[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {
@@ -570,14 +570,14 @@ class ImageApprovalMulti extends HTMLElement {
         // Admin explicitly selected a primary - honor their choice
         const newPrimaryId = pendingToApprovedIds.get(this.primaryImageId);
         if (newPrimaryId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, newPrimaryId);
+          await RecipeService.setPrimaryImage(this.recipe.id, newPrimaryId);
           console.log('Primary image set to admin selection:', newPrimaryId);
         }
       } else if (!recipeHadImages) {
         const firstPendingId = visibleImageIds[0];
         const firstNewId = pendingToApprovedIds.get(firstPendingId);
         if (firstNewId) {
-          await RecipeImageService.setPrimaryImage(this.recipe.id, firstNewId);
+          await RecipeService.setPrimaryImage(this.recipe.id, firstNewId);
           console.log('First image set as primary (recipe had no images):', firstNewId);
         }
       } else {

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -18,17 +18,12 @@ const storageMocks = {
   deleteFile: jest.fn(() => Promise.resolve()),
 };
 
-const imageUtilMocks = {
-  setPrimaryImage: jest.fn(() => Promise.resolve()),
-};
-
 jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
   FirestoreService: firestoreMocks,
 }));
 jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
   StorageService: storageMocks,
 }));
-jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
 
 beforeAll(() => {
   // jsdom doesn't ship `fetch`; the service calls it during the backup-fetch path.
@@ -41,21 +36,12 @@ beforeEach(async () => {
   Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   Object.values(storageMocks).forEach((m) => m.mockReset?.());
   storageMocks.deleteFile.mockImplementation(() => Promise.resolve());
-  Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
-  imageUtilMocks.setPrimaryImage.mockImplementation(() => Promise.resolve());
   global.fetch.mockReset();
 
   ({ RecipeImageService } = await import('src/js/services/recipes/recipe-image-service.js'));
 });
 
 describe('RecipeImageService', () => {
-  describe('setPrimaryImage', () => {
-    it('delegates to the recipe-image-utils helper', async () => {
-      await RecipeImageService.setPrimaryImage('recipe-x', 'img-1');
-      expect(imageUtilMocks.setPrimaryImage).toHaveBeenCalledWith('recipe-x', 'img-1');
-    });
-  });
-
   describe('replaceImage', () => {
     const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
 

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -370,4 +370,38 @@ describe('RecipeService', () => {
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-y');
     });
   });
+
+  describe('setPrimaryImage', () => {
+    it('updates isPrimary on the matching image and clears the rest', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        images: [
+          { id: 'a', isPrimary: true },
+          { id: 'b', isPrimary: false },
+        ],
+      });
+      firestoreMocks.updateDocument.mockResolvedValue();
+
+      await RecipeService.setPrimaryImage('recipe-9', 'b');
+
+      expect(firestoreMocks.updateDocument).toHaveBeenCalledWith('recipes', 'recipe-9', {
+        images: [
+          { id: 'a', isPrimary: false },
+          { id: 'b', isPrimary: true },
+        ],
+      });
+    });
+
+    it('throws if the recipe has no images', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'recipe-9' });
+      await expect(RecipeService.setPrimaryImage('recipe-9', 'b')).rejects.toThrow(
+        'no images to update',
+      );
+    });
+
+    it('throws on missing recipeId / imageId', async () => {
+      await expect(RecipeService.setPrimaryImage('', 'b')).rejects.toThrow('recipeId is required');
+      await expect(RecipeService.setPrimaryImage('r', '')).rejects.toThrow('imageId is required');
+    });
+  });
 });

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -8,7 +8,6 @@ import '../../../common/mocks/firebase-service.mock.js';
 let validateImageFile,
   getImageStoragePath,
   deleteImageFiles,
-  setPrimaryImage,
   getRecipeImages,
   getImageUrl,
   getPlaceholderImageUrl,
@@ -66,7 +65,6 @@ describe('recipe-image-utils', () => {
     validateImageFile = utils.validateImageFile;
     getImageStoragePath = utils.getImageStoragePath;
     deleteImageFiles = utils.deleteImageFiles;
-    setPrimaryImage = utils.setPrimaryImage;
     getRecipeImages = utils.getRecipeImages;
     getImageUrl = utils.getImageUrl;
     getPlaceholderImageUrl = utils.getPlaceholderImageUrl;
@@ -128,24 +126,6 @@ describe('recipe-image-utils', () => {
       await expect(
         deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
       ).rejects.toThrow('permission denied');
-    });
-  });
-
-  describe('setPrimaryImage', () => {
-    it('sets isPrimary on correct image', async () => {
-      getDocumentMock.mockResolvedValue({ images: [{ id: 'a' }, { id: 'b' }] });
-      updateDocumentMock.mockResolvedValue();
-      await setPrimaryImage('rid', 'b');
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [
-          { id: 'a', isPrimary: false },
-          { id: 'b', isPrimary: true },
-        ],
-      });
-    });
-    it('throws if no images', async () => {
-      getDocumentMock.mockResolvedValue({});
-      await expect(setPrimaryImage('rid', 'b')).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
Part of #211. First of 5 mini-PRs that together replace the original PR-Q1a, each scoped to one function + its call sites so it can be tested end-to-end.

## What changed
\`setPrimaryImage\` is now part of **RecipeService** (the recipe-doc owner). Before this PR the image-approval modal wrote primary-image state through \`RecipeImageService.setPrimaryImage\` → utils helper → Firestore, which made \`RecipeImageService\` a partial owner of \`recipes/{id}\` — duplicating responsibility with \`RecipeService\`.

- **Added**: \`RecipeService.setPrimaryImage(recipeId, imageId)\` (reads recipe doc, maps \`isPrimary\` flag, writes back).
- **Migrated**: \`src/lib/modals/image-approval-multi/image-approval-multi.js\` — 4 call sites + import switch from \`RecipeImageService\` → \`RecipeService\`.
- **Removed**: \`RecipeImageService.setPrimaryImage\` (was a passthrough).
- **Removed**: utils \`setPrimaryImage\` export (no remaining callers).

## Verify (no need to pull yet)
- \`npm run lint\` — 0 errors (pre-existing unrelated warning in \`functions/\`)
- \`npm test\` — 526/526 pass
- \`npm run build\` — green
- \`git diff --stat\` — 7 files, +61 / -67

## User flow to test (after pulling)
\`\`\`
git fetch origin && git checkout refactor/pr-q1a-1-set-primary
\`\`\`
1. As a manager, open a recipe with pending images.
2. Use the **image approval modal**: pick one or more pending images, select a different one as primary.
3. Approve. Confirm the primary image on the recipe doc updated to your selection (e.g. the home/categories card thumbnail switches).
4. Also try the path where the recipe had **no images before** and you approve a batch — the first should become primary automatically.
5. Try the path where you approve more pending images on a recipe that **already has a primary** but you don't explicitly select one — the existing primary should be preserved.

If all 3 paths work, this PR is good to merge.

## Next
On approval → merge to \`refactor/service-layer\` → start **Q1a-2** (\`replaceImage\` end-to-end, AI image enhance flow).