### PR TITLE
chore(jest): ignore .claude/worktrees in test path discovery

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -152,7 +152,12 @@ const config = {
   testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)', '**/?(*.)+(spec|test).mjs'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ['/node_modules/', '/tests/common/mocks/', '/tests/visuals/'],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/tests/common/mocks/',
+    '/tests/visuals/',
+    '<rootDir>/.claude/worktrees/',
+  ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],


### PR DESCRIPTION
## What changed

One-line addition to `jest.config.mjs` — `testPathIgnorePatterns` now also skips `<rootDir>/.claude/worktrees/`.

## Why

When agent worktrees live under `.claude/worktrees/`, running `npm test` from the main repo discovers their test files. Those tests resolve `src/*` imports through `moduleNameMapper` rooted at the **main repo's** `<rootDir>`, not the worktree's. So a worktree test that exercises a method only present in the worktree's source (e.g. PR-Q1a-1's `RecipeService.setPrimaryImage`) fails against the main repo's source — producing confusing "function is not defined" errors that don't reflect the PR itself being broken.

Anchoring with `<rootDir>` is important: a plain `/.claude/worktrees/` substring would also match when running tests *from inside* a worktree (because the worktree path contains `.claude/worktrees/`), erasing all test discovery there. The `<rootDir>` prefix scopes it to "ignore the worktrees subdirectory of whatever the current rootDir is" — main repo skips worktree tests; worktrees keep finding their own tests.

## Verify

- From main repo (`/home/roiguri/projects/private/My-Cook-Book/`): `npm test` → **27 suites, 526 tests pass** (previously 54 suites / 1052 tests, with 3 failing from worktree).
- From a worktree (`.claude/worktrees/pr-q1a-image-writes/`): `npm test` → **27 suites, 526 tests pass** (worktree's own tests still discovered).
- Lint: 0 errors. Build: green. Prettier: clean.

## User flow to test

This is config-only; no app behavior changes. Manual verification:
1. `git checkout refactor/jest-ignore-worktrees` in the main repo.
2. `npm test` — confirm 526 tests pass and the worktree's `recipe-service.test.mjs` is not in the output.
3. `cd .claude/worktrees/pr-q1a-image-writes && npm test` — confirm the worktree still runs its own 526 tests.

## Next

Once this merges into `refactor/service-layer`, PR-Q1a-1 (#236) tests will pass when run from your main repo, and future Q1a-* worktree PRs won't cause the same noise.

Refs #211.