### PR TITLE
refactor(recipes): move replaceImage to RecipeService (PR-Q1a-2)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -1,9 +1,6 @@
 // src/js/services/recipes/recipe-image-service.js
 
-import { FirestoreService } from '../_firebase/firestore-service.js';
 import { StorageService } from '../_firebase/storage-service.js';
-
-const RECIPES_COLLECTION = 'recipes';
 
 function makeBackupPath(fullPath) {
   return fullPath.replace(/(\.[^.]+)$/, '_original$1');
@@ -19,74 +16,43 @@ async function fileExists(path) {
 }
 
 /**
- * RecipeImageService — Image Lifecycle for Recipes
+ * RecipeImageService — Image Storage Operations
  *
- * Owns operations on the image files and image-entry metadata for a
- * recipe. Separated from RecipeService (which owns recipe doc CRUD) so
- * each service has a single responsibility: RecipeService manages the
- * recipe document; RecipeImageService manages what lives at the
- * Storage layer for a recipe's images plus the per-image entries
- * inside `recipes/{id}.images[]`.
+ * Owns the Storage-layer file operations for a recipe's images. Does NOT
+ * touch Firestore — recipe-document orchestration (image-entry lookups,
+ * patches, etc.) lives in RecipeService.
  *
  * Public API:
- *   - replaceImage(recipeId, imageId, blob, options)
+ *   - replaceFiles(recipeId, image, blob, options)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
- * Primary-image selection now lives on RecipeService.
+ * Primary-image selection and image-entry patches live on RecipeService.
  */
 export class RecipeImageService {
   /**
-   * Replace an existing image's storage file with new bytes. Optionally
-   * preserves the current image as a backup at `<path>_original.<ext>`
-   * (idempotent — only written if the backup doesn't already exist).
-   * Optionally patches the matching image entry inside
-   * `recipes/{id}.images[]` with caller-supplied fields.
+   * Replace an image's Storage file with new bytes. Optionally preserves
+   * the current file as a backup at `<path>_original.<ext>` (idempotent —
+   * only written if the backup doesn't already exist). Also best-effort
+   * deletes the stale 400/1080 WebP variants so consumers refresh promptly.
    *
-   * Steps:
-   *   1. Look up the image entry on the recipe doc. Throws if recipe
-   *      or image not found.
-   *   2. If keepOriginalBackup (default true) and no backup exists:
-   *      fetch the current image bytes and write them at the backup path.
-   *   3. Upload `blob` to the original path (overwrites). The Storage
-   *      Resize extension regenerates WebP variants asynchronously.
-   *   4. Best-effort: delete the stale _400x400.webp / _1080x1080.webp
-   *      variants at the original path so consumers refresh promptly.
-   *   5. If `fieldUpdates` is provided: best-effort merge it into the
-   *      matching image entry. A failure here logs but does NOT throw —
-   *      the image bytes already changed; the flag is cosmetic.
-   *
-   * @param {string} recipeId
-   * @param {string} imageId
-   * @param {Blob} blob - New image bytes (must be uploadable; e.g. from a fetch or canvas).
+   * @param {string} recipeId - Unused inside; kept in the signature for
+   * @param {{ full: string }} image - The image entry to replace (must have `.full`).
+   * @param {Blob} blob - New image bytes.
    * @param {Object} [options]
    * @param {boolean} [options.keepOriginalBackup=true]
-   * @param {Object} [options.fieldUpdates] - Patch merged into the matching image entry.
    * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
    */
-  static async replaceImage(recipeId, imageId, blob, options = {}) {
-    if (!recipeId) throw new Error('RecipeImageService.replaceImage: recipeId is required');
-    if (!imageId) throw new Error('RecipeImageService.replaceImage: imageId is required');
-    if (!blob) throw new Error('RecipeImageService.replaceImage: blob is required');
-
-    const { keepOriginalBackup = true, fieldUpdates } = options;
-
-    // 1. Look up the image entry.
-    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
-    if (!recipe) {
-      throw new Error(`RecipeImageService.replaceImage: recipe ${recipeId} not found`);
+  static async replaceFiles(recipeId, image, blob, options = {}) {
+    if (!image || !image.full) {
+      throw new Error('RecipeImageService.replaceFiles: image.full is required');
     }
-    const images = Array.isArray(recipe.images) ? recipe.images : [];
-    const image = images.find((img) => img.id === imageId);
-    if (!image) {
-      throw new Error(
-        `RecipeImageService.replaceImage: image ${imageId} not found on recipe ${recipeId}`,
-      );
-    }
+    if (!blob) throw new Error('RecipeImageService.replaceFiles: blob is required');
+
+    const { keepOriginalBackup = true } = options;
 
     const originalPath = image.full;
     const backupPath = makeBackupPath(originalPath);
 
-    // 2. Backup (idempotent).
     let backupCreated = false;
     if (keepOriginalBackup) {
       if (!(await fileExists(backupPath))) {
@@ -94,7 +60,7 @@ export class RecipeImageService {
         const response = await fetch(url);
         if (!response.ok) {
           throw new Error(
-            `RecipeImageService.replaceImage: failed to fetch original (${response.status})`,
+            `RecipeImageService.replaceFiles: failed to fetch original (${response.status})`,
           );
         }
         await StorageService.uploadFile(await response.blob(), backupPath);
@@ -102,38 +68,14 @@ export class RecipeImageService {
       }
     }
 
-    // 3. Overwrite the original.
     await StorageService.uploadFile(blob, originalPath);
 
-    // 4. Best-effort stale WebP variant cleanup so consumers refresh promptly.
     await Promise.all([
       StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp')).catch(() => {}),
       StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp')).catch(
         () => {},
       ),
     ]);
-
-    // 5. Best-effort image-entry patch.
-    if (fieldUpdates && Object.keys(fieldUpdates).length > 0) {
-      try {
-        const fresh = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
-        if (fresh && Array.isArray(fresh.images)) {
-          const updatedImages = fresh.images.map((img) =>
-            img.id === imageId ? { ...img, ...fieldUpdates } : img,
-          );
-          await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, {
-            images: updatedImages,
-          });
-        }
-      } catch (err) {
-        // The image bytes have already changed; failing the whole op
-        // because a metadata patch didn't land would be misleading.
-        console.error(
-          `RecipeImageService.replaceImage: fieldUpdates patch failed for image ${imageId}:`,
-          err,
-        );
-      }
-    }
 
     return { backupPath, backupCreated };
   }

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -1,6 +1,7 @@
 // src/js/services/recipes/recipe-service.js
 
 import { FirestoreService } from '../_firebase/firestore-service.js';
+import { RecipeImageService } from './recipe-image-service.js';
 import {
   uploadAndBuildImageMetadata,
   deleteImageFiles,
@@ -27,6 +28,7 @@ import {
  *   - update(recipeId, { changes, images, imagesToDelete, mediaItemsOrdered, uploadedBy, approved })
  *   - delete(recipeId)
  *   - setPrimaryImage(recipeId, imageId)
+ *   - replaceImage(recipeId, imageId, blob, options)
  *
  * Image proposal/moderation (the pending-images workflow) lives in
  * RecipeImageProposalService.
@@ -403,6 +405,67 @@ export class RecipeService {
     }
     const images = recipe.images.map((img) => ({ ...img, isPrimary: img.id === imageId }));
     await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { images });
+  }
+
+  /**
+   * Replace the bytes of an existing image on a recipe. Delegates Storage
+   * work (backup + overwrite + variant cleanup) to
+   * `RecipeImageService.replaceFiles`. Optionally patches the matching image
+   * entry inside `recipes/{id}.images[]` with caller-supplied fields
+   * (best-effort: the patch failure does NOT roll back the Storage write,
+   * since the bytes have already changed).
+   *
+   * @param {string} recipeId
+   * @param {string} imageId
+   * @param {Blob} blob - New image bytes.
+   * @param {Object} [options]
+   * @param {boolean} [options.keepOriginalBackup=true]
+   * @param {Object} [options.fieldUpdates] - Patch merged into the matching image entry.
+   * @returns {Promise<{ backupPath: string, backupCreated: boolean }>}
+   */
+  static async replaceImage(recipeId, imageId, blob, options = {}) {
+    if (!recipeId) throw new Error('RecipeService.replaceImage: recipeId is required');
+    if (!imageId) throw new Error('RecipeService.replaceImage: imageId is required');
+    if (!blob) throw new Error('RecipeService.replaceImage: blob is required');
+
+    const { keepOriginalBackup = true, fieldUpdates } = options;
+
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe) {
+      throw new Error(`RecipeService.replaceImage: recipe ${recipeId} not found`);
+    }
+    const images = Array.isArray(recipe.images) ? recipe.images : [];
+    const image = images.find((img) => img.id === imageId);
+    if (!image) {
+      throw new Error(
+        `RecipeService.replaceImage: image ${imageId} not found on recipe ${recipeId}`,
+      );
+    }
+
+    const result = await RecipeImageService.replaceFiles(recipeId, image, blob, {
+      keepOriginalBackup,
+    });
+
+    if (fieldUpdates && Object.keys(fieldUpdates).length > 0) {
+      try {
+        const fresh = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+        if (fresh && Array.isArray(fresh.images)) {
+          const updatedImages = fresh.images.map((img) =>
+            img.id === imageId ? { ...img, ...fieldUpdates } : img,
+          );
+          await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, {
+            images: updatedImages,
+          });
+        }
+      } catch (err) {
+        console.error(
+          `RecipeService.replaceImage: fieldUpdates patch failed for image ${imageId}:`,
+          err,
+        );
+      }
+    }
+
+    return result;
   }
 }
 

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -11,7 +11,7 @@
  */
 
 import { enhanceFoodImage } from '../../../js/services/recipes/ai-enhancement-service.js';
-import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
+import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { getImageUrl, getOptimizedImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { icons } from '../../../js/icons.js';
 import '../../utilities/modal/modal.js';
@@ -399,7 +399,7 @@ class AiImageEnhanceModal extends HTMLElement {
     this._setStatus('שומר את התמונה החדשה...');
 
     try {
-      const { backupPath, backupCreated } = await RecipeImageService.replaceImage(
+      const { backupPath, backupCreated } = await RecipeService.replaceImage(
         this._recipe.id,
         this._image.id,
         this._enhancedResult.blob,

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -6,11 +6,6 @@ import '../../common/mocks/firebase-service.mock.js';
 
 let RecipeImageService;
 
-const firestoreMocks = {
-  getDocument: jest.fn(),
-  updateDocument: jest.fn(),
-};
-
 const storageMocks = {
   getMetadata: jest.fn(),
   getFileUrl: jest.fn(),
@@ -18,22 +13,17 @@ const storageMocks = {
   deleteFile: jest.fn(() => Promise.resolve()),
 };
 
-jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
-  FirestoreService: firestoreMocks,
-}));
 jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
   StorageService: storageMocks,
 }));
 
 beforeAll(() => {
   // jsdom doesn't ship `fetch`; the service calls it during the backup-fetch path.
-  // Tests stub a Response-shaped object via this mock.
   global.fetch = jest.fn();
 });
 
 beforeEach(async () => {
   jest.resetModules();
-  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   Object.values(storageMocks).forEach((m) => m.mockReset?.());
   storageMocks.deleteFile.mockImplementation(() => Promise.resolve());
   global.fetch.mockReset();
@@ -42,67 +32,42 @@ beforeEach(async () => {
 });
 
 describe('RecipeImageService', () => {
-  describe('replaceImage', () => {
+  describe('replaceFiles', () => {
     const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
+    const image = { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg' };
 
-    function setupRecipeWithImage() {
-      firestoreMocks.getDocument.mockResolvedValue({
-        id: 'recipe-9',
-        images: [
-          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
-          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
-        ],
-      });
-    }
+    it('throws if image.full is missing', async () => {
+      await expect(RecipeImageService.replaceFiles('r', null, newBlob)).rejects.toThrow(
+        'image.full is required',
+      );
+      await expect(RecipeImageService.replaceFiles('r', {}, newBlob)).rejects.toThrow(
+        'image.full is required',
+      );
+    });
 
-    it('throws if recipeId / imageId / blob is missing', async () => {
-      await expect(RecipeImageService.replaceImage('', 'img-1', newBlob)).rejects.toThrow(
-        'recipeId is required',
-      );
-      await expect(RecipeImageService.replaceImage('r', '', newBlob)).rejects.toThrow(
-        'imageId is required',
-      );
-      await expect(RecipeImageService.replaceImage('r', 'i', null)).rejects.toThrow(
+    it('throws if blob is missing', async () => {
+      await expect(RecipeImageService.replaceFiles('r', image, null)).rejects.toThrow(
         'blob is required',
       );
     });
 
-    it('throws if the recipe is not found', async () => {
-      firestoreMocks.getDocument.mockResolvedValue(null);
-      await expect(RecipeImageService.replaceImage('missing', 'img-1', newBlob)).rejects.toThrow(
-        'recipe missing not found',
-      );
-    });
-
-    it('throws if the image id is not on the recipe', async () => {
-      setupRecipeWithImage();
-      await expect(
-        RecipeImageService.replaceImage('recipe-9', 'no-such-img', newBlob),
-      ).rejects.toThrow('image no-such-img not found');
-    });
-
     it('writes the backup when none exists, then overwrites the original', async () => {
-      setupRecipeWithImage();
-      // Backup missing → getMetadata rejects
       storageMocks.getMetadata.mockRejectedValueOnce(new Error('not-found'));
       storageMocks.getFileUrl.mockResolvedValue('https://storage/original-url');
       const originalBytes = new Blob(['original'], { type: 'image/jpeg' });
-      global.fetch.mockResolvedValue({
-        ok: true,
-        blob: async () => originalBytes,
+      global.fetch.mockResolvedValue({ ok: true, blob: async () => originalBytes });
+
+      const result = await RecipeImageService.replaceFiles('recipe-9', image, newBlob);
+
+      expect(result).toEqual({
+        backupPath: 'img/recipes/full/desserts/recipe-9/img-1_original.jpg',
+        backupCreated: true,
       });
-
-      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
-
-      expect(result.backupCreated).toBe(true);
-      expect(result.backupPath).toBe('img/recipes/full/desserts/recipe-9/img-1_original.jpg');
-      // 1st upload: backup
       expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
         1,
         originalBytes,
         'img/recipes/full/desserts/recipe-9/img-1_original.jpg',
       );
-      // 2nd upload: enhanced overwrite at original path
       expect(storageMocks.uploadFile).toHaveBeenNthCalledWith(
         2,
         newBlob,
@@ -111,15 +76,12 @@ describe('RecipeImageService', () => {
     });
 
     it('skips the backup write when one already exists', async () => {
-      setupRecipeWithImage();
-      // Backup already there → getMetadata resolves
       storageMocks.getMetadata.mockResolvedValue({ name: 'backup' });
 
-      const result = await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      const result = await RecipeImageService.replaceFiles('recipe-9', image, newBlob);
 
       expect(result.backupCreated).toBe(false);
       expect(global.fetch).not.toHaveBeenCalled();
-      // Only one upload: the overwrite
       expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
       expect(storageMocks.uploadFile).toHaveBeenCalledWith(
         newBlob,
@@ -128,23 +90,19 @@ describe('RecipeImageService', () => {
     });
 
     it('skips backup entirely when keepOriginalBackup is false', async () => {
-      setupRecipeWithImage();
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
+      await RecipeImageService.replaceFiles('recipe-9', image, newBlob, {
         keepOriginalBackup: false,
       });
 
       expect(storageMocks.getMetadata).not.toHaveBeenCalled();
       expect(global.fetch).not.toHaveBeenCalled();
-      // Only the overwrite upload
       expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
     });
 
     it('deletes stale 400 and 1080 WebP variants after overwrite (best-effort)', async () => {
-      setupRecipeWithImage();
       storageMocks.getMetadata.mockResolvedValue({});
 
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
+      await RecipeImageService.replaceFiles('recipe-9', image, newBlob);
 
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/img-1_400x400.webp',
@@ -154,72 +112,15 @@ describe('RecipeImageService', () => {
       );
     });
 
-    it('applies fieldUpdates to the matching image entry on the recipe doc', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-      // 2nd getDocument (the fresh re-read for the patch) returns the same recipe
-      firestoreMocks.getDocument.mockResolvedValue({
-        id: 'recipe-9',
-        images: [
-          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
-          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
-        ],
-      });
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-        fieldUpdates: { aiEnhanced: true },
-      });
-
-      const updateCall = firestoreMocks.updateDocument.mock.calls[0];
-      expect(updateCall[0]).toBe('recipes');
-      expect(updateCall[1]).toBe('recipe-9');
-      const updatedImages = updateCall[2].images;
-      expect(updatedImages.find((i) => i.id === 'img-1').aiEnhanced).toBe(true);
-      // Untargeted images are unchanged
-      expect(updatedImages.find((i) => i.id === 'img-2').aiEnhanced).toBeUndefined();
-      expect(updatedImages.find((i) => i.id === 'img-1').isPrimary).toBe(true);
-    });
-
-    it('skips the doc patch when fieldUpdates is empty or missing', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob);
-      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
-
-      await RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-        fieldUpdates: {},
-      });
-      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
-    });
-
-    it('treats a fieldUpdates write failure as best-effort (logs, does not throw)', async () => {
-      setupRecipeWithImage();
-      storageMocks.getMetadata.mockResolvedValue({});
-      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
-      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      await expect(
-        RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob, {
-          fieldUpdates: { aiEnhanced: true },
-        }),
-      ).resolves.toMatchObject({ backupCreated: false });
-
-      expect(errSpy).toHaveBeenCalled();
-      errSpy.mockRestore();
-    });
-
     it('throws when fetching the original for backup fails', async () => {
-      setupRecipeWithImage();
       storageMocks.getMetadata.mockRejectedValue(new Error('no backup yet'));
       storageMocks.getFileUrl.mockResolvedValue('https://storage/url');
       global.fetch.mockResolvedValue({ ok: false, status: 403 });
 
-      await expect(RecipeImageService.replaceImage('recipe-9', 'img-1', newBlob)).rejects.toThrow(
+      await expect(RecipeImageService.replaceFiles('recipe-9', image, newBlob)).rejects.toThrow(
         'failed to fetch original (403)',
       );
 
-      // Overwrite never happened
       expect(storageMocks.uploadFile).not.toHaveBeenCalled();
     });
   });

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -28,8 +28,17 @@ const mediaUtilMocks = {
   removeAllMediaInstructions: jest.fn(() => Promise.resolve({ success: 0, failed: 0, errors: [] })),
 };
 
+const recipeImageServiceMocks = {
+  replaceFiles: jest.fn(() =>
+    Promise.resolve({ backupPath: 'backup/path.jpg', backupCreated: true }),
+  ),
+};
+
 jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
   FirestoreService: firestoreMocks,
+}));
+jest.unstable_mockModule('src/js/services/recipes/recipe-image-service.js', () => ({
+  RecipeImageService: recipeImageServiceMocks,
 }));
 jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
 jest.unstable_mockModule('src/js/utils/recipes/recipe-media-utils.js', () => mediaUtilMocks);
@@ -48,6 +57,10 @@ beforeEach(async () => {
   Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
   mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
     Promise.resolve({ success: 0, failed: 0, errors: [] }),
+  );
+  Object.values(recipeImageServiceMocks).forEach((m) => m.mockReset?.());
+  recipeImageServiceMocks.replaceFiles.mockImplementation(() =>
+    Promise.resolve({ backupPath: 'backup/path.jpg', backupCreated: true }),
   );
 
   ({ RecipeService } = await import('src/js/services/recipes/recipe-service.js'));
@@ -402,6 +415,126 @@ describe('RecipeService', () => {
     it('throws on missing recipeId / imageId', async () => {
       await expect(RecipeService.setPrimaryImage('', 'b')).rejects.toThrow('recipeId is required');
       await expect(RecipeService.setPrimaryImage('r', '')).rejects.toThrow('imageId is required');
+    });
+  });
+
+  describe('replaceImage', () => {
+    const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
+
+    function setupRecipeWithImage() {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-9',
+        images: [
+          { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg', isPrimary: true },
+          { id: 'img-2', full: 'img/recipes/full/desserts/recipe-9/img-2.jpg' },
+        ],
+      });
+    }
+
+    it('throws on missing recipeId / imageId / blob', async () => {
+      await expect(RecipeService.replaceImage('', 'img-1', newBlob)).rejects.toThrow(
+        'recipeId is required',
+      );
+      await expect(RecipeService.replaceImage('r', '', newBlob)).rejects.toThrow(
+        'imageId is required',
+      );
+      await expect(RecipeService.replaceImage('r', 'i', null)).rejects.toThrow('blob is required');
+    });
+
+    it('throws if the recipe is not found', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      await expect(RecipeService.replaceImage('missing', 'img-1', newBlob)).rejects.toThrow(
+        'recipe missing not found',
+      );
+      expect(recipeImageServiceMocks.replaceFiles).not.toHaveBeenCalled();
+    });
+
+    it('throws if the image id is not on the recipe', async () => {
+      setupRecipeWithImage();
+      await expect(RecipeService.replaceImage('recipe-9', 'no-such-img', newBlob)).rejects.toThrow(
+        'image no-such-img not found',
+      );
+      expect(recipeImageServiceMocks.replaceFiles).not.toHaveBeenCalled();
+    });
+
+    it('delegates Storage work to RecipeImageService.replaceFiles and returns its result', async () => {
+      setupRecipeWithImage();
+      recipeImageServiceMocks.replaceFiles.mockResolvedValueOnce({
+        backupPath: 'img/recipes/full/desserts/recipe-9/img-1_original.jpg',
+        backupCreated: true,
+      });
+
+      const result = await RecipeService.replaceImage('recipe-9', 'img-1', newBlob);
+
+      expect(recipeImageServiceMocks.replaceFiles).toHaveBeenCalledWith(
+        'recipe-9',
+        expect.objectContaining({
+          id: 'img-1',
+          full: 'img/recipes/full/desserts/recipe-9/img-1.jpg',
+        }),
+        newBlob,
+        { keepOriginalBackup: true },
+      );
+      expect(result).toEqual({
+        backupPath: 'img/recipes/full/desserts/recipe-9/img-1_original.jpg',
+        backupCreated: true,
+      });
+    });
+
+    it('forwards keepOriginalBackup=false to replaceFiles', async () => {
+      setupRecipeWithImage();
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+        keepOriginalBackup: false,
+      });
+
+      expect(recipeImageServiceMocks.replaceFiles).toHaveBeenCalledWith(
+        'recipe-9',
+        expect.any(Object),
+        newBlob,
+        { keepOriginalBackup: false },
+      );
+    });
+
+    it('applies fieldUpdates to the matching image entry on the recipe doc', async () => {
+      setupRecipeWithImage();
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+        fieldUpdates: { aiEnhanced: true },
+      });
+
+      const updateCall = firestoreMocks.updateDocument.mock.calls[0];
+      expect(updateCall[0]).toBe('recipes');
+      expect(updateCall[1]).toBe('recipe-9');
+      const updatedImages = updateCall[2].images;
+      expect(updatedImages.find((i) => i.id === 'img-1').aiEnhanced).toBe(true);
+      expect(updatedImages.find((i) => i.id === 'img-2').aiEnhanced).toBeUndefined();
+      expect(updatedImages.find((i) => i.id === 'img-1').isPrimary).toBe(true);
+    });
+
+    it('skips the doc patch when fieldUpdates is empty or missing', async () => {
+      setupRecipeWithImage();
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob);
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+
+      await RecipeService.replaceImage('recipe-9', 'img-1', newBlob, { fieldUpdates: {} });
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('treats a fieldUpdates write failure as best-effort (logs, does not throw)', async () => {
+      setupRecipeWithImage();
+      firestoreMocks.updateDocument.mockRejectedValue(new Error('boom'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(
+        RecipeService.replaceImage('recipe-9', 'img-1', newBlob, {
+          fieldUpdates: { aiEnhanced: true },
+        }),
+      ).resolves.toMatchObject({ backupCreated: true });
+
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## What changed

Splits the previous monolithic `RecipeImageService.replaceImage` (which mixed Firestore lookup + image-entry patching with Storage backup/overwrite) into a clean two-layer flow:

- **`RecipeImageService.replaceFiles(recipeId, image, blob, options)`** — Storage only. Takes a pre-fetched typed `image` (must have `.full`), writes the idempotent `_original` backup, overwrites the file, and best-effort deletes stale `_400x400.webp` / `_1080x1080.webp` variants. **No Firestore.**
- **`RecipeService.replaceImage(recipeId, imageId, blob, options)`** — Owner. Validates inputs, reads the recipe doc, finds the image entry by id, delegates Storage to `RecipeImageService.replaceFiles`, then best-effort patches the matching image entry with `fieldUpdates`. Patch failure does NOT roll back (bytes already changed).

Single caller (`ai-image-enhance-modal.js`) migrated. `RecipeImageService` no longer touches Firestore for write ops; `RecipeService` remains the sole owner of `recipes/{id}`.

5 files changed, +238/−199.

## Verify

- `npm test` → **27 suites / 530 tests pass** (was 526; +4 net).
- Targeted: `recipe-image-service` + `recipe-service` → 38/38, 100% line coverage on `recipe-image-service.js`, 97% on `recipe-service.js`.
- `npm run lint` → 0 errors.
- `npx prettier --check` on touched files → clean.
- `npm run build` → ✓.
- Grep: zero remaining references to `RecipeImageService.replaceImage` in `src/`.

## User flow to test

1. `git checkout refactor/pr-q1a-2-replace-image && npm run dev` (or `netlify dev`).
2. Sign in as a manager / approved user. Open a recipe that has at least one image.
3. Open the **AI image-enhance modal** on an existing image.
4. **Enhance** the image, then **Save**.
5. Expect:
   - Toast: "התמונה הוחלפה. התמונה המקורית נשמרה כגיבוי."
   - In Firebase Storage (`img/recipes/full/<category>/<recipeId>/`), the original file is replaced **and** a sibling `<imageId>_original.<ext>` exists.
   - Stale `_400x400.webp` / `_1080x1080.webp` variants deleted (Storage resize extension regenerates them).
   - On page refresh, the recipe doc shows the image with `aiEnhanced: true` and the new bytes display.
6. Re-enhance the **same** image → `_original` is **not** overwritten (idempotent backup).

## Next

After merge → PR-Q1a-3 (`uploadAndBuildImageMetadata` → `RecipeImageService.uploadFiles`).

Refs #211.