### PR TITLE
refactor(recipes): move uploadAndBuildImageMetadata to RecipeImageService.uploadFile (PR-Q1a-3)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -1,6 +1,7 @@
 // src/js/services/recipes/recipe-image-service.js
 
 import { StorageService } from '../_firebase/storage-service.js';
+import { getImageStoragePath, generateImageId } from '../../utils/recipes/recipe-image-utils.js';
 
 function makeBackupPath(fullPath) {
   return fullPath.replace(/(\.[^.]+)$/, '_original$1');
@@ -23,12 +24,47 @@ async function fileExists(path) {
  * patches, etc.) lives in RecipeService.
  *
  * Public API:
+ *   - uploadFile(recipeId, category, file, options)
  *   - replaceFiles(recipeId, image, blob, options)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
  * Primary-image selection and image-entry patches live on RecipeService.
  */
 export class RecipeImageService {
+  /**
+   * Upload a single image file to Storage under the recipe's category path
+   * and return its metadata entry (id, full path, fileName, isPrimary,
+   * uploadedBy, access, uploadTimestamp). Storage only — does NOT touch
+   * `recipes/{id}.images[]`; caller is responsible for persisting the
+   * returned entry on the recipe document. The Storage Resize extension
+   * regenerates WebP variants asynchronously.
+   *
+   * @param {string} recipeId
+   * @param {string} category
+   * @param {File} file
+   * @param {Object} [options]
+   * @param {boolean} [options.isPrimary=false]
+   * @param {string} [options.uploadedBy]
+   * @returns {Promise<Object>} image metadata entry
+   */
+  static async uploadFile(recipeId, category, file, options = {}) {
+    const { isPrimary = false, uploadedBy } = options;
+    const fileExtension = file.name.split('.').pop();
+    const fileName = isPrimary ? 'primary.jpg' : `${Date.now()}.${fileExtension}`;
+    const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
+    await StorageService.uploadFile(file, fullPath);
+
+    return {
+      id: generateImageId(),
+      full: fullPath,
+      fileName,
+      isPrimary,
+      uploadedBy,
+      access: 'public',
+      uploadTimestamp: new Date(),
+    };
+  }
+
   /**
    * Replace an image's Storage file with new bytes. Optionally preserves
    * the current file as a backup at `<path>_original.<ext>` (idempotent —

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -3,7 +3,6 @@
 import { FirestoreService } from '../_firebase/firestore-service.js';
 import { RecipeImageService } from './recipe-image-service.js';
 import {
-  uploadAndBuildImageMetadata,
   deleteImageFiles,
   migrateImageToCategory,
   removeAllRecipeImages,
@@ -41,10 +40,7 @@ async function uploadImagesAtomic(recipeId, category, imagesToUpload, uploadedBy
   // rejects — Promise.all leaves us blind to which uploads actually landed.
   const settled = await Promise.allSettled(
     imagesToUpload.map(({ file, isPrimary }) =>
-      uploadAndBuildImageMetadata({
-        recipeId,
-        category,
-        file,
+      RecipeImageService.uploadFile(recipeId, category, file, {
         isPrimary: !!isPrimary,
         uploadedBy: uploadedBy || 'anonymous',
       }),
@@ -300,10 +296,7 @@ export class RecipeService {
       try {
         for (const img of images) {
           if (img.source === 'new' && img.file) {
-            const meta = await uploadAndBuildImageMetadata({
-              recipeId,
-              category: newCategory,
-              file: img.file,
+            const meta = await RecipeImageService.uploadFile(recipeId, newCategory, img.file, {
               isPrimary: !!img.isPrimary,
               uploadedBy: img.uploadedBy || uploadedBy || 'anonymous',
             });

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -30,7 +30,6 @@
  *   - getPlaceholderImageUrl(): Get the placeholder image URL.
  *   - removeAllRecipeImages(recipeId): Remove all images (approved and pending) for a recipe.
  *   - migrateImageToCategory(image, recipeId, oldCategory, newCategory): Migrate image to new category path.
- *   - uploadAndBuildImageMetadata({ recipeId, category, file, isPrimary, uploadedBy }): Upload and return metadata for an image.
  */
 
 /**
@@ -328,39 +327,6 @@ export async function migrateImageToCategory(image, recipeId, oldCategory, newCa
     );
     throw new Error(`Failed to migrate image ${image.id}: ${error.message}`);
   }
-}
-
-/**
- * Uploads a recipe image (full only) and returns metadata
- * @param {Object} params
- * @param {string} recipeId
- * @param {string} category
- * @param {File} file
- * @param {boolean} isPrimary
- * @param {string} uploadedBy
- * @returns {Promise<Object>} image metadata
- */
-export async function uploadAndBuildImageMetadata({
-  recipeId,
-  category,
-  file,
-  isPrimary,
-  uploadedBy,
-}) {
-  const fileExtension = file.name.split('.').pop();
-  const fileName = isPrimary ? 'primary.jpg' : `${Date.now()}.${fileExtension}`;
-  const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
-  await StorageService.uploadFile(file, fullPath);
-
-  return {
-    id: generateImageId(),
-    full: fullPath,
-    fileName,
-    isPrimary,
-    uploadedBy,
-    access: 'public',
-    uploadTimestamp: new Date(),
-  };
 }
 
 /**

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -32,6 +32,62 @@ beforeEach(async () => {
 });
 
 describe('RecipeImageService', () => {
+  describe('uploadFile', () => {
+    function makeFile(name = 'test.jpg', type = 'image/jpeg') {
+      return new File([new Blob(['a'], { type })], name, { type });
+    }
+
+    it('uploads to category path and returns metadata with primary.jpg filename when isPrimary', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('foo.jpg');
+
+      const meta = await RecipeImageService.uploadFile('r1', 'desserts', file, {
+        isPrimary: true,
+        uploadedBy: 'user-1',
+      });
+
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
+      const [uploadedFile, uploadedPath] = storageMocks.uploadFile.mock.calls[0];
+      expect(uploadedFile).toBe(file);
+      expect(uploadedPath).toBe('img/recipes/full/desserts/r1/primary.jpg');
+
+      expect(meta).toMatchObject({
+        full: 'img/recipes/full/desserts/r1/primary.jpg',
+        fileName: 'primary.jpg',
+        isPrimary: true,
+        uploadedBy: 'user-1',
+        access: 'public',
+      });
+      expect(typeof meta.id).toBe('string');
+      expect(meta.uploadTimestamp).toBeInstanceOf(Date);
+    });
+
+    it('uses a timestamped filename keeping the extension when not primary', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('cake.png', 'image/png');
+
+      const meta = await RecipeImageService.uploadFile('r2', 'mains', file, {
+        isPrimary: false,
+        uploadedBy: 'user-2',
+      });
+
+      expect(meta.fileName).toMatch(/^\d+\.png$/);
+      expect(meta.full).toBe(`img/recipes/full/mains/r2/${meta.fileName}`);
+      expect(meta.isPrimary).toBe(false);
+    });
+
+    it('propagates Storage upload errors', async () => {
+      storageMocks.uploadFile.mockRejectedValue(new Error('storage down'));
+
+      await expect(
+        RecipeImageService.uploadFile('r3', 'sides', makeFile(), {
+          isPrimary: true,
+          uploadedBy: 'user-3',
+        }),
+      ).rejects.toThrow('storage down');
+    });
+  });
+
   describe('replaceFiles', () => {
     const newBlob = new Blob(['enhanced'], { type: 'image/jpeg' });
     const image = { id: 'img-1', full: 'img/recipes/full/desserts/recipe-9/img-1.jpg' };

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -17,7 +17,6 @@ const firestoreMocks = {
 };
 
 const imageUtilMocks = {
-  uploadAndBuildImageMetadata: jest.fn(),
   deleteImageFiles: jest.fn(() => Promise.resolve()),
   migrateImageToCategory: jest.fn(),
   removeAllRecipeImages: jest.fn(() => Promise.resolve()),
@@ -29,6 +28,7 @@ const mediaUtilMocks = {
 };
 
 const recipeImageServiceMocks = {
+  uploadFile: jest.fn(),
   replaceFiles: jest.fn(() =>
     Promise.resolve({ backupPath: 'backup/path.jpg', backupCreated: true }),
   ),
@@ -90,7 +90,7 @@ describe('RecipeService', () => {
 
   describe('create', () => {
     it('uploads images, writes doc, returns id and media result', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFile
         .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
         .mockResolvedValueOnce({ id: 'img-2', full: 'p/2.jpg' });
       firestoreMocks.setDocument.mockResolvedValue();
@@ -113,7 +113,7 @@ describe('RecipeService', () => {
         successCount: 0,
         failedCount: 0,
       });
-      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(2);
+      expect(recipeImageServiceMocks.uploadFile).toHaveBeenCalledTimes(2);
       expect(firestoreMocks.setDocument).toHaveBeenCalledWith(
         'recipes',
         'recipe-123',
@@ -141,7 +141,7 @@ describe('RecipeService', () => {
     });
 
     it('cleans up uploaded images if a later image fails', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFile
         .mockResolvedValueOnce({ id: 'img-1', full: 'p/1.jpg' })
         .mockRejectedValueOnce(new Error('upload failed'));
 
@@ -244,7 +244,7 @@ describe('RecipeService', () => {
     });
 
     it('deletes removed images, uploads new ones, keeps existing', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata.mockResolvedValueOnce({
+      recipeImageServiceMocks.uploadFile.mockResolvedValueOnce({
         id: 'img-new',
         full: 'p/new.jpg',
       });
@@ -264,7 +264,7 @@ describe('RecipeService', () => {
         id: 'img-rm',
         full: 'p/rm.jpg',
       });
-      expect(imageUtilMocks.uploadAndBuildImageMetadata).toHaveBeenCalledTimes(1);
+      expect(recipeImageServiceMocks.uploadFile).toHaveBeenCalledTimes(1);
       const payload = firestoreMocks.updateDocument.mock.calls[0][2];
       expect(payload.approved).toBe(true);
       expect(payload.images.map((i) => i.id)).toEqual(['img-old', 'img-new']);
@@ -322,7 +322,7 @@ describe('RecipeService', () => {
     });
 
     it('rolls back uploaded images when an image upload throws mid-loop', async () => {
-      imageUtilMocks.uploadAndBuildImageMetadata
+      recipeImageServiceMocks.uploadFile
         .mockResolvedValueOnce({ id: 'new-1', full: 'p/n1.jpg' })
         .mockRejectedValueOnce(new Error('upload boom'));
 

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -15,7 +15,6 @@ let validateImageFile,
   getPrimaryImage,
   getPrimaryImageUrl,
   removeAllRecipeImages,
-  uploadAndBuildImageMetadata,
   addPendingImages,
   approvePendingImageById,
   rejectPendingImageById,
@@ -72,7 +71,6 @@ describe('recipe-image-utils', () => {
     getPrimaryImage = utils.getPrimaryImage;
     getPrimaryImageUrl = utils.getPrimaryImageUrl;
     removeAllRecipeImages = utils.removeAllRecipeImages;
-    uploadAndBuildImageMetadata = utils.uploadAndBuildImageMetadata;
     addPendingImages = utils.addPendingImages;
     approvePendingImageById = utils.approvePendingImageById;
     rejectPendingImageById = utils.rejectPendingImageById;
@@ -287,42 +285,6 @@ describe('recipe-image-utils', () => {
         images: [],
         pendingImages: [],
       });
-    });
-  });
-
-  describe('uploadAndBuildImageMetadata', () => {
-    it('uploads full image and returns correct metadata', async () => {
-      uploadFileMock.mockResolvedValue('url');
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1234);
-      const meta = await uploadAndBuildImageMetadata({
-        recipeId: 'rid',
-        category: 'cat',
-        file,
-        isPrimary: true,
-        uploadedBy: 'user1',
-      });
-      expect(uploadFileMock).toHaveBeenCalledTimes(1);
-      expect(meta).toHaveProperty('id');
-      expect(meta.full).toContain('img/recipes/full/cat/rid/');
-      expect(meta.fileName).toBe('primary.jpg');
-      expect(meta.isPrimary).toBe(true);
-      expect(meta.uploadedBy).toBe('user1');
-      expect(meta.access).toBe('public');
-      expect(meta.uploadTimestamp).toBeDefined();
-    });
-    it('uses a timestamped fileName for non-primary', async () => {
-      uploadFileMock.mockResolvedValue('url');
-      const file = createFakeFile('test2.jpg', 'image/jpeg', 1234);
-      const meta = await uploadAndBuildImageMetadata({
-        recipeId: 'rid',
-        category: 'cat',
-        file,
-        isPrimary: false,
-        uploadedBy: 'user2',
-      });
-      expect(meta.fileName).toMatch(/\.jpg$/);
-      expect(meta.isPrimary).toBe(false);
-      expect(meta.uploadedBy).toBe('user2');
     });
   });
 


### PR DESCRIPTION
## What changed

Moves the image upload primitive out of `recipe-image-utils.js` into `RecipeImageService.uploadFile` with a cleaner positional+options signature:

```js
RecipeImageService.uploadFile(recipeId, category, file, { isPrimary, uploadedBy })
```

- **Singular `uploadFile`** (not the originally-planned `uploadFiles`) — the call writes exactly one file to Storage; WebP variants are regenerated asynchronously by the Storage Resize extension. Plural would have misled.
- **Positional + options** matches the sibling `replaceFiles(recipeId, image, blob, options)` already on the service.

Internal callers in `RecipeService` (the `create` flow + the `update` flow) migrated to the new method (2 sites). `uploadAndBuildImageMetadata` export deleted from utils. After this PR, `RecipeImageService` owns recipe-image upload Storage ops; `recipe-image-utils.js` retains only the pending-image workflow + read helpers (those move in Q2 / Q1b).

6 files changed, +101/−88.

## Verify

- `npm test` → **27 suites / 531 tests pass** (was 530 on parent; +3 new `uploadFile` tests in service test, −2 obsolete `uploadAndBuildImageMetadata` tests from utils test = +1 net).
- Targeted: `recipe-image-service` + `recipe-service` + `recipe-image-utils` → 78/78. `recipe-image-service.js` is 100% covered.
- `npm run lint` → 0 errors.
- `npx prettier --check` on touched files → clean.
- `npm run build` → ✓.
- Grep audit: **0 remaining references** to `uploadAndBuildImageMetadata` in `src/` or `tests/`. The `uploadFiles` plural hits in `media-instructions-editor.js` are an unrelated component method (not `RecipeImageService`) — left alone.

## User flow to test

1. `git checkout refactor/pr-q1a-3-upload-files && npm run dev` (or `netlify dev`).
2. **Propose a recipe with images**: sign in, go to `/propose-recipe`, fill in a recipe, attach 1–2 image files (one marked primary), submit.
   - In Firebase Storage at `img/recipes/full/<category>/<recipeId>/`: primary image at `primary.jpg`, others at `<timestamp>.<ext>`.
   - Open the new recipe → images render correctly.
3. **Edit a recipe and add new images**: sign in as manager/approved, open an existing recipe, edit it, attach a new image, save.
   - New image lands at the recipe's category path with a timestamped filename.
   - Recipe doc's `images[]` contains a new entry with `id` / `full` / `fileName` / `isPrimary` / `uploadedBy` / `access: 'public'` / `uploadTimestamp`.

## Next

After merge → PR-Q1a-4 (`deleteImageFiles` → `RecipeImageService.deleteFiles` + inline `removeAllRecipeImages` into `RecipeService.delete`).

Refs #211.