### PR TITLE
refactor(recipes): RecipeImageService.deleteFiles + inline removeAll (PR-Q1a-4)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -26,6 +26,7 @@ async function fileExists(path) {
  * Public API:
  *   - uploadFile(recipeId, category, file, options)
  *   - replaceFiles(recipeId, image, blob, options)
+ *   - deleteFiles(image)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
  * Primary-image selection and image-entry patches live on RecipeService.
@@ -114,6 +115,37 @@ export class RecipeImageService {
     ]);
 
     return { backupPath, backupCreated };
+  }
+
+  /**
+   * Delete all Storage files associated with an image: the full original,
+   * its `_400x400.webp` and `_1080x1080.webp` variants, the `_original`
+   * backup (if present), and the backup's own WebP variants. The full-size
+   * deletion propagates errors; variant/backup deletions are best-effort.
+   *
+   * @param {{ full: string }} image - The image entry (must have `.full`).
+   * @returns {Promise<void>}
+   */
+  static async deleteFiles(image) {
+    if (!image || !image.full) {
+      throw new Error('RecipeImageService.deleteFiles: image.full is required');
+    }
+    const { full } = image;
+    const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
+    const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
+    const originalBackup = full.replace(/(\.[^.]+)$/, '_original$1');
+    // The Storage Resize extension also generates WebP variants for the
+    // `_original` backup file itself, so those need explicit cleanup too.
+    const originalOpt400 = originalBackup.replace(/\.[^.]+$/, '_400x400.webp');
+    const originalOpt1080 = originalBackup.replace(/\.[^.]+$/, '_1080x1080.webp');
+    await StorageService.deleteFile(full);
+    await Promise.all([
+      StorageService.deleteFile(optimized400).catch(() => {}),
+      StorageService.deleteFile(optimized1080).catch(() => {}),
+      StorageService.deleteFile(originalBackup).catch(() => {}),
+      StorageService.deleteFile(originalOpt400).catch(() => {}),
+      StorageService.deleteFile(originalOpt1080).catch(() => {}),
+    ]);
   }
 }
 

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -2,11 +2,7 @@
 
 import { FirestoreService } from '../_firebase/firestore-service.js';
 import { RecipeImageService } from './recipe-image-service.js';
-import {
-  deleteImageFiles,
-  migrateImageToCategory,
-  removeAllRecipeImages,
-} from '../../utils/recipes/recipe-image-utils.js';
+import { migrateImageToCategory } from '../../utils/recipes/recipe-image-utils.js';
 import {
   uploadMediaInstructionFile,
   removeAllMediaInstructions,
@@ -51,7 +47,7 @@ async function uploadImagesAtomic(recipeId, category, imagesToUpload, uploadedBy
   if (firstRejection) {
     await Promise.all(
       uploaded.map((img) =>
-        deleteImageFiles(img).catch((e) =>
+        RecipeImageService.deleteFiles(img).catch((e) =>
           console.warn('Failed to cleanup partially-uploaded image:', e),
         ),
       ),
@@ -223,7 +219,7 @@ export class RecipeService {
     } catch (error) {
       await Promise.all(
         uploadedImages.map((img) =>
-          deleteImageFiles(img).catch((e) =>
+          RecipeImageService.deleteFiles(img).catch((e) =>
             console.warn('Failed to cleanup uploaded image on error:', e),
           ),
         ),
@@ -281,7 +277,7 @@ export class RecipeService {
     if (Array.isArray(imagesToDelete)) {
       for (const img of imagesToDelete) {
         if (img && img.full) {
-          await deleteImageFiles(img).catch((e) =>
+          await RecipeImageService.deleteFiles(img).catch((e) =>
             console.warn(`Failed to delete removed image ${img.id}:`, e),
           );
         }
@@ -327,7 +323,7 @@ export class RecipeService {
       } catch (error) {
         await Promise.all(
           uploadedThisCall.map((img) =>
-            deleteImageFiles(img).catch((e) =>
+            RecipeImageService.deleteFiles(img).catch((e) =>
               console.warn('Failed to cleanup uploaded image on update error:', e),
             ),
           ),
@@ -371,7 +367,30 @@ export class RecipeService {
       return;
     }
 
-    await removeAllRecipeImages(recipeId);
+    const imageDeletes = [];
+    if (Array.isArray(recipe.images)) {
+      for (const image of recipe.images) {
+        if (image && image.full) {
+          imageDeletes.push(
+            RecipeImageService.deleteFiles(image).catch((err) =>
+              console.warn(`Failed to delete files for image ${image.id}:`, err),
+            ),
+          );
+        }
+      }
+    }
+    if (Array.isArray(recipe.pendingImages)) {
+      for (const image of recipe.pendingImages) {
+        if (image && image.full) {
+          imageDeletes.push(
+            RecipeImageService.deleteFiles(image).catch((err) =>
+              console.warn(`Failed to delete files for pending image ${image.id}:`, err),
+            ),
+          );
+        }
+      }
+    }
+    await Promise.all(imageDeletes);
 
     if (Array.isArray(recipe.mediaInstructions) && recipe.mediaInstructions.length > 0) {
       await removeAllMediaInstructions(recipe.mediaInstructions);

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -12,9 +12,6 @@
  *   - getImageStoragePath(recipeId, category, fileName, type): Get storage path for image.
  *   - generateImageId(): Generate a unique image ID.
  *
- * Image File Deletion:
- *   - deleteImageFiles(image): Delete all storage files for an image (full + WebP variants).
- *
  * Multi Pending Images:
  *   - addPendingImages(recipeId, files, category, uploader): Upload multiple pending images.
  *   - approvePendingImageById(recipeId, pendingImageId): Approve a specific pending image by ID.
@@ -28,7 +25,6 @@
  *   - getImageUrl(storagePath): Get the download URL for a storage path.
  *   - getOptimizedImageUrl(image, size): Get the download URL for an optimized version of an image with fallback.
  *   - getPlaceholderImageUrl(): Get the placeholder image URL.
- *   - removeAllRecipeImages(recipeId): Remove all images (approved and pending) for a recipe.
  *   - migrateImageToCategory(image, recipeId, oldCategory, newCategory): Migrate image to new category path.
  */
 
@@ -102,10 +98,16 @@ export function generateImageId() {
 /**
  * Deletes all storage files for an image: full original and WebP variants.
  * The full-size deletion propagates errors; variant deletions are best-effort.
+ *
+ * Not exported: the public API for image-file deletion is
+ * RecipeImageService.deleteFiles. This helper remains here only so the
+ * pending-image proposal flow (rejectPendingImageById) can call it without
+ * crossing layers. It moves into RecipeImageProposalService in Q2.
+ *
  * @param {Object} image - Image object with `full` path
  * @returns {Promise<void>}
  */
-export async function deleteImageFiles({ full }) {
+async function deleteImageFiles({ full }) {
   const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
   const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
   const originalBackup = full.replace(/(\.[^.]+)$/, '_original$1');
@@ -213,43 +215,6 @@ export async function getPrimaryImageUrl(recipe, size = '400x400') {
     return await getOptimizedImageUrl(primary, size);
   }
   return getPlaceholderImageUrl();
-}
-
-/**
- * Removes all images (approved and pending) for a recipe
- * @param {string} recipeId
- * @returns {Promise<void>}
- */
-export async function removeAllRecipeImages(recipeId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe) {
-    console.warn('Recipe not found for image removal:', recipeId);
-    return;
-  }
-  const deletePromises = [];
-  if (recipe.images && Array.isArray(recipe.images)) {
-    recipe.images.forEach((image) => {
-      if (image.full)
-        deletePromises.push(
-          deleteImageFiles(image).catch((err) =>
-            console.warn(`Failed to delete files for image ${image.id}:`, err),
-          ),
-        );
-    });
-  }
-  if (recipe.pendingImages && Array.isArray(recipe.pendingImages)) {
-    recipe.pendingImages.forEach((image) => {
-      if (image.full)
-        deletePromises.push(
-          deleteImageFiles(image).catch((err) =>
-            console.warn(`Failed to delete files for pending image ${image.id}:`, err),
-          ),
-        );
-    });
-  }
-  await Promise.all(deletePromises);
-  // Remove images and pendingImages from Firestore
-  await updateRecipeDoc(recipeId, { images: [], pendingImages: [] });
 }
 
 // TODO: Consider migrating images to be category agnostic

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -180,4 +180,54 @@ describe('RecipeImageService', () => {
       expect(storageMocks.uploadFile).not.toHaveBeenCalled();
     });
   });
+
+  describe('deleteFiles', () => {
+    it('throws if image.full is missing', async () => {
+      await expect(RecipeImageService.deleteFiles(null)).rejects.toThrow('image.full is required');
+      await expect(RecipeImageService.deleteFiles({})).rejects.toThrow('image.full is required');
+    });
+
+    it('deletes the full file, its WebP variants, and the _original backup with its variants', async () => {
+      await RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' });
+
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_400x400.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_1080x1080.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_original.jpg',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_original_400x400.webp',
+      );
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'img/recipes/full/cat/rid/image_original_1080x1080.webp',
+      );
+    });
+
+    it('silently ignores errors on variant/backup deletion (best-effort)', async () => {
+      storageMocks.deleteFile
+        .mockResolvedValueOnce(undefined) // full OK
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockRejectedValueOnce(new Error('not found'));
+
+      await expect(
+        RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('propagates errors from full file deletion', async () => {
+      storageMocks.deleteFile.mockRejectedValueOnce(new Error('permission denied'));
+
+      await expect(
+        RecipeImageService.deleteFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
+      ).rejects.toThrow('permission denied');
+    });
+  });
 });

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -17,9 +17,7 @@ const firestoreMocks = {
 };
 
 const imageUtilMocks = {
-  deleteImageFiles: jest.fn(() => Promise.resolve()),
   migrateImageToCategory: jest.fn(),
-  removeAllRecipeImages: jest.fn(() => Promise.resolve()),
 };
 
 const mediaUtilMocks = {
@@ -32,6 +30,7 @@ const recipeImageServiceMocks = {
   replaceFiles: jest.fn(() =>
     Promise.resolve({ backupPath: 'backup/path.jpg', backupCreated: true }),
   ),
+  deleteFiles: jest.fn(() => Promise.resolve()),
 };
 
 jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
@@ -52,8 +51,6 @@ beforeEach(async () => {
   Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   firestoreMocks.generateId.mockImplementation(() => 'recipe-123');
   Object.values(imageUtilMocks).forEach((m) => m.mockReset?.());
-  imageUtilMocks.deleteImageFiles.mockImplementation(() => Promise.resolve());
-  imageUtilMocks.removeAllRecipeImages.mockImplementation(() => Promise.resolve());
   Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
   mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
     Promise.resolve({ success: 0, failed: 0, errors: [] }),
@@ -62,6 +59,7 @@ beforeEach(async () => {
   recipeImageServiceMocks.replaceFiles.mockImplementation(() =>
     Promise.resolve({ backupPath: 'backup/path.jpg', backupCreated: true }),
   );
+  recipeImageServiceMocks.deleteFiles.mockImplementation(() => Promise.resolve());
 
   ({ RecipeService } = await import('src/js/services/recipes/recipe-service.js'));
 });
@@ -156,7 +154,7 @@ describe('RecipeService', () => {
         }),
       ).rejects.toThrow('upload failed');
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'img-1',
         full: 'p/1.jpg',
       });
@@ -260,7 +258,7 @@ describe('RecipeService', () => {
         approved: true,
       });
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'img-rm',
         full: 'p/rm.jpg',
       });
@@ -337,7 +335,7 @@ describe('RecipeService', () => {
         }),
       ).rejects.toThrow('upload boom');
 
-      expect(imageUtilMocks.deleteImageFiles).toHaveBeenCalledWith({
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith({
         id: 'new-1',
         full: 'p/n1.jpg',
       });
@@ -356,22 +354,40 @@ describe('RecipeService', () => {
   });
 
   describe('delete', () => {
-    it('removes images, media, and the document', async () => {
+    it('removes approved + pending image files, media, and the document', async () => {
       firestoreMocks.getDocument.mockResolvedValue({
         id: 'recipe-x',
+        images: [
+          { id: 'a', full: 'img/recipes/full/cat/recipe-x/a.jpg' },
+          { id: 'b', full: 'img/recipes/full/cat/recipe-x/b.jpg' },
+        ],
+        pendingImages: [{ id: 'p1', full: 'img/recipes/full/cat/recipe-x/p1.jpg' }],
         mediaInstructions: [{ path: 'mp/1' }],
       });
+
       await RecipeService.delete('recipe-x');
-      expect(imageUtilMocks.removeAllRecipeImages).toHaveBeenCalledWith('recipe-x');
+
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledTimes(3);
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'a' }),
+      );
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'b' }),
+      );
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p1' }),
+      );
       expect(mediaUtilMocks.removeAllMediaInstructions).toHaveBeenCalledWith([{ path: 'mp/1' }]);
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-x');
+      // The pre-delete updateDoc({ images: [], pendingImages: [] }) is gone now.
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
     });
 
     it('is idempotent when the recipe does not exist', async () => {
       firestoreMocks.getDocument.mockResolvedValue(null);
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       await RecipeService.delete('missing');
-      expect(imageUtilMocks.removeAllRecipeImages).not.toHaveBeenCalled();
+      expect(recipeImageServiceMocks.deleteFiles).not.toHaveBeenCalled();
       expect(firestoreMocks.deleteDocument).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
@@ -381,6 +397,21 @@ describe('RecipeService', () => {
       await RecipeService.delete('recipe-y');
       expect(mediaUtilMocks.removeAllMediaInstructions).not.toHaveBeenCalled();
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-y');
+    });
+
+    it('logs but does not throw when an individual image deletion fails', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'recipe-z',
+        images: [{ id: 'a', full: 'img/recipes/full/cat/recipe-z/a.jpg' }],
+      });
+      recipeImageServiceMocks.deleteFiles.mockRejectedValueOnce(new Error('boom'));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await expect(RecipeService.delete('recipe-z')).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-z');
+      warnSpy.mockRestore();
     });
   });
 

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -7,14 +7,12 @@ import '../../../common/mocks/firebase-service.mock.js';
 
 let validateImageFile,
   getImageStoragePath,
-  deleteImageFiles,
   getRecipeImages,
   getImageUrl,
   getPlaceholderImageUrl,
   getOptimizedImageUrl,
   getPrimaryImage,
   getPrimaryImageUrl,
-  removeAllRecipeImages,
   addPendingImages,
   approvePendingImageById,
   rejectPendingImageById,
@@ -63,14 +61,12 @@ describe('recipe-image-utils', () => {
     const utils = await import('src/js/utils/recipes/recipe-image-utils.js');
     validateImageFile = utils.validateImageFile;
     getImageStoragePath = utils.getImageStoragePath;
-    deleteImageFiles = utils.deleteImageFiles;
     getRecipeImages = utils.getRecipeImages;
     getImageUrl = utils.getImageUrl;
     getPlaceholderImageUrl = utils.getPlaceholderImageUrl;
     getOptimizedImageUrl = utils.getOptimizedImageUrl;
     getPrimaryImage = utils.getPrimaryImage;
     getPrimaryImageUrl = utils.getPrimaryImageUrl;
-    removeAllRecipeImages = utils.removeAllRecipeImages;
     addPendingImages = utils.addPendingImages;
     approvePendingImageById = utils.approvePendingImageById;
     rejectPendingImageById = utils.rejectPendingImageById;
@@ -100,30 +96,6 @@ describe('recipe-image-utils', () => {
       expect(getImageStoragePath('id1', 'cat', 'file.jpg', 'full')).toBe(
         'img/recipes/full/cat/id1/file.jpg',
       );
-    });
-  });
-
-  describe('deleteImageFiles', () => {
-    it('deletes full and WebP variants', async () => {
-      await deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' });
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_1080x1080.webp');
-    });
-    it('silently ignores errors on variant deletion', async () => {
-      deleteFileMock
-        .mockResolvedValueOnce(undefined) // full OK
-        .mockRejectedValueOnce(new Error('not found')) // 400 variant missing
-        .mockRejectedValueOnce(new Error('not found')); // 1080 variant missing
-      await expect(
-        deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
-      ).resolves.not.toThrow();
-    });
-    it('propagates errors from full file deletion', async () => {
-      deleteFileMock.mockRejectedValueOnce(new Error('permission denied'));
-      await expect(
-        deleteImageFiles({ full: 'img/recipes/full/cat/rid/image.jpg' }),
-      ).rejects.toThrow('permission denied');
     });
   });
 
@@ -240,51 +212,6 @@ describe('recipe-image-utils', () => {
       await expect(getPrimaryImageUrl({ images: [] })).resolves.toBeNull();
       await expect(getPrimaryImageUrl({})).resolves.toBeNull();
       await expect(getPrimaryImageUrl(null)).resolves.toBeNull();
-    });
-  });
-
-  describe('removeAllRecipeImages', () => {
-    it('removes all approved and pending images and updates Firestore', async () => {
-      getDocumentMock.mockResolvedValue({
-        images: [
-          { id: 'a', full: 'img/recipes/full/cat/rid/a.jpg' },
-          { id: 'b', full: 'img/recipes/full/cat/rid/b.jpg' },
-        ],
-        pendingImages: [
-          { id: 'p1', full: 'img/recipes/full/cat/rid/p1.jpg' },
-          { id: 'p2', full: 'img/recipes/full/cat/rid/p2.jpg' },
-        ],
-      });
-      updateDocumentMock.mockResolvedValue();
-      await removeAllRecipeImages('rid');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/a.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/a_400x400.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/b.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/p1.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/p2.jpg');
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [],
-        pendingImages: [],
-      });
-    });
-    it('handles missing recipe gracefully', async () => {
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      getDocumentMock.mockResolvedValue(null);
-      await expect(removeAllRecipeImages('rid')).resolves.toBeUndefined();
-      expect(deleteFileMock).not.toHaveBeenCalled();
-      expect(updateDocumentMock).not.toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith('Recipe not found for image removal:', 'rid');
-      consoleSpy.mockRestore();
-    });
-    it('handles empty images and pendingImages arrays', async () => {
-      getDocumentMock.mockResolvedValue({ images: [], pendingImages: [] });
-      updateDocumentMock.mockResolvedValue();
-      await removeAllRecipeImages('rid');
-      expect(deleteFileMock).not.toHaveBeenCalled();
-      expect(updateDocumentMock).toHaveBeenCalledWith('recipes', 'rid', {
-        images: [],
-        pendingImages: [],
-      });
     });
   });
 


### PR DESCRIPTION
## What changed

Two related moves that complete the Storage-deletion half of the service split:

### 1. `RecipeImageService.deleteFiles(image)` — new public method

Takes a typed image with `.full`. Deletes:
- the full original file (errors propagate),
- the `_400x400.webp` and `_1080x1080.webp` variants (best-effort),
- the `_original` backup (best-effort),
- the backup's own WebP variants (best-effort).

Storage-only. Same behavior as the previous util.

### 2. `removeAllRecipeImages` inlined into `RecipeService.delete`

Previous flow re-fetched the recipe inside `removeAllRecipeImages`, then deleted Storage files, then called `updateDoc({ images: [], pendingImages: [] })` right before `deleteDoc`. New flow:
- Uses the already-fetched `recipe` from `delete()` (no re-read).
- Iterates `recipe.images[]` + `recipe.pendingImages[]`, calls `RecipeImageService.deleteFiles(image)` for each (logs but doesn't throw on individual failure).
- **Drops the redundant `updateDoc({ images: [], pendingImages: [] })`** — the doc is about to be deleted.

### 3. Internal cleanup callers migrated

4 `deleteImageFiles(img)` rollback callers in `RecipeService` (create/update flows) → `RecipeImageService.deleteFiles(img)`.

### 4. Utils file slimmed

- `deleteImageFiles`: kept as a **private** helper (no `export`) — one inbound call from `rejectPendingImageById`, which moves to `RecipeImageProposalService` in PR-Q2. Inverting the import (utils → services) would violate the layering the refactor is establishing, so a brief private holding state is preferred.
- `removeAllRecipeImages`: **deleted entirely**.

6 files changed, +159/−135.

## Verify

- `npm test` → **27 suites / 530 tests pass** (was 531; −1 net: +4 new in service test, +1 new delete-rejection test, −6 from utils test).
- Targeted (`recipe-image-service` + `recipe-service` + `recipe-image-utils`): 77/77, `recipe-image-service.js` at 100% coverage.
- `npm run lint` → 0 errors.
- `npx prettier --check` → clean.
- `npm run build` → ✓.
- **Caller audit**:
  - `removeAllRecipeImages` — **0 references anywhere**.
  - `deleteImageFiles` — 2 references, both in `recipe-image-utils.js`: the private helper body itself and the one internal caller in `rejectPendingImageById`. No external callers.
  - `RecipeImageService.deleteFiles` — 6 src call sites (4 rollbacks in create/update + 2 inlined `delete()` loops) + 5 test sites. All using the positional `(image)` signature.

## User flow to test

1. `git checkout refactor/pr-q1a-4-delete-files && npm run dev` (or `netlify dev`).
2. **Edit a recipe and remove an image** (manager/approved):
   - Open a recipe that has multiple images, edit, remove one image, save.
   - In Firebase Storage at `img/recipes/full/<category>/<recipeId>/`: the removed image's full file is gone along with its `_400x400.webp` / `_1080x1080.webp` variants (and `_original*` if any).
   - The remaining images on the recipe still display.
3. **Delete a recipe** (manager):
   - Pick a recipe that has approved images, **at least one pending image**, and media instructions. Delete it.
   - All approved image files removed from Storage.
   - All pending image files removed from Storage.
   - Media instruction files removed.
   - Recipe doc gone from Firestore.
   - Network panel: **no Firestore `update` call** right before the `delete` call (the redundant write is gone).
4. **Failure-tolerance** (optional): manually rename one image's storage file in the console, then delete the recipe → recipe deletion still succeeds; only a `console.warn` for the missing image.

## Next

After merge → PR-Q1a-5 (`migrateImageToCategory` → `RecipeImageService.migrateFilesToCategory`) — the last in the Q1a series. After Q1a-5 lands, `RecipeImageService` is fully Storage-only and `RecipeService` is the sole owner of `recipes/{id}`.

Refs #211.