### PR TITLE
refactor(recipes): move getImageUrl to RecipeImageService.getFullUrl (PR-Q1b-2)

### DIFF
--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -34,6 +34,7 @@ async function fileExists(path) {
  *   - migrateFilesToCategory(recipeId, image, newCategory)
  *   - getOptimizedUrl(image, size)
  *   - getPrimaryUrl(recipe, size)
+ *   - getFullUrl(image)
  *
  * Image proposal/moderation lives in RecipeImageProposalService.
  * Primary-image selection and image-entry patches live on RecipeService.
@@ -276,6 +277,22 @@ export class RecipeImageService {
     const primary = getPrimaryImage(recipe);
     if (!primary) return null;
     return RecipeImageService.getOptimizedUrl(primary, size);
+  }
+
+  /**
+   * Resolve the download URL for an image's full-size original file.
+   * Takes a typed image (must have `.full`) rather than a raw Storage path
+   * so the service surface stays scoped to recipe-image objects (no
+   * generic storage-URL resolver leaks into call sites).
+   *
+   * @param {{ full: string }} image
+   * @returns {Promise<string>}
+   */
+  static async getFullUrl(image) {
+    if (!image || !image.full) {
+      throw new Error('RecipeImageService.getFullUrl: image.full is required');
+    }
+    return StorageService.getFileUrl(image.full);
   }
 }
 

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -21,7 +21,6 @@
  * Approved Images:
  *   - getRecipeImages(recipe, userRole): Get accessible images for a user role.
  *   - getPrimaryImage(recipe): Get the primary image object.
- *   - getImageUrl(storagePath): Get the download URL for a storage path.
  *   - getPlaceholderImageUrl(): Get the placeholder image URL.
  */
 
@@ -139,15 +138,6 @@ export function getRecipeImages(recipe, userRole) {
   };
   const allowed = ACCESS_LEVELS[userRole] || ['public'];
   return recipe.images.filter((img) => allowed.includes(img.access));
-}
-
-/**
- * Gets the download URL for a storage path
- * @param {string} storagePath
- * @returns {Promise<string>}
- */
-export async function getImageUrl(storagePath) {
-  return await StorageService.getFileUrl(storagePath);
 }
 
 /**

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -13,7 +13,6 @@
 import { enhanceFoodImage } from '../../../js/services/recipes/ai-enhancement-service.js';
 import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
 import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
-import { getImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { icons } from '../../../js/icons.js';
 import '../../utilities/modal/modal.js';
 
@@ -337,7 +336,7 @@ class AiImageEnhanceModal extends HTMLElement {
     this._setStatus('שולח לשיפור בעזרת AI...');
 
     try {
-      const downloadUrl = await getImageUrl(this._image.full);
+      const downloadUrl = await RecipeImageService.getFullUrl(this._image);
       const response = await fetch(downloadUrl);
       if (!response.ok) throw new Error(`Failed to fetch image (${response.status})`);
       const sourceBlob = await response.blob();

--- a/src/lib/media/image-carousel/image-carousel.js
+++ b/src/lib/media/image-carousel/image-carousel.js
@@ -1,5 +1,4 @@
 import { icons } from '../../../js/icons.js';
-import { getImageUrl } from '../../../js/utils/recipes/recipe-image-utils.js';
 import { RecipeImageService } from '../../../js/services/recipes/recipe-image-service.js';
 
 class ImageCarousel extends HTMLElement {
@@ -86,8 +85,10 @@ class ImageCarousel extends HTMLElement {
             console.error('Error loading optimized image:', error);
           }
         } else if (typeof image === 'string' && image.startsWith('img/recipes/')) {
+          // Legacy data: a raw Storage path. Normalize to a typed image so
+          // the service surface keeps accepting only RecipeImage-shaped input.
           try {
-            src = await getImageUrl(image);
+            src = await RecipeImageService.getFullUrl({ full: image });
           } catch (error) {
             console.error('Error loading Firebase image path:', error);
           }

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -411,4 +411,30 @@ describe('RecipeImageService', () => {
       expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
     });
   });
+
+  describe('getFullUrl', () => {
+    it('resolves to StorageService.getFileUrl for image.full', async () => {
+      storageMocks.getFileUrl.mockResolvedValueOnce('https://storage/full');
+      const result = await RecipeImageService.getFullUrl({
+        full: 'img/recipes/full/cat/rid/img.jpg',
+      });
+      expect(storageMocks.getFileUrl).toHaveBeenCalledWith('img/recipes/full/cat/rid/img.jpg');
+      expect(result).toBe('https://storage/full');
+    });
+
+    it('throws if image.full is missing', async () => {
+      await expect(RecipeImageService.getFullUrl(null)).rejects.toThrow('image.full is required');
+      await expect(RecipeImageService.getFullUrl({})).rejects.toThrow('image.full is required');
+      await expect(RecipeImageService.getFullUrl({ full: '' })).rejects.toThrow(
+        'image.full is required',
+      );
+    });
+
+    it('propagates Storage errors', async () => {
+      storageMocks.getFileUrl.mockRejectedValueOnce(new Error('permission denied'));
+      await expect(
+        RecipeImageService.getFullUrl({ full: 'img/recipes/full/cat/rid/img.jpg' }),
+      ).rejects.toThrow('permission denied');
+    });
+  });
 });

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -8,7 +8,6 @@ import '../../../common/mocks/firebase-service.mock.js';
 let validateImageFile,
   getImageStoragePath,
   getRecipeImages,
-  getImageUrl,
   getPlaceholderImageUrl,
   getPrimaryImage,
   addPendingImages,
@@ -60,7 +59,6 @@ describe('recipe-image-utils', () => {
     validateImageFile = utils.validateImageFile;
     getImageStoragePath = utils.getImageStoragePath;
     getRecipeImages = utils.getRecipeImages;
-    getImageUrl = utils.getImageUrl;
     getPlaceholderImageUrl = utils.getPlaceholderImageUrl;
     getPrimaryImage = utils.getPrimaryImage;
     addPendingImages = utils.addPendingImages;
@@ -114,14 +112,6 @@ describe('recipe-image-utils', () => {
     });
     it('returns [] for no images', () => {
       expect(getRecipeImages({}, 'public')).toEqual([]);
-    });
-  });
-
-  describe('getImageUrl', () => {
-    it('calls StorageService.getFileUrl', async () => {
-      getFileUrlMock.mockResolvedValue('url');
-      expect(await getImageUrl('path')).toBe('url');
-      expect(getFileUrlMock).toHaveBeenCalledWith('path');
     });
   });
 


### PR DESCRIPTION
## What changed

Final URL helper move. After this PR, `recipe-image-utils.js` exports no async URL functions.

- `getImageUrl(storagePath)` → **`RecipeImageService.getFullUrl(image)`** — signature change.

The new method takes a typed image (must have `.full`) rather than a raw Storage path. Throws if `.full` is missing. The narrower input keeps the service surface scoped to recipe-image objects and prevents it from drifting into a generic storage-URL resolver.

**Two callers (PR-O1's temp imports) unwound:**

- `ai-image-enhance-modal.js`: passes the typed `this._image` directly instead of `this._image.full`.
- `image-carousel.js`: the legacy-string-path branch wraps the raw path in `{ full: image }` at the caller boundary before calling the service.

**Follow-up filed**: #243 — investigate whether the carousel's legacy-string fallback is still needed in production data, and if not, remove it.

6 files changed, +47/−24.

## Verify

- `npm test` → **27 suites / 539 tests pass** (was 537; +3 service tests, −1 utils test, +1 net from existing tests).
- `npm run lint` → 0 errors.
- `npx prettier --check` → clean.
- `npm run build` → ✓.
- **Caller audit**: `getImageUrl` → **0 references** in `src/` or `tests/`. Both PR-O1 temp imports unwound.

## Behavioral changes

Functionally none. Two shape changes at the caller boundary:

- **Modal**: previously `getImageUrl(this._image.full)` → now `getFullUrl(this._image)`. Service unwraps. Same underlying `StorageService.getFileUrl(path)` call.
- **Carousel legacy string**: previously `getImageUrl(image)` (raw path string) → now `getFullUrl({ full: image })`. Same Storage call.

One stricter behavior: `getFullUrl` validates `image.full` is present and throws if not. The old util didn't validate — it would have passed `undefined` to Storage and gotten a rejection. Both call sites already guarantee a valid image, so no realistic caller triggers this.

## User flow to test

1. `git checkout refactor/pr-q1b-2-full-url && npm run dev`.
2. **AI image enhance** — open the modal on an existing image, click Enhance. The source image fetches (toast progresses to "שולח לשיפור בעזרת AI...") and the enhanced result returns.
3. **Image carousel — typed objects** (the common case) — swipe through a recipe with multiple images. Covered by `getOptimizedUrl` (Q1b-1); sanity-check no regression.
4. **Image carousel — legacy string path** — hard to trigger naturally without legacy data; the unit-test sanity-check for the wrap covers it. See #243 for whether this code path is even live.

## End state of `recipe-image-utils.js` after this PR

- **No async URL exports.** No async helpers that touch Storage in the exported surface.
- Exports remaining: `validateImageFile`, `getImageStoragePath`, `generateImageId`, `getRecipeImages`, `getPlaceholderImageUrl`, `getPrimaryImage` — all pure.
- Non-pure code still inside (all bound for PR-Q2): private `getRecipeDoc` / `updateRecipeDoc` / `deleteImageFiles` helpers; exported `addPendingImages` / `approvePendingImageById` / `rejectPendingImageById` / `getPendingImages` (only `RecipeImageProposalService` calls these).
- `StorageService` import in utils still needed by the Q2-bound code.

## Next

After merge → **PR-Q2** (inline the 4 pending-image helpers into `RecipeImageProposalService`; delete the 3 private helpers; drop `StorageService` import from utils → `recipe-image-utils.js` becomes pure-only).

Refs #211.