### PR TITLE
refactor(recipes): inline proposal helpers into RecipeImageProposalService (PR-Q2)

### DIFF
--- a/src/js/services/recipes/recipe-image-proposal-service.js
+++ b/src/js/services/recipes/recipe-image-proposal-service.js
@@ -1,18 +1,19 @@
 // src/js/services/recipes/recipe-image-proposal-service.js
 
-import {
-  addPendingImages,
-  approvePendingImageById,
-  rejectPendingImageById,
-  getPendingImages,
-} from '../../utils/recipes/recipe-image-utils.js';
+import { FirestoreService } from '../_firebase/firestore-service.js';
+import { StorageService } from '../_firebase/storage-service.js';
+import { RecipeImageService } from './recipe-image-service.js';
+import { generateImageId, getImageStoragePath } from '../../utils/recipes/recipe-image-utils.js';
+
+const RECIPES_COLLECTION = 'recipes';
 
 /**
  * RecipeImageProposalService — Image Proposal & Moderation
  *
  * Distinct workflow from owner CRUD: end-users propose images on existing
  * recipes; managers approve/reject. Kept separate from RecipeService so the
- * owner surface stays focused.
+ * owner surface stays focused. Bounded writes to
+ * `recipes/{id}.{pendingImages, images}` live here.
  *
  * Public API:
  *   - propose(recipeId, files, category, uploadedBy)
@@ -22,45 +23,107 @@ import {
  */
 export class RecipeImageProposalService {
   /**
-   * Upload one or more images as proposals against an existing recipe.
+   * Upload one or more files as pending images on an existing recipe.
+   * Each file lands at its category Storage path and an entry is appended
+   * to `recipes/{id}.pendingImages[]`. Returns the new entries (without
+   * the previously-existing pending entries).
+   *
    * @param {string} recipeId
    * @param {File[]} files
    * @param {string} category
    * @param {string} uploadedBy
-   * @returns {Promise<Array>} pending image metadata
+   * @returns {Promise<Array>} the new pending image entries
    */
   static async propose(recipeId, files, category, uploadedBy) {
-    return await addPendingImages(recipeId, files, category, uploadedBy);
+    if (!Array.isArray(files) || files.length === 0) return [];
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    const pendingImages = Array.isArray(recipe.pendingImages) ? [...recipe.pendingImages] : [];
+
+    const newPendingImages = await Promise.all(
+      files.map(async (file) => {
+        const fileExtension = file.name.split('.').pop();
+        const id = generateImageId();
+        const fileName = `${id}.${fileExtension}`;
+        const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
+        await StorageService.uploadFile(file, fullPath);
+        return {
+          id,
+          full: fullPath,
+          fileExtension,
+          timestamp: new Date(),
+          uploadedBy,
+        };
+      }),
+    );
+
+    pendingImages.push(...newPendingImages);
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { pendingImages });
+    return newPendingImages;
   }
 
   /**
-   * Approve a pending image, moving it into the approved images array.
+   * Approve a single pending image: move it from `pendingImages[]` into
+   * the approved `images[]` array as a typed RecipeImage. Marks the new
+   * entry as primary if no approved images exist yet on the recipe.
+   *
    * @param {string} recipeId
    * @param {string} pendingImageId
-   * @returns {Promise<string>} new image ID
+   * @returns {Promise<string>} the new image id assigned to the approved entry
    */
   static async approve(recipeId, pendingImageId) {
-    return await approvePendingImageById(recipeId, pendingImageId);
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe || !Array.isArray(recipe.pendingImages)) {
+      throw new Error('No pending images to approve');
+    }
+    const pendingImage = recipe.pendingImages.find((img) => img.id === pendingImageId);
+    if (!pendingImage) throw new Error('Pending image not found');
+
+    const newImageId = generateImageId();
+    const newImage = {
+      id: newImageId,
+      full: pendingImage.full,
+      isPrimary: !recipe.images || recipe.images.length === 0,
+      access: 'public',
+      uploadedBy: pendingImage.uploadedBy,
+      fileName: `${pendingImageId}.${pendingImage.fileExtension}`,
+      uploadTimestamp: new Date(),
+    };
+    const images = Array.isArray(recipe.images) ? [...recipe.images, newImage] : [newImage];
+    const pendingImages = recipe.pendingImages.filter((img) => img.id !== pendingImageId);
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { images, pendingImages });
+    return newImageId;
   }
 
   /**
-   * Reject a pending image, deleting its files and removing it from the
-   * pending array.
+   * Reject a single pending image: delete its Storage files (via
+   * RecipeImageService.deleteFiles) and remove it from `pendingImages[]`.
+   *
    * @param {string} recipeId
    * @param {string} pendingImageId
    * @returns {Promise<void>}
    */
   static async reject(recipeId, pendingImageId) {
-    return await rejectPendingImageById(recipeId, pendingImageId);
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    if (!recipe || !Array.isArray(recipe.pendingImages)) {
+      throw new Error('No pending images to reject');
+    }
+    const pendingImage = recipe.pendingImages.find((img) => img.id === pendingImageId);
+    if (!pendingImage) throw new Error('Pending image not found');
+
+    await RecipeImageService.deleteFiles(pendingImage);
+    const pendingImages = recipe.pendingImages.filter((img) => img.id !== pendingImageId);
+    await FirestoreService.updateDocument(RECIPES_COLLECTION, recipeId, { pendingImages });
   }
 
   /**
-   * List all pending images for a recipe.
+   * List all pending images for a recipe (empty array if none).
+   *
    * @param {string} recipeId
    * @returns {Promise<Array>}
    */
   static async listPending(recipeId) {
-    return await getPendingImages(recipeId);
+    const recipe = await FirestoreService.getDocument(RECIPES_COLLECTION, recipeId);
+    return Array.isArray(recipe?.pendingImages) ? recipe.pendingImages : [];
   }
 }
 

--- a/src/js/utils/recipes/recipe-image-utils.js
+++ b/src/js/utils/recipes/recipe-image-utils.js
@@ -1,27 +1,21 @@
 /*
  * Recipe Image Utilities
  * ---------------------
- * This module provides helper functions for image upload, management, and retrieval for recipes.
+ * Pure helpers for recipe-image handling. No I/O, no service/SDK imports.
  *
- * Exported Methods:
+ * Exported:
  *
  * Validation:
  *   - validateImageFile(file): Validate file type and size.
  *
  * Storage Path Helpers:
- *   - getImageStoragePath(recipeId, category, fileName, type): Get storage path for image.
+ *   - getImageStoragePath(recipeId, category, fileName, type): Build a storage path.
  *   - generateImageId(): Generate a unique image ID.
  *
- * Multi Pending Images:
- *   - addPendingImages(recipeId, files, category, uploader): Upload multiple pending images.
- *   - approvePendingImageById(recipeId, pendingImageId): Approve a specific pending image by ID.
- *   - rejectPendingImageById(recipeId, pendingImageId): Reject/delete a specific pending image by ID.
- *   - getPendingImages(recipeId): Get all pending images for a recipe.
- *
- * Approved Images:
- *   - getRecipeImages(recipe, userRole): Get accessible images for a user role.
- *   - getPrimaryImage(recipe): Get the primary image object.
- *   - getPlaceholderImageUrl(): Get the placeholder image URL.
+ * Access / Selection:
+ *   - getRecipeImages(recipe, userRole): Filter images by access level for a user role.
+ *   - getPrimaryImage(recipe): Pick the primary (or first) image object.
+ *   - getPlaceholderImageUrl(): Returns null (sentinel for "no image").
  */
 
 /**
@@ -34,19 +28,6 @@
  * @property {string} fileName
  * @property {Timestamp} uploadTimestamp
  */
-
-/**
- * @typedef {Object} PendingRecipeImage
- * @property {string} id
- * @property {string} full
- * @property {string} fileExtension
- * @property {Timestamp} timestamp
- * @property {string} uploadedBy
- */
-
-// --- Imports ---
-import { StorageService } from '../../services/_firebase/storage-service.js';
-import { FirestoreService } from '../../services/_firebase/firestore-service.js';
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_SIZE = 5 * 1024 * 1024; // 5MB
@@ -73,14 +54,6 @@ export function getImageStoragePath(recipeId, category, fileName, type = 'full')
   return `${base}/${fileName}`;
 }
 
-// --- Firestore Helpers ---
-async function getRecipeDoc(recipeId) {
-  return await FirestoreService.getDocument('recipes', recipeId);
-}
-async function updateRecipeDoc(recipeId, data) {
-  return await FirestoreService.updateDocument('recipes', recipeId, data);
-}
-
 // --- Image ID Helper ---
 /**
  * Generates a unique image ID with 'img-' prefix
@@ -88,37 +61,6 @@ async function updateRecipeDoc(recipeId, data) {
  */
 export function generateImageId() {
   return 'img-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);
-}
-
-// --- Image File Deletion ---
-/**
- * Deletes all storage files for an image: full original and WebP variants.
- * The full-size deletion propagates errors; variant deletions are best-effort.
- *
- * Not exported: the public API for image-file deletion is
- * RecipeImageService.deleteFiles. This helper remains here only so the
- * pending-image proposal flow (rejectPendingImageById) can call it without
- * crossing layers. It moves into RecipeImageProposalService in Q2.
- *
- * @param {Object} image - Image object with `full` path
- * @returns {Promise<void>}
- */
-async function deleteImageFiles({ full }) {
-  const optimized400 = full.replace(/\.[^.]+$/, '_400x400.webp');
-  const optimized1080 = full.replace(/\.[^.]+$/, '_1080x1080.webp');
-  const originalBackup = full.replace(/(\.[^.]+)$/, '_original$1');
-  // The Storage Resize extension also generates WebP variants for the
-  // `_original` backup file itself, so those need explicit cleanup too.
-  const originalOpt400 = originalBackup.replace(/\.[^.]+$/, '_400x400.webp');
-  const originalOpt1080 = originalBackup.replace(/\.[^.]+$/, '_1080x1080.webp');
-  await StorageService.deleteFile(full);
-  await Promise.all([
-    StorageService.deleteFile(optimized400).catch(() => {}),
-    StorageService.deleteFile(optimized1080).catch(() => {}),
-    StorageService.deleteFile(originalBackup).catch(() => {}),
-    StorageService.deleteFile(originalOpt400).catch(() => {}),
-    StorageService.deleteFile(originalOpt1080).catch(() => {}),
-  ]);
 }
 
 // --- Retrieval ---
@@ -157,98 +99,4 @@ export function getPrimaryImage(recipe) {
   if (!recipe || !Array.isArray(recipe.images) || recipe.images.length === 0) return undefined;
   const primary = recipe.images.find((img) => img.isPrimary);
   return primary || recipe.images[0];
-}
-
-/**
- * Uploads multiple pending images for a recipe (to be approved by manager)
- * @param {string} recipeId
- * @param {File[]} files
- * @param {string} category
- * @param {string} uploader
- * @returns {Promise<Array>} Array of pending image objects
- */
-export async function addPendingImages(recipeId, files, category, uploader) {
-  if (!Array.isArray(files) || files.length === 0) return [];
-  const recipe = await getRecipeDoc(recipeId);
-  const pendingImages = Array.isArray(recipe.pendingImages) ? [...recipe.pendingImages] : [];
-
-  // Upload all images in parallel for better performance
-  const uploadPromises = files.map(async (file) => {
-    const fileExtension = file.name.split('.').pop();
-    const id = generateImageId();
-    const fileName = `${id}.${fileExtension}`;
-    // Upload full-size
-    const fullPath = getImageStoragePath(recipeId, category, fileName, 'full');
-    await StorageService.uploadFile(file, fullPath);
-
-    return {
-      id,
-      full: fullPath,
-      fileExtension,
-      timestamp: new Date(),
-      uploadedBy: uploader,
-    };
-  });
-
-  const newPendingImages = await Promise.all(uploadPromises);
-  pendingImages.push(...newPendingImages);
-  await updateRecipeDoc(recipeId, { pendingImages });
-  return newPendingImages;
-}
-
-/**
- * Approves a specific pending image for a recipe, moving it to the images array
- * @param {string} recipeId
- * @param {string} pendingImageId
- * @returns {Promise<string>} The new image ID after approval
- */
-export async function approvePendingImageById(recipeId, pendingImageId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe || !Array.isArray(recipe.pendingImages))
-    throw new Error('No pending images to approve');
-  const idx = recipe.pendingImages.findIndex((img) => img.id === pendingImageId);
-  if (idx === -1) throw new Error('Pending image not found');
-  const pendingImage = recipe.pendingImages[idx];
-  const newImageId = generateImageId();
-  const newImage = {
-    id: newImageId,
-    full: pendingImage.full,
-    isPrimary: !recipe.images || recipe.images.length === 0,
-    access: 'public',
-    uploadedBy: pendingImage.uploadedBy,
-    fileName: `${pendingImageId}.${pendingImage.fileExtension}`,
-    uploadTimestamp: new Date(),
-  };
-  const images = Array.isArray(recipe.images) ? [...recipe.images, newImage] : [newImage];
-  const pendingImages = recipe.pendingImages.filter((img) => img.id !== pendingImageId);
-  await updateRecipeDoc(recipeId, { images, pendingImages });
-  return newImageId;
-}
-
-/**
- * Rejects a specific pending image for a recipe, deleting it from storage and Firestore
- * @param {string} recipeId
- * @param {string} pendingImageId
- * @returns {Promise<void>}
- */
-export async function rejectPendingImageById(recipeId, pendingImageId) {
-  const recipe = await getRecipeDoc(recipeId);
-  if (!recipe || !Array.isArray(recipe.pendingImages))
-    throw new Error('No pending images to reject');
-  const idx = recipe.pendingImages.findIndex((img) => img.id === pendingImageId);
-  if (idx === -1) throw new Error('Pending image not found');
-  const pendingImage = recipe.pendingImages[idx];
-  await deleteImageFiles(pendingImage);
-  const pendingImages = recipe.pendingImages.filter((img) => img.id !== pendingImageId);
-  await updateRecipeDoc(recipeId, { pendingImages });
-}
-
-/**
- * Returns the array of pending images for a recipe
- * @param {string} recipeId
- * @returns {Promise<Array>}
- */
-export async function getPendingImages(recipeId) {
-  const recipe = await getRecipeDoc(recipeId);
-  return Array.isArray(recipe?.pendingImages) ? recipe.pendingImages : [];
 }

--- a/tests/js/services/recipe-image-proposal-service.test.mjs
+++ b/tests/js/services/recipe-image-proposal-service.test.mjs
@@ -6,49 +6,236 @@ import '../../common/mocks/firebase-service.mock.js';
 
 let RecipeImageProposalService;
 
-const imageUtilMocks = {
-  addPendingImages: jest.fn(),
-  approvePendingImageById: jest.fn(),
-  rejectPendingImageById: jest.fn(),
-  getPendingImages: jest.fn(),
+const firestoreMocks = {
+  getDocument: jest.fn(),
+  updateDocument: jest.fn(),
 };
 
-jest.unstable_mockModule('src/js/utils/recipes/recipe-image-utils.js', () => imageUtilMocks);
+const storageMocks = {
+  uploadFile: jest.fn(() => Promise.resolve()),
+};
+
+const recipeImageServiceMocks = {
+  deleteFiles: jest.fn(() => Promise.resolve()),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
+  StorageService: storageMocks,
+}));
+jest.unstable_mockModule('src/js/services/recipes/recipe-image-service.js', () => ({
+  RecipeImageService: recipeImageServiceMocks,
+}));
+
+function makeFile(name = 'a.jpg', type = 'image/jpeg') {
+  return new File([new Blob(['a'], { type })], name, { type });
+}
 
 beforeEach(async () => {
   jest.resetModules();
-  Object.values(imageUtilMocks).forEach((m) => m.mockReset());
+  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
+  Object.values(storageMocks).forEach((m) => m.mockReset?.());
+  storageMocks.uploadFile.mockImplementation(() => Promise.resolve());
+  Object.values(recipeImageServiceMocks).forEach((m) => m.mockReset?.());
+  recipeImageServiceMocks.deleteFiles.mockImplementation(() => Promise.resolve());
+
   ({ RecipeImageProposalService } = await import(
     'src/js/services/recipes/recipe-image-proposal-service.js'
   ));
 });
 
 describe('RecipeImageProposalService', () => {
-  it('propose delegates to addPendingImages', async () => {
-    imageUtilMocks.addPendingImages.mockResolvedValue([{ id: 'p1' }]);
-    const files = [new File([new Blob(['a'])], 'a.jpg', { type: 'image/jpeg' })];
-    const result = await RecipeImageProposalService.propose('r1', files, 'cat', 'user-1');
-    expect(imageUtilMocks.addPendingImages).toHaveBeenCalledWith('r1', files, 'cat', 'user-1');
-    expect(result).toEqual([{ id: 'p1' }]);
+  describe('propose', () => {
+    it('returns an empty array (and skips reads/writes) when no files are passed', async () => {
+      await expect(RecipeImageProposalService.propose('r1', [], 'cat', 'u1')).resolves.toEqual([]);
+      await expect(RecipeImageProposalService.propose('r1', null, 'cat', 'u1')).resolves.toEqual(
+        [],
+      );
+      expect(firestoreMocks.getDocument).not.toHaveBeenCalled();
+      expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
+    });
+
+    it('uploads each file to its category path and appends entries to pendingImages', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [{ id: 'existing', full: 'x' }],
+      });
+      const files = [makeFile('a.jpg'), makeFile('b.png', 'image/png')];
+
+      const result = await RecipeImageProposalService.propose('r1', files, 'desserts', 'user-1');
+
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(2);
+      // Storage paths include the new id + extension under the category prefix.
+      const paths = storageMocks.uploadFile.mock.calls.map((args) => args[1]);
+      expect(paths[0]).toMatch(/^img\/recipes\/full\/desserts\/r1\/img-\d+-[a-z0-9]+\.jpg$/);
+      expect(paths[1]).toMatch(/^img\/recipes\/full\/desserts\/r1\/img-\d+-[a-z0-9]+\.png$/);
+
+      // updateDocument receives existing + new entries, in that order.
+      const update = firestoreMocks.updateDocument.mock.calls[0];
+      expect(update[0]).toBe('recipes');
+      expect(update[1]).toBe('r1');
+      const persisted = update[2].pendingImages;
+      expect(persisted).toHaveLength(3);
+      expect(persisted[0]).toEqual({ id: 'existing', full: 'x' });
+      expect(persisted[1]).toMatchObject({
+        fileExtension: 'jpg',
+        uploadedBy: 'user-1',
+      });
+      expect(persisted[2]).toMatchObject({
+        fileExtension: 'png',
+        uploadedBy: 'user-1',
+      });
+
+      // Return value is just the new entries.
+      expect(result).toHaveLength(2);
+      expect(result.every((e) => e.uploadedBy === 'user-1')).toBe(true);
+    });
+
+    it('starts with an empty pendingImages array when the recipe has none yet', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'r1' });
+      const files = [makeFile()];
+
+      await RecipeImageProposalService.propose('r1', files, 'cat', 'user-1');
+
+      const persisted = firestoreMocks.updateDocument.mock.calls[0][2].pendingImages;
+      expect(persisted).toHaveLength(1);
+    });
   });
 
-  it('approve delegates to approvePendingImageById', async () => {
-    imageUtilMocks.approvePendingImageById.mockResolvedValue('new-id');
-    const result = await RecipeImageProposalService.approve('r1', 'pid');
-    expect(imageUtilMocks.approvePendingImageById).toHaveBeenCalledWith('r1', 'pid');
-    expect(result).toBe('new-id');
+  describe('approve', () => {
+    it('moves the pending entry into images[] as a typed RecipeImage and removes it from pendingImages', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        images: [{ id: 'existing', isPrimary: true }],
+        pendingImages: [
+          {
+            id: 'p1',
+            full: 'img/recipes/full/cat/r1/p1.jpg',
+            fileExtension: 'jpg',
+            uploadedBy: 'u1',
+          },
+          {
+            id: 'p2',
+            full: 'img/recipes/full/cat/r1/p2.jpg',
+            fileExtension: 'jpg',
+            uploadedBy: 'u2',
+          },
+        ],
+      });
+
+      const newId = await RecipeImageProposalService.approve('r1', 'p1');
+
+      expect(typeof newId).toBe('string');
+      expect(newId).toMatch(/^img-/);
+
+      const update = firestoreMocks.updateDocument.mock.calls[0];
+      expect(update[0]).toBe('recipes');
+      expect(update[1]).toBe('r1');
+      const { images, pendingImages } = update[2];
+      // New image appended (not primary — recipe already had approved images).
+      expect(images).toHaveLength(2);
+      expect(images[1]).toMatchObject({
+        id: newId,
+        full: 'img/recipes/full/cat/r1/p1.jpg',
+        isPrimary: false,
+        access: 'public',
+        uploadedBy: 'u1',
+        fileName: 'p1.jpg',
+      });
+      // Only p2 left pending.
+      expect(pendingImages).toEqual([expect.objectContaining({ id: 'p2' })]);
+    });
+
+    it('marks the approved entry as primary when the recipe had no approved images yet', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [{ id: 'p1', full: 'p/1', fileExtension: 'jpg', uploadedBy: 'u1' }],
+      });
+
+      await RecipeImageProposalService.approve('r1', 'p1');
+
+      const images = firestoreMocks.updateDocument.mock.calls[0][2].images;
+      expect(images).toHaveLength(1);
+      expect(images[0].isPrimary).toBe(true);
+    });
+
+    it('throws when there are no pending images', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'r1' });
+      await expect(RecipeImageProposalService.approve('r1', 'p1')).rejects.toThrow(
+        'No pending images to approve',
+      );
+    });
+
+    it('throws when the pending image id is not found', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [{ id: 'other' }],
+      });
+      await expect(RecipeImageProposalService.approve('r1', 'p1')).rejects.toThrow(
+        'Pending image not found',
+      );
+    });
   });
 
-  it('reject delegates to rejectPendingImageById', async () => {
-    imageUtilMocks.rejectPendingImageById.mockResolvedValue();
-    await RecipeImageProposalService.reject('r1', 'pid');
-    expect(imageUtilMocks.rejectPendingImageById).toHaveBeenCalledWith('r1', 'pid');
+  describe('reject', () => {
+    it('deletes the pending Storage files via RecipeImageService.deleteFiles and trims the pending entry', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [
+          { id: 'p1', full: 'img/recipes/full/cat/r1/p1.jpg' },
+          { id: 'p2', full: 'img/recipes/full/cat/r1/p2.jpg' },
+        ],
+      });
+
+      await RecipeImageProposalService.reject('r1', 'p1');
+
+      expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'p1' }),
+      );
+      const update = firestoreMocks.updateDocument.mock.calls[0];
+      expect(update[2].pendingImages).toEqual([expect.objectContaining({ id: 'p2' })]);
+    });
+
+    it('throws when there are no pending images', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'r1' });
+      await expect(RecipeImageProposalService.reject('r1', 'p1')).rejects.toThrow(
+        'No pending images to reject',
+      );
+      expect(recipeImageServiceMocks.deleteFiles).not.toHaveBeenCalled();
+    });
+
+    it('throws when the pending image id is not found', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [{ id: 'other' }],
+      });
+      await expect(RecipeImageProposalService.reject('r1', 'p1')).rejects.toThrow(
+        'Pending image not found',
+      );
+      expect(recipeImageServiceMocks.deleteFiles).not.toHaveBeenCalled();
+    });
   });
 
-  it('listPending delegates to getPendingImages', async () => {
-    imageUtilMocks.getPendingImages.mockResolvedValue([{ id: 'p1' }]);
-    const result = await RecipeImageProposalService.listPending('r1');
-    expect(imageUtilMocks.getPendingImages).toHaveBeenCalledWith('r1');
-    expect(result).toEqual([{ id: 'p1' }]);
+  describe('listPending', () => {
+    it('returns the pending images array', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({
+        id: 'r1',
+        pendingImages: [{ id: 'p1' }, { id: 'p2' }],
+      });
+      const result = await RecipeImageProposalService.listPending('r1');
+      expect(result).toEqual([{ id: 'p1' }, { id: 'p2' }]);
+    });
+
+    it('returns an empty array when the recipe has no pendingImages', async () => {
+      firestoreMocks.getDocument.mockResolvedValue({ id: 'r1' });
+      await expect(RecipeImageProposalService.listPending('r1')).resolves.toEqual([]);
+    });
+
+    it('returns an empty array when the recipe document is missing', async () => {
+      firestoreMocks.getDocument.mockResolvedValue(null);
+      await expect(RecipeImageProposalService.listPending('r1')).resolves.toEqual([]);
+    });
   });
 });

--- a/tests/js/utils/recipes/recipe-image-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-image-utils.test.mjs
@@ -1,40 +1,10 @@
 import { jest } from '@jest/globals';
 
-// Mocks for Firebase/Firestore/Storage
-import '../../../common/mocks/firebase-firestore.mock.js';
-import '../../../common/mocks/firebase-storage.mock.js';
-import '../../../common/mocks/firebase-service.mock.js';
-
 let validateImageFile,
   getImageStoragePath,
   getRecipeImages,
   getPlaceholderImageUrl,
-  getPrimaryImage,
-  addPendingImages,
-  approvePendingImageById,
-  rejectPendingImageById,
-  getPendingImages;
-
-// Mock StorageService and FirestoreService
-const uploadFileMock = jest.fn();
-const getFileUrlMock = jest.fn();
-const deleteFileMock = jest.fn();
-const getDocumentMock = jest.fn();
-const updateDocumentMock = jest.fn();
-
-jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
-  StorageService: {
-    uploadFile: uploadFileMock,
-    getFileUrl: getFileUrlMock,
-    deleteFile: deleteFileMock,
-  },
-}));
-jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
-  FirestoreService: {
-    getDocument: getDocumentMock,
-    updateDocument: updateDocumentMock,
-  },
-}));
+  getPrimaryImage;
 
 // Helper: create a fake File
 function createFakeFile(name = 'test.jpg', type = 'image/jpeg', size = 1000) {
@@ -49,22 +19,12 @@ describe('recipe-image-utils', () => {
 
   beforeEach(async () => {
     jest.resetModules();
-    uploadFileMock.mockReset();
-    getFileUrlMock.mockReset();
-    deleteFileMock.mockReset();
-    deleteFileMock.mockImplementation(() => Promise.resolve());
-    getDocumentMock.mockReset();
-    updateDocumentMock.mockReset();
     const utils = await import('src/js/utils/recipes/recipe-image-utils.js');
     validateImageFile = utils.validateImageFile;
     getImageStoragePath = utils.getImageStoragePath;
     getRecipeImages = utils.getRecipeImages;
     getPlaceholderImageUrl = utils.getPlaceholderImageUrl;
     getPrimaryImage = utils.getPrimaryImage;
-    addPendingImages = utils.addPendingImages;
-    approvePendingImageById = utils.approvePendingImageById;
-    rejectPendingImageById = utils.rejectPendingImageById;
-    getPendingImages = utils.getPendingImages;
   });
 
   describe('validateImageFile', () => {
@@ -136,96 +96,6 @@ describe('recipe-image-utils', () => {
       expect(getPrimaryImage({ images: [] })).toBeUndefined();
       expect(getPrimaryImage({})).toBeUndefined();
       expect(getPrimaryImage(null)).toBeUndefined();
-    });
-  });
-
-  describe('addPendingImages', () => {
-    it('uploads multiple files and appends to pendingImages', async () => {
-      uploadFileMock.mockResolvedValue('url');
-      updateDocumentMock.mockResolvedValue();
-      getDocumentMock.mockResolvedValue({ pendingImages: [] });
-      const files = [createFakeFile('a.jpg'), createFakeFile('b.jpg')];
-      const result = await addPendingImages('rid', files, 'cat', 'user1');
-      expect(uploadFileMock).toHaveBeenCalledTimes(2);
-      expect(updateDocumentMock).toHaveBeenCalledWith(
-        'recipes',
-        'rid',
-        expect.objectContaining({ pendingImages: expect.any(Array) }),
-      );
-      expect(result.length).toBe(2);
-      expect(result[0]).toHaveProperty('id');
-      expect(result[1]).toHaveProperty('id');
-    });
-    it('returns [] if no files', async () => {
-      getDocumentMock.mockResolvedValue({ pendingImages: [] });
-      const result = await addPendingImages('rid', [], 'cat', 'user1');
-      expect(result).toEqual([]);
-      expect(updateDocumentMock).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('approvePendingImageById', () => {
-    it('moves the correct pending image to images array', async () => {
-      const pending = {
-        id: 'pid',
-        full: 'img/recipes/full/cat/rid/img.jpg',
-        fileExtension: 'jpg',
-        uploadedBy: 'u',
-      };
-      getDocumentMock.mockResolvedValue({ pendingImages: [pending], images: [] });
-      updateDocumentMock.mockResolvedValue();
-      await approvePendingImageById('rid', 'pid');
-      expect(updateDocumentMock).toHaveBeenCalledWith(
-        'recipes',
-        'rid',
-        expect.objectContaining({ images: expect.any(Array), pendingImages: [] }),
-      );
-    });
-    it('throws if pending image not found', async () => {
-      getDocumentMock.mockResolvedValue({ pendingImages: [{ id: 'other' }] });
-      await expect(approvePendingImageById('rid', 'pid')).rejects.toThrow();
-    });
-    it('throws if no pendingImages', async () => {
-      getDocumentMock.mockResolvedValue({});
-      await expect(approvePendingImageById('rid', 'pid')).rejects.toThrow();
-    });
-  });
-
-  describe('rejectPendingImageById', () => {
-    it('deletes all files and removes the pending image from the array', async () => {
-      const pending = { id: 'pid', full: 'img/recipes/full/cat/rid/image.jpg' };
-      getDocumentMock.mockResolvedValue({ pendingImages: [pending, { id: 'other' }] });
-      updateDocumentMock.mockResolvedValue();
-      await rejectPendingImageById('rid', 'pid');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_400x400.webp');
-      expect(deleteFileMock).toHaveBeenCalledWith('img/recipes/full/cat/rid/image_1080x1080.webp');
-      expect(updateDocumentMock).toHaveBeenCalledWith(
-        'recipes',
-        'rid',
-        expect.objectContaining({ pendingImages: [{ id: 'other' }] }),
-      );
-    });
-    it('throws if pending image not found', async () => {
-      getDocumentMock.mockResolvedValue({ pendingImages: [{ id: 'other' }] });
-      await expect(rejectPendingImageById('rid', 'pid')).rejects.toThrow();
-    });
-    it('throws if no pendingImages', async () => {
-      getDocumentMock.mockResolvedValue({});
-      await expect(rejectPendingImageById('rid', 'pid')).rejects.toThrow();
-    });
-  });
-
-  describe('getPendingImages', () => {
-    it('returns the pendingImages array', async () => {
-      getDocumentMock.mockResolvedValue({ pendingImages: [{ id: 'a' }, { id: 'b' }] });
-      const result = await getPendingImages('rid');
-      expect(result).toEqual([{ id: 'a' }, { id: 'b' }]);
-    });
-    it('returns [] if no pendingImages', async () => {
-      getDocumentMock.mockResolvedValue({});
-      const result = await getPendingImages('rid');
-      expect(result).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## What changed

End state after this PR: **`recipe-image-utils.js` is pure-only** — no Storage/Firestore imports, no async exports, no I/O. Matches the plan's stated target.

Inlines the four utility passthroughs the service was forwarding to:

| utils export | inlined into |
|---|---|
| `addPendingImages(recipeId, files, category, uploader)` | `RecipeImageProposalService.propose` |
| `approvePendingImageById(recipeId, pendingImageId)` | `RecipeImageProposalService.approve` |
| `rejectPendingImageById(recipeId, pendingImageId)` | `RecipeImageProposalService.reject` |
| `getPendingImages(recipeId)` | `RecipeImageProposalService.listPending` |

`reject` delegates Storage cleanup to `RecipeImageService.deleteFiles` instead of duplicating the multi-file deletion logic. `approve` writes to `recipes/{id}.{images, pendingImages}` directly — bounded proposal-workflow exception to the "RecipeService owns recipes/{id}" rule (proposal-service is the documented exception for moderation flow).

**Removed from utils:**
- Private helpers: `getRecipeDoc`, `updateRecipeDoc`, `deleteImageFiles`
- Exports: `addPendingImages`, `approvePendingImageById`, `rejectPendingImageById`, `getPendingImages`
- `StorageService` + `FirestoreService` imports
- `PendingRecipeImage` typedef (now lives only inside the service)

4 files changed, +303/−335.

## End state of `recipe-image-utils.js`

```
// All pure — no async, no I/O, no service imports
export function validateImageFile(file) { ... }       // type + size validation
export function getImageStoragePath(...) { ... }       // path builder
export function generateImageId() { ... }              // 'img-' + ts + rand
export function getRecipeImages(recipe, userRole) {} // access-level filter
export function getPlaceholderImageUrl() { return null; }
export function getPrimaryImage(recipe) { ... }        // selects isPrimary || first
```

## Public service surface (unchanged)

`RecipeImageProposalService.{propose, approve, reject, listPending}` — same names, same call shape as before. No caller migration needed.

## Verify

- `npm test` → **27 suites / 538 tests pass** (was 539 in parent; −1 net: rewrote service tests +12, dropped utils tests −13).
- `npm run lint` → 0 errors.
- `npx prettier --check` → clean.
- `npm run build` → ✓.
- Pre-commit hook (including Playwright) green.

**Caller audit**: zero remaining references in `src/` to the 4 removed util functions or the 3 removed private helpers. `StorageService` / `FirestoreService` imports removed from utils.

## Behavioral changes

**Approve**: previously did a single `updateDoc({ images, pendingImages })`. Same now. No change.

**Reject**: previously called private `deleteImageFiles({ full })` which did Storage cleanup of full + WebP variants + `_original` backup. Now calls `RecipeImageService.deleteFiles(pendingImage)` — identical logic since `deleteFiles` is the public service version of the same function (lifted in PR-Q1a-4). No change.

**Propose / listPending**: pure inlines. No change.

## User flow to test

1. \`git checkout refactor/pr-q2-inline-proposal-helpers && npm run dev\`.
2. **Propose pending images** (as approved user or above): open a recipe you don't own, use the image-proposal entry point to upload 2 images.
   - In Firestore: \`recipes/{id}.pendingImages\` gains 2 entries with id / full / fileExtension / timestamp / uploadedBy.
   - In Storage: 2 files at \`img/recipes/full/<category>/<recipeId>/\`.
3. **Approve a pending image** (as manager): open the image-approval modal, mark one pending as approved, save.
   - The approved entry moves to \`images[]\` with a new id, isPrimary set if it was the first approved image, access: 'public'.
   - It's removed from \`pendingImages[]\`.
4. **Reject the other pending image** (as manager): mark it rejected, save.
   - It's removed from \`pendingImages[]\`.
   - Its Storage files + WebP variants are gone.
5. **List pending images**: refresh the modal on a recipe with pending entries → they're shown. No pending → empty state.

## Chain

This PR is the first link of a stacked chain (no merges between):

- **#244 (merged)** → PR-Q1b-2 — last merged commit
- **THIS PR (Q2)** → base \`refactor/service-layer\`
- **Q3** → MediaInstructionService — branched off this PR
- **Q4** → delete recipe-data-utils passthroughs — branched off Q3
- **O2** → ESLint enforcement — branched off Q4

User reviews + merges each in order at the end.

Refs #211.