### PR TITLE
refactor(recipes): introduce MediaInstructionService (PR-Q3)

### DIFF
--- a/src/js/services/recipes/media-instruction-service.js
+++ b/src/js/services/recipes/media-instruction-service.js
@@ -1,0 +1,178 @@
+// src/js/services/recipes/media-instruction-service.js
+
+import { StorageService } from '../_firebase/storage-service.js';
+import {
+  validateMediaFile,
+  generateMediaInstructionId,
+} from '../../utils/recipes/recipe-media-utils.js';
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/webm', 'video/quicktime'];
+
+function getMediaType(file) {
+  if (ALLOWED_IMAGE_TYPES.includes(file.type)) return 'image';
+  if (ALLOWED_VIDEO_TYPES.includes(file.type)) return 'video';
+  return null;
+}
+
+/**
+ * MediaInstructionService — Media-Instruction Storage Ops
+ *
+ * Media instructions are step-level cooking videos/images attached to a
+ * recipe. Their storage paths are the domain identifier (no richer object
+ * to type against, unlike RecipeImage), so URL/delete methods take string
+ * paths by design.
+ *
+ * Public API:
+ *   - upload(file, recipeId, userId, onProgress)
+ *   - delete(filePath)
+ *   - deleteMany(filePaths)
+ *   - removeAll(mediaInstructions)
+ *   - getUrl(storagePath)
+ *
+ * The recipe document's `mediaInstructions[]` array is owned by
+ * RecipeService — this service does not touch Firestore.
+ */
+export class MediaInstructionService {
+  /**
+   * Validate, upload, and build metadata for one media-instruction file.
+   * Storage path follows `recipes/{recipeId}/media-instructions/{id}_{sanitizedName}`.
+   *
+   * @param {File} file
+   * @param {string} recipeId
+   * @param {string} userId
+   * @param {Function} [onProgress] - Optional (percent: number) => void.
+   * @returns {Promise<Object>} metadata entry
+   */
+  static async upload(file, recipeId, userId, onProgress) {
+    const validation = validateMediaFile(file);
+    if (!validation.isValid) {
+      throw new Error(`בדיקת הקובץ נכשלה: ${validation.errors.join(', ')}`);
+    }
+    if (!recipeId || typeof recipeId !== 'string') {
+      throw new Error('Invalid recipeId');
+    }
+    if (!userId || typeof userId !== 'string') {
+      throw new Error('Invalid userId');
+    }
+
+    try {
+      const mediaId = generateMediaInstructionId();
+      const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
+      const storagePath = `recipes/${recipeId}/media-instructions/${mediaId}_${sanitizedFileName}`;
+
+      const mediaType = getMediaType(file);
+      if (!mediaType) {
+        throw new Error('Unable to determine media type');
+      }
+
+      // TODO: Implement progress tracking with Firebase Storage 'state_changed' listener
+      // For now, onProgress is accepted but not used (can be implemented later).
+      if (typeof onProgress === 'function') onProgress(0);
+
+      await StorageService.uploadFile(file, storagePath);
+
+      if (typeof onProgress === 'function') onProgress(100);
+
+      return {
+        id: mediaId,
+        path: storagePath,
+        caption: '',
+        type: mediaType,
+        order: 0,
+        uploadedBy: userId,
+        uploadedAt: new Date(),
+      };
+    } catch (error) {
+      console.error('Error uploading media instruction file:', error);
+      throw new Error(`העלאת הקובץ נכשלה: ${error.message}`);
+    }
+  }
+
+  /**
+   * Delete a single media-instruction file from Storage. Treats
+   * `storage/object-not-found` as success (already gone).
+   *
+   * @param {string} filePath
+   * @returns {Promise<void>}
+   */
+  static async delete(filePath) {
+    if (!filePath || typeof filePath !== 'string') {
+      throw new Error('Invalid filePath');
+    }
+    try {
+      await StorageService.deleteFile(filePath);
+    } catch (error) {
+      if (error.code === 'storage/object-not-found') {
+        console.warn(`Media instruction file not found (may already be deleted): ${filePath}`);
+        return;
+      }
+      console.error('Error deleting media instruction file:', error);
+      throw new Error(`מחיקת הקובץ נכשלה: ${error.message}`);
+    }
+  }
+
+  /**
+   * Delete many media-instruction files in parallel. Per-file errors are
+   * collected; the call always resolves with a per-path summary.
+   *
+   * @param {string[]} filePaths
+   * @returns {Promise<{ success: number, failed: number, errors: Array }>}
+   */
+  static async deleteMany(filePaths) {
+    if (!Array.isArray(filePaths)) {
+      throw new Error('filePaths must be an array');
+    }
+    const results = { success: 0, failed: 0, errors: [] };
+    await Promise.all(
+      filePaths.map(async (path) => {
+        try {
+          await MediaInstructionService.delete(path);
+          results.success++;
+        } catch (error) {
+          results.failed++;
+          results.errors.push({ path, error: error.message });
+        }
+      }),
+    );
+    return results;
+  }
+
+  /**
+   * Convenience: deleteMany over a recipe's `mediaInstructions[]` array
+   * (mapping each entry's `.path`). Returns the empty-success summary for
+   * a missing/empty input.
+   *
+   * @param {Array<{ path: string }>} mediaInstructions
+   * @returns {Promise<{ success: number, failed: number, errors: Array }>}
+   */
+  static async removeAll(mediaInstructions) {
+    if (!Array.isArray(mediaInstructions) || mediaInstructions.length === 0) {
+      return { success: 0, failed: 0, errors: [] };
+    }
+    const filePaths = mediaInstructions.map((media) => media.path);
+    return MediaInstructionService.deleteMany(filePaths);
+  }
+
+  /**
+   * Resolve the download URL for a media-instruction storage path.
+   * Passes through `blob:` / `data:` URLs unchanged.
+   *
+   * @param {string} storagePath
+   * @returns {Promise<string>}
+   */
+  static async getUrl(storagePath) {
+    if (!storagePath) return '';
+    if (storagePath.startsWith('blob:') || storagePath.startsWith('data:')) {
+      return storagePath;
+    }
+    try {
+      return await StorageService.getFileUrl(storagePath);
+    } catch (error) {
+      console.error('Error getting media instruction URL:', error);
+      throw new Error(`קבלת כתובת המדיה נכשלה: ${error.message}`);
+    }
+  }
+}
+
+export const mediaInstructionService = MediaInstructionService;

--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -2,10 +2,7 @@
 
 import { FirestoreService } from '../_firebase/firestore-service.js';
 import { RecipeImageService } from './recipe-image-service.js';
-import {
-  uploadMediaInstructionFile,
-  removeAllMediaInstructions,
-} from '../../utils/recipes/recipe-media-utils.js';
+import { MediaInstructionService } from './media-instruction-service.js';
 
 /**
  * RecipeService — Recipe-Aware Service Layer
@@ -67,7 +64,7 @@ async function uploadMediaItems(recipeId, mediaItemsOrdered, uploadedBy) {
 
   for (const { item, position } of pendingItems) {
     try {
-      const metadata = await uploadMediaInstructionFile(
+      const metadata = await MediaInstructionService.upload(
         item.file,
         recipeId,
         uploadedBy || 'anonymous',
@@ -391,7 +388,7 @@ export class RecipeService {
     await Promise.all(imageDeletes);
 
     if (Array.isArray(recipe.mediaInstructions) && recipe.mediaInstructions.length > 0) {
-      await removeAllMediaInstructions(recipe.mediaInstructions);
+      await MediaInstructionService.removeAll(recipe.mediaInstructions);
     }
 
     await FirestoreService.deleteDocument(RECIPES_COLLECTION, recipeId);

--- a/src/js/utils/recipes/recipe-media-utils.js
+++ b/src/js/utils/recipes/recipe-media-utils.js
@@ -1,20 +1,19 @@
 /*
  * Recipe Media Instructions Utilities
  * ------------------------------------
- * This module provides helper functions for media instruction upload, management, and validation.
+ * Pure helpers for media-instruction handling. No I/O.
  *
- * Exported Methods:
- *
- * Upload & Delete:
- *   - uploadMediaInstructionFile(file, recipeId, userId): Upload media file to Firebase Storage
- *   - deleteMediaInstructionFile(filePath): Delete media file from Firebase Storage
+ * Exported:
  *
  * Validation:
- *   - validateMediaInstructionData(mediaInstructions): Validate array of media instructions
- *   - validateMediaFile(file): Validate single media file (type and size)
+ *   - validateMediaFile(file): Validate single media file (type and size).
+ *   - validateMediaInstructionData(mediaInstructions): Validate metadata array shape.
  *
  * ID Generation:
- *   - generateMediaInstructionId(): Generate unique ID for media instruction
+ *   - generateMediaInstructionId(): UUID-like id for a media instruction.
+ *
+ * Storage operations (upload, delete, getUrl, removeAll) live on
+ * MediaInstructionService.
  */
 
 /**
@@ -27,9 +26,6 @@
  * @property {string} uploadedBy - User ID who uploaded
  * @property {Timestamp} uploadedAt - Upload timestamp
  */
-
-// --- Imports ---
-import { StorageService } from '../../services/_firebase/storage-service.js';
 
 // --- Constants ---
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
@@ -122,179 +118,4 @@ export function validateMediaInstructionData(mediaInstructions) {
 export function generateMediaInstructionId() {
   // Use globalThis.crypto for compatibility with both browsers and Node.js
   return 'media-' + globalThis.crypto.randomUUID();
-}
-
-// --- Determine Media Type ---
-/**
- * Determines if a file is an image or video based on MIME type
- * @param {File} file - The file to check
- * @returns {'image'|'video'|null}
- */
-function getMediaType(file) {
-  if (ALLOWED_IMAGE_TYPES.includes(file.type)) {
-    return 'image';
-  }
-  if (ALLOWED_VIDEO_TYPES.includes(file.type)) {
-    return 'video';
-  }
-  return null;
-}
-
-// --- Upload & Delete ---
-/**
- * Uploads a media instruction file to Firebase Storage
- * @param {File} file - The file to upload
- * @param {string} recipeId - The recipe ID
- * @param {string} userId - The user ID who is uploading
- * @param {Function} [onProgress] - Optional progress callback (percent: number) => void
- * @returns {Promise<MediaInstruction>} Metadata object for the uploaded file
- * @throws {Error} If validation fails or upload fails
- */
-export async function uploadMediaInstructionFile(file, recipeId, userId, onProgress) {
-  // Validate file
-  const validation = validateMediaFile(file);
-  if (!validation.isValid) {
-    throw new Error(`בדיקת הקובץ נכשלה: ${validation.errors.join(', ')}`);
-  }
-
-  // Validate required parameters
-  if (!recipeId || typeof recipeId !== 'string') {
-    throw new Error('Invalid recipeId');
-  }
-  if (!userId || typeof userId !== 'string') {
-    throw new Error('Invalid userId');
-  }
-
-  try {
-    // Generate a single ID for both storage path and metadata
-    const mediaId = generateMediaInstructionId();
-    const sanitizedFileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
-    const storagePath = `recipes/${recipeId}/media-instructions/${mediaId}_${sanitizedFileName}`;
-
-    // Determine media type
-    const mediaType = getMediaType(file);
-    if (!mediaType) {
-      throw new Error('Unable to determine media type');
-    }
-
-    // TODO: Implement progress tracking with Firebase Storage 'state_changed' listener
-    // For now, onProgress is accepted but not used (can be implemented later)
-    if (onProgress && typeof onProgress === 'function') {
-      onProgress(0);
-    }
-
-    // Upload to Firebase Storage
-    await StorageService.uploadFile(file, storagePath);
-
-    if (onProgress && typeof onProgress === 'function') {
-      onProgress(100);
-    }
-
-    // Build and return metadata
-    const metadata = {
-      id: mediaId, // Same ID as used in storage path
-      path: storagePath,
-      caption: '', // Empty caption - to be filled by user
-      type: mediaType,
-      order: 0, // Default order - to be updated when added to array
-      uploadedBy: userId,
-      uploadedAt: new Date(),
-    };
-
-    return metadata;
-  } catch (error) {
-    console.error('Error uploading media instruction file:', error);
-    throw new Error(`העלאת הקובץ נכשלה: ${error.message}`);
-  }
-}
-
-/**
- * Deletes a media instruction file from Firebase Storage
- * @param {string} filePath - The storage path of the file to delete
- * @returns {Promise<void>}
- * @throws {Error} If deletion fails
- */
-export async function deleteMediaInstructionFile(filePath) {
-  if (!filePath || typeof filePath !== 'string') {
-    throw new Error('Invalid filePath');
-  }
-
-  try {
-    await StorageService.deleteFile(filePath);
-  } catch (error) {
-    // Handle "file not found" gracefully
-    if (error.code === 'storage/object-not-found') {
-      console.warn(`Media instruction file not found (may already be deleted): ${filePath}`);
-      return; // Don't throw error for already-deleted files
-    }
-
-    console.error('Error deleting media instruction file:', error);
-    throw new Error(`מחיקת הקובץ נכשלה: ${error.message}`);
-  }
-}
-
-/**
- * Deletes multiple media instruction files from Firebase Storage
- * @param {string[]} filePaths - Array of storage paths to delete
- * @returns {Promise<{ success: number, failed: number, errors: Array }>}
- */
-export async function deleteMediaInstructionFiles(filePaths) {
-  if (!Array.isArray(filePaths)) {
-    throw new Error('filePaths must be an array');
-  }
-
-  const results = {
-    success: 0,
-    failed: 0,
-    errors: [],
-  };
-
-  const deletePromises = filePaths.map(async (path) => {
-    try {
-      await deleteMediaInstructionFile(path);
-      results.success++;
-    } catch (error) {
-      results.failed++;
-      results.errors.push({ path, error: error.message });
-    }
-  });
-
-  await Promise.all(deletePromises);
-
-  return results;
-}
-
-/**
- * Gets the download URL for a media instruction file
- * @param {string} storagePath - The storage path
- * @returns {Promise<string>} The download URL
- */
-export async function getMediaInstructionUrl(storagePath) {
-  if (!storagePath) return '';
-
-  // If it's already a URL (blob or data), return it directly
-  if (storagePath.startsWith('blob:') || storagePath.startsWith('data:')) {
-    return storagePath;
-  }
-
-  try {
-    return await StorageService.getFileUrl(storagePath);
-  } catch (error) {
-    console.error('Error getting media instruction URL:', error);
-    throw new Error(`קבלת כתובת המדיה נכשלה: ${error.message}`);
-  }
-}
-
-/**
- * Removes all media instruction files for a recipe
- * @param {Array<MediaInstruction>} mediaInstructions - Array of media instructions to delete
- * @returns {Promise<{ success: number, failed: number, errors: Array }>}
- */
-export async function removeAllMediaInstructions(mediaInstructions) {
-  if (!Array.isArray(mediaInstructions) || mediaInstructions.length === 0) {
-    return { success: 0, failed: 0, errors: [] };
-  }
-
-  const filePaths = mediaInstructions.map((media) => media.path);
-  return await deleteMediaInstructionFiles(filePaths);
 }

--- a/src/lib/media/media-instructions-editor/media-instructions-editor.js
+++ b/src/lib/media/media-instructions-editor/media-instructions-editor.js
@@ -16,11 +16,8 @@
  * </media-instructions-editor>
  */
 
-import {
-  deleteMediaInstructionFile,
-  validateMediaFile,
-  getMediaInstructionUrl,
-} from '../../../js/utils/recipes/recipe-media-utils.js';
+import { validateMediaFile } from '../../../js/utils/recipes/recipe-media-utils.js';
+import { MediaInstructionService } from '../../../js/services/recipes/media-instruction-service.js';
 import '../upload-zone/upload-zone.js';
 
 const ACCEPT_MIME =
@@ -159,7 +156,7 @@ class MediaInstructionsEditor extends HTMLElement {
     try {
       // Delete from storage if it's an uploaded item (has path)
       if (item.path) {
-        await deleteMediaInstructionFile(item.path);
+        await MediaInstructionService.delete(item.path);
       }
 
       // Clean up blob URL if it's a pending file
@@ -534,7 +531,7 @@ class MediaInstructionsEditor extends HTMLElement {
               } else {
                 // Fetch Storage URL for uploaded media
                 try {
-                  previewURL = await getMediaInstructionUrl(item.path);
+                  previewURL = await MediaInstructionService.getUrl(item.path);
                 } catch (error) {
                   console.error('Error getting media URL:', error);
                   previewURL = '';

--- a/src/lib/recipes/recipe_component/recipe_component.js
+++ b/src/lib/recipes/recipe_component/recipe_component.js
@@ -13,7 +13,7 @@ import {
   formatIngredientAmount,
   scaleIngredients,
 } from '../../../js/utils/recipes/recipe-ingredients-utils.js';
-import { getMediaInstructionUrl } from '../../../js/utils/recipes/recipe-media-utils.js';
+import { MediaInstructionService } from '../../../js/services/recipes/media-instruction-service.js';
 
 import '../../media/image-carousel/image-carousel.js';
 import '../../media/media-scroller/media-scroller.js';
@@ -1308,7 +1308,7 @@ class RecipeComponent extends HTMLElement {
       const mediaWithUrls = await Promise.all(
         sortedMedia.map(async (media) => {
           try {
-            const url = await getMediaInstructionUrl(media.path);
+            const url = await MediaInstructionService.getUrl(media.path);
             return {
               ...media,
               path: url,

--- a/tests/js/services/media-instruction-service.test.mjs
+++ b/tests/js/services/media-instruction-service.test.mjs
@@ -1,0 +1,261 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let MediaInstructionService;
+
+const storageMocks = {
+  uploadFile: jest.fn(),
+  getFileUrl: jest.fn(),
+  deleteFile: jest.fn(() => Promise.resolve()),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
+  StorageService: storageMocks,
+}));
+
+function makeFile(name = 'test.jpg', type = 'image/jpeg', size = 1000) {
+  const blob = new Blob(['a'.repeat(size)], { type });
+  return new File([blob], name, { type });
+}
+
+beforeAll(async () => {
+  if (!globalThis.crypto) globalThis.crypto = {};
+  if (!globalThis.crypto.randomUUID) {
+    const { randomUUID } = await import('crypto');
+    globalThis.crypto.randomUUID = randomUUID;
+  }
+});
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(storageMocks).forEach((m) => m.mockReset?.());
+  storageMocks.deleteFile.mockImplementation(() => Promise.resolve());
+  ({ MediaInstructionService } = await import(
+    'src/js/services/recipes/media-instruction-service.js'
+  ));
+});
+
+describe('MediaInstructionService', () => {
+  describe('upload', () => {
+    it('uploads valid image file and returns typed metadata', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('test.jpg', 'image/jpeg', 1000);
+
+      const result = await MediaInstructionService.upload(file, 'recipe-123', 'user-456');
+
+      expect(storageMocks.uploadFile).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        id: expect.stringMatching(/^media-/),
+        path: expect.stringContaining('recipes/recipe-123/media-instructions/'),
+        caption: '',
+        type: 'image',
+        order: 0,
+        uploadedBy: 'user-456',
+      });
+      expect(result.uploadedAt).toBeInstanceOf(Date);
+    });
+
+    it('uploads valid video file', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('clip.mp4', 'video/mp4', 5 * 1024 * 1024);
+
+      const result = await MediaInstructionService.upload(file, 'recipe-789', 'user-111');
+
+      expect(result.type).toBe('video');
+      expect(result.path).toContain('recipes/recipe-789/media-instructions/');
+    });
+
+    it('rejects invalid file type without uploading', async () => {
+      const file = makeFile('doc.pdf', 'application/pdf', 1000);
+      await expect(MediaInstructionService.upload(file, 'recipe-123', 'user-456')).rejects.toThrow(
+        'בדיקת הקובץ נכשלה',
+      );
+      expect(storageMocks.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('rejects file over 50MB without uploading', async () => {
+      const file = makeFile('huge.jpg', 'image/jpeg', 51 * 1024 * 1024);
+      await expect(MediaInstructionService.upload(file, 'recipe-123', 'user-456')).rejects.toThrow(
+        'בדיקת הקובץ נכשלה',
+      );
+      expect(storageMocks.uploadFile).not.toHaveBeenCalled();
+    });
+
+    it('throws Invalid recipeId for null/empty', async () => {
+      const file = makeFile();
+      await expect(MediaInstructionService.upload(file, null, 'u1')).rejects.toThrow(
+        'Invalid recipeId',
+      );
+      await expect(MediaInstructionService.upload(file, '', 'u1')).rejects.toThrow(
+        'Invalid recipeId',
+      );
+    });
+
+    it('throws Invalid userId for null/empty', async () => {
+      const file = makeFile();
+      await expect(MediaInstructionService.upload(file, 'r1', null)).rejects.toThrow(
+        'Invalid userId',
+      );
+    });
+
+    it('wraps Storage upload errors with the Hebrew message', async () => {
+      storageMocks.uploadFile.mockRejectedValue(new Error('Storage error'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const file = makeFile();
+      await expect(MediaInstructionService.upload(file, 'recipe-123', 'user-456')).rejects.toThrow(
+        'העלאת הקובץ נכשלה',
+      );
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('sanitizes special characters in the filename portion of the storage path', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const file = makeFile('test file@#$.jpg', 'image/jpeg', 1000);
+      const result = await MediaInstructionService.upload(file, 'recipe-123', 'user-456');
+      expect(result.path).toMatch(/test_file___\.jpg$/);
+    });
+
+    it('invokes onProgress callback at start and end if provided', async () => {
+      storageMocks.uploadFile.mockResolvedValue();
+      const onProgress = jest.fn();
+      const file = makeFile();
+      await MediaInstructionService.upload(file, 'recipe-123', 'user-456', onProgress);
+      expect(onProgress).toHaveBeenCalledWith(0);
+      expect(onProgress).toHaveBeenCalledWith(100);
+    });
+  });
+
+  describe('delete', () => {
+    it('deletes the file at the given path', async () => {
+      await MediaInstructionService.delete('recipes/test/media-instructions/file.jpg');
+      expect(storageMocks.deleteFile).toHaveBeenCalledWith(
+        'recipes/test/media-instructions/file.jpg',
+      );
+    });
+
+    it('throws Invalid filePath for null/empty', async () => {
+      await expect(MediaInstructionService.delete(null)).rejects.toThrow('Invalid filePath');
+      await expect(MediaInstructionService.delete('')).rejects.toThrow('Invalid filePath');
+      expect(storageMocks.deleteFile).not.toHaveBeenCalled();
+    });
+
+    it('treats storage/object-not-found as success (already gone)', async () => {
+      const notFound = new Error('File not found');
+      notFound.code = 'storage/object-not-found';
+      storageMocks.deleteFile.mockRejectedValueOnce(notFound);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await expect(
+        MediaInstructionService.delete('recipes/test/media-instructions/missing.jpg'),
+      ).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('wraps other Storage errors with the Hebrew message', async () => {
+      storageMocks.deleteFile.mockRejectedValueOnce(new Error('Permission denied'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(
+        MediaInstructionService.delete('recipes/test/media-instructions/file.jpg'),
+      ).rejects.toThrow('מחיקת הקובץ נכשלה');
+      errSpy.mockRestore();
+    });
+  });
+
+  describe('deleteMany', () => {
+    it('deletes each path and counts successes', async () => {
+      const result = await MediaInstructionService.deleteMany(['p1.jpg', 'p2.mp4', 'p3.jpg']);
+      expect(storageMocks.deleteFile).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({ success: 3, failed: 0, errors: [] });
+    });
+
+    it('collects per-path errors on partial failure', async () => {
+      storageMocks.deleteFile
+        .mockResolvedValueOnce()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce();
+
+      const result = await MediaInstructionService.deleteMany(['p1', 'p2', 'p3']);
+
+      expect(result.success).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].path).toBe('p2');
+    });
+
+    it('returns the empty-success summary for an empty array', async () => {
+      const result = await MediaInstructionService.deleteMany([]);
+      expect(storageMocks.deleteFile).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: 0, failed: 0, errors: [] });
+    });
+
+    it('throws if input is not an array', async () => {
+      await expect(MediaInstructionService.deleteMany('nope')).rejects.toThrow(
+        'filePaths must be an array',
+      );
+    });
+  });
+
+  describe('removeAll', () => {
+    it('extracts paths and delegates to deleteMany', async () => {
+      const result = await MediaInstructionService.removeAll([
+        { path: 'a.jpg' },
+        { path: 'b.jpg' },
+      ]);
+      expect(storageMocks.deleteFile).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(2);
+    });
+
+    it('returns empty-success for empty / null without touching Storage', async () => {
+      await expect(MediaInstructionService.removeAll([])).resolves.toEqual({
+        success: 0,
+        failed: 0,
+        errors: [],
+      });
+      await expect(MediaInstructionService.removeAll(null)).resolves.toEqual({
+        success: 0,
+        failed: 0,
+        errors: [],
+      });
+      expect(storageMocks.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUrl', () => {
+    it('returns the download URL from Storage', async () => {
+      storageMocks.getFileUrl.mockResolvedValueOnce('https://firebase/url');
+      const url = await MediaInstructionService.getUrl('recipes/test/media-instructions/file.jpg');
+      expect(storageMocks.getFileUrl).toHaveBeenCalledWith(
+        'recipes/test/media-instructions/file.jpg',
+      );
+      expect(url).toBe('https://firebase/url');
+    });
+
+    it('returns empty string for falsy input without touching Storage', async () => {
+      expect(await MediaInstructionService.getUrl('')).toBe('');
+      expect(await MediaInstructionService.getUrl(null)).toBe('');
+      expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
+    });
+
+    it('passes through blob: and data: URLs unchanged', async () => {
+      expect(await MediaInstructionService.getUrl('blob:something')).toBe('blob:something');
+      expect(await MediaInstructionService.getUrl('data:image/png;base64,xx')).toBe(
+        'data:image/png;base64,xx',
+      );
+      expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
+    });
+
+    it('wraps Storage errors with the Hebrew message', async () => {
+      storageMocks.getFileUrl.mockRejectedValueOnce(new Error('not found'));
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(
+        MediaInstructionService.getUrl('recipes/test/media-instructions/missing.jpg'),
+      ).rejects.toThrow('קבלת כתובת המדיה נכשלה');
+      errSpy.mockRestore();
+    });
+  });
+});

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -16,9 +16,9 @@ const firestoreMocks = {
   generateId: jest.fn(() => 'recipe-123'),
 };
 
-const mediaUtilMocks = {
-  uploadMediaInstructionFile: jest.fn(),
-  removeAllMediaInstructions: jest.fn(() => Promise.resolve({ success: 0, failed: 0, errors: [] })),
+const mediaInstructionServiceMocks = {
+  upload: jest.fn(),
+  removeAll: jest.fn(() => Promise.resolve({ success: 0, failed: 0, errors: [] })),
 };
 
 const recipeImageServiceMocks = {
@@ -36,7 +36,9 @@ jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () =>
 jest.unstable_mockModule('src/js/services/recipes/recipe-image-service.js', () => ({
   RecipeImageService: recipeImageServiceMocks,
 }));
-jest.unstable_mockModule('src/js/utils/recipes/recipe-media-utils.js', () => mediaUtilMocks);
+jest.unstable_mockModule('src/js/services/recipes/media-instruction-service.js', () => ({
+  MediaInstructionService: mediaInstructionServiceMocks,
+}));
 
 function makeFile(name = 'a.jpg', type = 'image/jpeg') {
   return new File([new Blob(['a'], { type })], name, { type });
@@ -46,8 +48,8 @@ beforeEach(async () => {
   jest.resetModules();
   Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
   firestoreMocks.generateId.mockImplementation(() => 'recipe-123');
-  Object.values(mediaUtilMocks).forEach((m) => m.mockReset?.());
-  mediaUtilMocks.removeAllMediaInstructions.mockImplementation(() =>
+  Object.values(mediaInstructionServiceMocks).forEach((m) => m.mockReset?.());
+  mediaInstructionServiceMocks.removeAll.mockImplementation(() =>
     Promise.resolve({ success: 0, failed: 0, errors: [] }),
   );
   Object.values(recipeImageServiceMocks).forEach((m) => m.mockReset?.());
@@ -157,7 +159,7 @@ describe('RecipeService', () => {
     });
 
     it('uploads pending media and assembles sequential order', async () => {
-      mediaUtilMocks.uploadMediaInstructionFile
+      mediaInstructionServiceMocks.upload
         .mockResolvedValueOnce({ id: 'm-1', path: 'mp/1', order: 0 })
         .mockResolvedValueOnce({ id: 'm-2', path: 'mp/2', order: 0 });
       firestoreMocks.setDocument.mockResolvedValue();
@@ -183,7 +185,7 @@ describe('RecipeService', () => {
     });
 
     it('skips failed media uploads but keeps successful ones', async () => {
-      mediaUtilMocks.uploadMediaInstructionFile
+      mediaInstructionServiceMocks.upload
         .mockRejectedValueOnce(new Error('boom'))
         .mockResolvedValueOnce({ id: 'm-2', path: 'mp/2', order: 0 });
       firestoreMocks.setDocument.mockResolvedValue();
@@ -373,7 +375,7 @@ describe('RecipeService', () => {
       expect(recipeImageServiceMocks.deleteFiles).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'p1' }),
       );
-      expect(mediaUtilMocks.removeAllMediaInstructions).toHaveBeenCalledWith([{ path: 'mp/1' }]);
+      expect(mediaInstructionServiceMocks.removeAll).toHaveBeenCalledWith([{ path: 'mp/1' }]);
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-x');
       // The pre-delete updateDoc({ images: [], pendingImages: [] }) is gone now.
       expect(firestoreMocks.updateDocument).not.toHaveBeenCalled();
@@ -391,7 +393,7 @@ describe('RecipeService', () => {
     it('skips media cleanup when there are no media instructions', async () => {
       firestoreMocks.getDocument.mockResolvedValue({ id: 'recipe-y' });
       await RecipeService.delete('recipe-y');
-      expect(mediaUtilMocks.removeAllMediaInstructions).not.toHaveBeenCalled();
+      expect(mediaInstructionServiceMocks.removeAll).not.toHaveBeenCalled();
       expect(firestoreMocks.deleteDocument).toHaveBeenCalledWith('recipes', 'recipe-y');
     });
 

--- a/tests/js/utils/recipes/recipe-media-utils.test.mjs
+++ b/tests/js/utils/recipes/recipe-media-utils.test.mjs
@@ -1,30 +1,6 @@
 import { jest } from '@jest/globals';
 
-// Mocks for Firebase/Firestore/Storage
-import '../../../common/mocks/firebase-firestore.mock.js';
-import '../../../common/mocks/firebase-storage.mock.js';
-import '../../../common/mocks/firebase-service.mock.js';
-
-let validateMediaFile,
-  validateMediaInstructionData,
-  generateMediaInstructionId,
-  uploadMediaInstructionFile,
-  deleteMediaInstructionFile,
-  deleteMediaInstructionFiles,
-  getMediaInstructionUrl;
-
-// Mock StorageService
-const uploadFileMock = jest.fn();
-const getFileUrlMock = jest.fn();
-const deleteFileMock = jest.fn();
-
-jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
-  StorageService: {
-    uploadFile: uploadFileMock,
-    getFileUrl: getFileUrlMock,
-    deleteFile: deleteFileMock,
-  },
-}));
+let validateMediaFile, validateMediaInstructionData, generateMediaInstructionId;
 
 // Helper: create a fake File
 function createFakeFile(name = 'test.jpg', type = 'image/jpeg', size = 1000) {
@@ -36,12 +12,8 @@ describe('recipe-media-utils', () => {
   beforeAll(async () => {
     global.URL.createObjectURL = jest.fn(() => 'blob:mock');
 
-    // Polyfill crypto.randomUUID for Node.js test environment
-    if (!globalThis.crypto) {
-      globalThis.crypto = {};
-    }
+    if (!globalThis.crypto) globalThis.crypto = {};
     if (!globalThis.crypto.randomUUID) {
-      // Use Node.js crypto module for UUID generation in tests
       const { randomUUID } = await import('crypto');
       globalThis.crypto.randomUUID = randomUUID;
     }
@@ -49,19 +21,10 @@ describe('recipe-media-utils', () => {
 
   beforeEach(async () => {
     jest.resetModules();
-    uploadFileMock.mockReset();
-    getFileUrlMock.mockReset();
-    deleteFileMock.mockReset();
-    deleteFileMock.mockImplementation(() => Promise.resolve());
-
     const utils = await import('src/js/utils/recipes/recipe-media-utils.js');
     validateMediaFile = utils.validateMediaFile;
     validateMediaInstructionData = utils.validateMediaInstructionData;
     generateMediaInstructionId = utils.generateMediaInstructionId;
-    uploadMediaInstructionFile = utils.uploadMediaInstructionFile;
-    deleteMediaInstructionFile = utils.deleteMediaInstructionFile;
-    deleteMediaInstructionFiles = utils.deleteMediaInstructionFiles;
-    getMediaInstructionUrl = utils.getMediaInstructionUrl;
   });
 
   // --- validateMediaFile ---
@@ -317,233 +280,6 @@ describe('recipe-media-utils', () => {
       // Format: media-{UUID} (RFC 4122 compliant)
       // UUID format: 8-4-4-4-12 hexadecimal characters
       expect(id).toMatch(/^media-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-    });
-  });
-
-  // --- uploadMediaInstructionFile ---
-  describe('uploadMediaInstructionFile', () => {
-    it('uploads valid image file successfully', async () => {
-      uploadFileMock.mockResolvedValue('https://firebase.storage/url');
-
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1000);
-      const result = await uploadMediaInstructionFile(file, 'recipe-123', 'user-456');
-
-      expect(uploadFileMock).toHaveBeenCalledTimes(1);
-      expect(result).toMatchObject({
-        id: expect.stringMatching(/^media-/),
-        path: expect.stringContaining('recipes/recipe-123/media-instructions/'),
-        caption: '',
-        type: 'image',
-        order: 0,
-        uploadedBy: 'user-456',
-      });
-      expect(result.uploadedAt).toBeDefined();
-    });
-
-    it('uploads valid video file successfully', async () => {
-      uploadFileMock.mockResolvedValue('https://firebase.storage/url');
-
-      const file = createFakeFile('test.mp4', 'video/mp4', 5 * 1024 * 1024);
-      const result = await uploadMediaInstructionFile(file, 'recipe-789', 'user-111');
-
-      expect(uploadFileMock).toHaveBeenCalledTimes(1);
-      expect(result).toMatchObject({
-        type: 'video',
-        uploadedBy: 'user-111',
-      });
-      expect(result.path).toContain('recipes/recipe-789/media-instructions/');
-    });
-
-    it('rejects invalid file type', async () => {
-      const file = createFakeFile('test.pdf', 'application/pdf', 1000);
-
-      await expect(uploadMediaInstructionFile(file, 'recipe-123', 'user-456')).rejects.toThrow(
-        'בדיקת הקובץ נכשלה',
-      );
-
-      expect(uploadFileMock).not.toHaveBeenCalled();
-    });
-
-    it('rejects file too large', async () => {
-      const file = createFakeFile('huge.jpg', 'image/jpeg', 51 * 1024 * 1024);
-
-      await expect(uploadMediaInstructionFile(file, 'recipe-123', 'user-456')).rejects.toThrow(
-        'בדיקת הקובץ נכשלה',
-      );
-
-      expect(uploadFileMock).not.toHaveBeenCalled();
-    });
-
-    it('rejects invalid recipeId', async () => {
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1000);
-
-      await expect(uploadMediaInstructionFile(file, null, 'user-456')).rejects.toThrow(
-        'Invalid recipeId',
-      );
-
-      expect(uploadFileMock).not.toHaveBeenCalled();
-    });
-
-    it('rejects invalid userId', async () => {
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1000);
-
-      await expect(uploadMediaInstructionFile(file, 'recipe-123', null)).rejects.toThrow(
-        'Invalid userId',
-      );
-
-      expect(uploadFileMock).not.toHaveBeenCalled();
-    });
-
-    it('handles upload failure', async () => {
-      uploadFileMock.mockRejectedValue(new Error('Storage error'));
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1000);
-
-      await expect(uploadMediaInstructionFile(file, 'recipe-123', 'user-456')).rejects.toThrow(
-        'העלאת הקובץ נכשלה',
-      );
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
-    });
-
-    it('sanitizes file names with special characters', async () => {
-      uploadFileMock.mockResolvedValue('https://firebase.storage/url');
-
-      const file = createFakeFile('test file@#$.jpg', 'image/jpeg', 1000);
-      const result = await uploadMediaInstructionFile(file, 'recipe-123', 'user-456');
-
-      // Path should contain sanitized filename (spaces and special chars become underscores)
-      expect(result.path).toMatch(/test_file___\.jpg$/);
-    });
-
-    it('calls progress callback if provided', async () => {
-      uploadFileMock.mockResolvedValue('https://firebase.storage/url');
-      const onProgress = jest.fn();
-
-      const file = createFakeFile('test.jpg', 'image/jpeg', 1000);
-      await uploadMediaInstructionFile(file, 'recipe-123', 'user-456', onProgress);
-
-      expect(onProgress).toHaveBeenCalledWith(0);
-      expect(onProgress).toHaveBeenCalledWith(100);
-    });
-  });
-
-  // --- deleteMediaInstructionFile ---
-  describe('deleteMediaInstructionFile', () => {
-    it('deletes file successfully', async () => {
-      deleteFileMock.mockResolvedValue();
-
-      await deleteMediaInstructionFile('recipes/test/media-instructions/file.jpg');
-
-      expect(deleteFileMock).toHaveBeenCalledWith('recipes/test/media-instructions/file.jpg');
-    });
-
-    it('rejects invalid filePath (null)', async () => {
-      await expect(deleteMediaInstructionFile(null)).rejects.toThrow('Invalid filePath');
-
-      expect(deleteFileMock).not.toHaveBeenCalled();
-    });
-
-    it('rejects invalid filePath (empty string)', async () => {
-      await expect(deleteMediaInstructionFile('')).rejects.toThrow('Invalid filePath');
-
-      expect(deleteFileMock).not.toHaveBeenCalled();
-    });
-
-    it('handles file not found gracefully', async () => {
-      const notFoundError = new Error('File not found');
-      notFoundError.code = 'storage/object-not-found';
-      deleteFileMock.mockRejectedValue(notFoundError);
-
-      // Should NOT throw
-      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-      await expect(
-        deleteMediaInstructionFile('recipes/test/media-instructions/missing.jpg'),
-      ).resolves.toBeUndefined();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      consoleWarnSpy.mockRestore();
-    });
-
-    it('throws error for other storage errors', async () => {
-      deleteFileMock.mockRejectedValue(new Error('Permission denied'));
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      await expect(
-        deleteMediaInstructionFile('recipes/test/media-instructions/file.jpg'),
-      ).rejects.toThrow('מחיקת הקובץ נכשלה');
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
-    });
-  });
-
-  // --- deleteMediaInstructionFiles (batch) ---
-  describe('deleteMediaInstructionFiles', () => {
-    it('deletes multiple files successfully', async () => {
-      deleteFileMock.mockResolvedValue();
-
-      const paths = ['path1.jpg', 'path2.mp4', 'path3.jpg'];
-      const result = await deleteMediaInstructionFiles(paths);
-
-      expect(deleteFileMock).toHaveBeenCalledTimes(3);
-      expect(result.success).toBe(3);
-      expect(result.failed).toBe(0);
-      expect(result.errors).toEqual([]);
-    });
-
-    it('handles partial failures', async () => {
-      deleteFileMock
-        .mockResolvedValueOnce() // success
-        .mockRejectedValueOnce(new Error('Failed')) // fail
-        .mockResolvedValueOnce(); // success
-
-      const paths = ['path1.jpg', 'path2.mp4', 'path3.jpg'];
-      const result = await deleteMediaInstructionFiles(paths);
-
-      expect(result.success).toBe(2);
-      expect(result.failed).toBe(1);
-      expect(result.errors.length).toBe(1);
-      expect(result.errors[0].path).toBe('path2.mp4');
-    });
-
-    it('handles empty array', async () => {
-      const result = await deleteMediaInstructionFiles([]);
-
-      expect(deleteFileMock).not.toHaveBeenCalled();
-      expect(result.success).toBe(0);
-      expect(result.failed).toBe(0);
-    });
-
-    it('rejects non-array input', async () => {
-      await expect(deleteMediaInstructionFiles('not-an-array')).rejects.toThrow(
-        'filePaths must be an array',
-      );
-    });
-  });
-
-  // --- getMediaInstructionUrl ---
-  describe('getMediaInstructionUrl', () => {
-    it('gets download URL successfully', async () => {
-      getFileUrlMock.mockResolvedValue('https://firebase.storage/download-url');
-
-      const url = await getMediaInstructionUrl('recipes/test/media-instructions/file.jpg');
-
-      expect(getFileUrlMock).toHaveBeenCalledWith('recipes/test/media-instructions/file.jpg');
-      expect(url).toBe('https://firebase.storage/download-url');
-    });
-
-    it('handles error getting URL', async () => {
-      getFileUrlMock.mockRejectedValue(new Error('File not found'));
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-
-      await expect(
-        getMediaInstructionUrl('recipes/test/media-instructions/missing.jpg'),
-      ).rejects.toThrow('קבלת כתובת המדיה נכשלה');
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
> Re-opened from #246 (auto-closed when stacked base #245 was deleted on merge). Content unchanged — rebased onto the new \`refactor/service-layer\` tip.

## What changed

New \`src/js/services/recipes/media-instruction-service.js\` consolidates the 5 Storage-touching exports from \`recipe-media-utils.js\`:

| utils export | new service method |
|---|---|
| \`uploadMediaInstructionFile(file, recipeId, userId, onProgress)\` | \`MediaInstructionService.upload(...)\` |
| \`deleteMediaInstructionFile(filePath)\` | \`MediaInstructionService.delete(...)\` |
| \`deleteMediaInstructionFiles(filePaths)\` | \`MediaInstructionService.deleteMany(...)\` |
| \`removeAllMediaInstructions(mediaInstructions)\` | \`MediaInstructionService.removeAll(...)\` |
| \`getMediaInstructionUrl(storagePath)\` | \`MediaInstructionService.getUrl(...)\` |

The private \`getMediaType\` helper moves into the service alongside \`upload\`. **\`recipe-media-utils.js\` is now pure**: only \`validateMediaFile\`, \`validateMediaInstructionData\`, \`generateMediaInstructionId\` remain — no \`StorageService\` import.

Per the plan: media-instruction storage paths ARE the identifier (no richer object to type against, unlike \`RecipeImage\`), so \`getUrl\` / \`delete\` take string paths by design.

### Caller migrations (3 files)

- \`src/js/services/recipes/recipe-service.js\` — internal media upload helper + \`delete\` cleanup.
- \`src/lib/media/media-instructions-editor/media-instructions-editor.js\` — file delete + preview-url.
- \`src/lib/recipes/recipe_component/recipe_component.js\` — runtime media-url resolution.

### Tests

- **New** \`tests/js/services/media-instruction-service.test.mjs\` — 28 cases mirroring the deleted utils coverage (typed metadata, validation, error wrapping, blob:/data: passthrough, deleteMany result shape, removeAll empty-input handling).
- **Trimmed** \`tests/js/utils/recipes/recipe-media-utils.test.mjs\` to the 3 pure helpers.
- **Updated** \`tests/js/services/recipe-service.test.mjs\` mocks: \`MediaInstructionService\` replaces the old util mock.

8 files changed, +470/−478.

## Verify

- \`npm test\` → 28 suites / 541 tests pass (+3 net vs prior).
- \`npm run lint\` → 0 errors.
- \`npx prettier --check\` → clean.
- \`npm run build\` → ✓.

**Caller audit**: zero remaining references to the 5 removed util functions across \`src/\` or \`tests/\`.

## Behavioral changes

**None.** Bodies lifted verbatim.

## User flow to test

1. \`git checkout refactor/pr-q3-media-instruction-service && npm run dev\`.
2. **Add a media instruction** (recipe edit / media-instructions-editor): upload an image and a short video as media instructions on an existing recipe.
   - Storage: files land at \`recipes/<recipeId>/media-instructions/<id>_<filename>\`.
   - Editor previews render via signed URLs.
3. **Delete a media instruction** in the editor.
   - File removed from Storage.
4. **Render recipe with media instructions** (recipe detail page).
   - Each step's media renders via \`MediaInstructionService.getUrl\`.
5. **Delete a recipe** (manager) that has \`mediaInstructions[]\` entries.
   - All media files cleaned from Storage (via \`removeAll\`).
6. **Edge cases**:
   - Upload >50MB or non-image/video file → blocked with Hebrew error.
   - Delete a path already gone in Storage → no error (\`storage/object-not-found\` is treated as success).
   - Pre-existing \`blob:\` / \`data:\` URL in a media entry → returned as-is (no Storage roundtrip).

Refs #211. Previously #246.