### PR TITLE
chore(import-modal): drop dead firebase/storage import (PR-O2-1)

### DIFF
--- a/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
+++ b/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
@@ -7,7 +7,6 @@ import cropperStyles from 'cropperjs/dist/cropper.css?inline';
 import memoryGameStyles from '../../games/memory_game.css?inline';
 import burgerStackerStyles from '../../games/burger_stacker.css?inline';
 import gameWrapperStyles from '../../games/game_wrapper.css?inline';
-import { getStorage, ref, uploadString, getDownloadURL } from 'firebase/storage';
 import { CookingMemoryGame } from '../../games/memory_game.js';
 import { BurgerStackerGame } from '../../games/burger_stacker.js';
 import { GameWrapper } from '../../games/game_wrapper.js';


### PR DESCRIPTION
First of three cleanup PRs that unblock the strict \`no-restricted-imports\` ESLint rule (PR-O2-4).

## What changed (1 file, −1 line)

\`\`\`diff
-import { getStorage, ref, uploadString, getDownloadURL } from 'firebase/storage';
\`\`\`

## Why

None of the 4 named imports are referenced in \`recipe_import_modal.js\`. Confirmed by grep — only the import line mentions them. Dead code from an earlier iteration of the recipe-import flow; image upload now goes through Cloud Functions via \`httpsCallable\` (\`firebase/functions\`, which isn't in the planned ban list).

## Verify

- \`npm test\` → 28 suites / 534 tests pass.
- \`npm run lint\` → 0 errors.
- \`npm run build\` → ✓.

## Behavioral changes

**None.** The removed import had zero references.

## User flow to test

Sanity-only — the recipe-import flow shouldn't depend on these imports:

1. \`git checkout refactor/o2-cleanup-import-modal-dead-imports && npm run dev\`
2. Open the recipe-import modal from a recipe form.
3. **Image import path**: upload a food photo → crop → extract → \`extractRecipeFromImage\` Cloud Function runs → recipe gets imported.
4. **URL import path**: paste a recipe URL → \`extractRecipeFromUrl\` runs → recipe gets imported.

Both should work unchanged. If they don't, the imports weren't actually dead and we need a different fix.

## Series

- **THIS PR (O2-1)** — drop dead firebase/storage import in recipe_import_modal.js
- **O2-2** (next) — migrate \`Timestamp.now()\` in propose_recipe_component.js
- **O2-3** — migrate firestore + storage reads in pdf_viewer.js
- **O2-4** — add the strict \`no-restricted-imports\` ESLint rule; closes #215

Refs #211.