### PR TITLE
refactor(recipes): service-stamp creationTime; drop firebase/firestore from propose component (PR-O2-2)

### DIFF
--- a/src/js/services/recipes/recipe-service.js
+++ b/src/js/services/recipes/recipe-service.js
@@ -1,5 +1,6 @@
 // src/js/services/recipes/recipe-service.js
 
+import { Timestamp } from 'firebase/firestore';
 import { FirestoreService } from '../_firebase/firestore-service.js';
 import { RecipeImageService } from './recipe-image-service.js';
 import { MediaInstructionService } from './media-instruction-service.js';
@@ -162,7 +163,7 @@ export class RecipeService {
    *
    * @param {Object} params
    * @param {Object} params.recipeData - Base recipe fields (no images/mediaInstructions/toDelete).
-   *                                     Caller is responsible for timestamps, userId, approved.
+   *                                     Caller sets userId + approved; creationTime is service-stamped.
    * @param {Array<{file: File, isPrimary: boolean}>} [params.imagesToUpload]
    * @param {Array<Object>} [params.mediaItemsOrdered] - Ordered media items
    *        from the editor; each entry has either `file` (pending) or
@@ -195,6 +196,7 @@ export class RecipeService {
       );
 
       const docPayload = { ...cleanedData };
+      docPayload.creationTime = Timestamp.now();
       if (uploadedImages.length > 0) {
         docPayload.images = uploadedImages;
         docPayload.allowImageSuggestions = true;

--- a/src/lib/recipes/recipe_form_component/propose_recipe_component.js
+++ b/src/lib/recipes/recipe_form_component/propose_recipe_component.js
@@ -15,7 +15,6 @@
  */
 
 import { RecipeService } from '../../../js/services/recipes/recipe-service.js';
-import { Timestamp } from 'firebase/firestore';
 import authService from '../../../js/services/auth/auth-service.js';
 import { logError, getErrorMessage } from '../../../js/utils/error-handler.js';
 import { showToast } from '../../notifications/toast-notification/toast-notification.js';
@@ -71,7 +70,6 @@ class ProposeRecipeComponent extends HTMLElement {
 
       const recipeDataForFirestore = {
         ...baseFields,
-        creationTime: Timestamp.now(),
         userId: uploadedBy,
         approved: false,
       };

--- a/tests/js/services/recipe-service.test.mjs
+++ b/tests/js/services/recipe-service.test.mjs
@@ -221,6 +221,28 @@ describe('RecipeService', () => {
     it('throws when recipeData is missing', async () => {
       await expect(RecipeService.create({})).rejects.toThrow('recipeData is required');
     });
+
+    it('service-stamps creationTime on the persisted payload', async () => {
+      firestoreMocks.setDocument.mockResolvedValue();
+      await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts' },
+        uploadedBy: 'user-1',
+      });
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload.creationTime).toBeDefined();
+    });
+
+    it('overrides caller-supplied creationTime (service is the single source of truth)', async () => {
+      firestoreMocks.setDocument.mockResolvedValue();
+      const stale = { fake: 'caller-set' };
+      await RecipeService.create({
+        recipeData: { name: 'Cake', category: 'desserts', creationTime: stale },
+        uploadedBy: 'user-1',
+      });
+      const payload = firestoreMocks.setDocument.mock.calls[0][2];
+      expect(payload.creationTime).toBeDefined();
+      expect(payload.creationTime).not.toBe(stale);
+    });
   });
 
   describe('update', () => {


### PR DESCRIPTION
Second of three cleanup PRs that unblock the strict \`no-restricted-imports\` ESLint rule (PR-O2-4).

## What changed (3 files, +25/−3)

| File | Change |
|---|---|
| \`src/js/services/recipes/recipe-service.js\` | Adds \`import { Timestamp } from 'firebase/firestore'\`. \`RecipeService.create\` now stamps \`docPayload.creationTime = Timestamp.now()\` after building the payload (always-override). JSDoc updated: callers set \`userId\`/\`approved\`; \`creationTime\` is service-stamped. |
| \`src/lib/recipes/recipe_form_component/propose_recipe_component.js\` | Drops \`import { Timestamp } from 'firebase/firestore'\` and the \`creationTime: Timestamp.now()\` field from \`recipeDataForFirestore\`. |
| \`tests/js/services/recipe-service.test.mjs\` | 2 new assertions: \`creationTime\` is defined on the persisted payload, and a caller-supplied \`creationTime\` value is overridden. |

## Why \`Timestamp.now()\` and not \`new Date()\`

Git archeology surfaced PR #98 (Mar 2026) titled *"Optimize Home Page fetches: server-side sorting/limiting, **unify creationTime schema**, and fix timestamp validation bug in backend functions"*. That PR deliberately migrated \`new Date()\` → \`Timestamp.now()\` across multiple writers (cookbook prep, retry-counter timestamps, etc.) and fixed a backend-functions timestamp-validation bug. Replacing \`Timestamp.now()\` with \`new Date()\` would have regressed that decision. This PR preserves the schema choice; only the **location of the stamp** moves (lib component → service layer where raw-SDK imports are allowed by convention).

## Caller audit

Only one src caller of \`RecipeService.create\` exists: \`propose_recipe_component.js\`. It stops sending \`creationTime\`. No other call sites affected.

## Verify

- \`npm test\` → 28 suites / 536 tests pass (+2 net new in recipe-service.test.mjs).
- \`npm run lint\` → 0 errors.
- \`npx prettier --check\` → clean.
- \`npm run build\` → ✓.

**Violation audit**: \`Timestamp\` / \`firebase/firestore\` references outside \`src/js/services/**\` now show only \`pdf_viewer.js\` (O2-3's scope) and a coincidental \`formatTimestamp\` method name (no import).

## Behavioral changes

**None on the wire.** The persisted recipe doc still has \`creationTime: Timestamp\`. Reads (home-page sort uses \`.seconds\`) keep working. The only difference: caller-supplied \`creationTime\` is now ignored (was previously honored). No current caller does this; the test pins the new contract.

## User flow to test

1. \`git checkout refactor/o2-cleanup-propose-timestamp && npm run dev\`
2. **Propose a new recipe** (sign in, navigate to \`/propose-recipe\`):
   - Fill in name, category, ingredients, instructions, attach 1+ images.
   - Submit. Toast shows success.
3. **Verify in Firestore** (Firebase console or via app):
   - The new doc at \`recipes/{id}\` has \`creationTime\` set to a Firestore Timestamp (not null, not a JS Date map).
   - The doc still has \`userId\` and \`approved: false\` (caller-set).
4. **Home-page sort sanity**: refresh home page; the new recipe should appear in the "recently added" list at the correct chronological position (home page sorts by \`creationTime.seconds\`).
5. **Edge case**: pass a caller-set \`creationTime\` (only possible via dev tools — not a user-reachable path) → the service overrides it. Already covered by unit test.

## Series

- **O2-1** (merged) — drop dead firebase/storage import in recipe_import_modal.js
- **THIS PR (O2-2)** — service-stamp creationTime; drop firebase/firestore from propose component
- **O2-3** (next) — migrate firestore + storage reads in pdf_viewer.js
- **O2-4** — add the strict \`no-restricted-imports\` ESLint rule; closes #215

Refs #211.