### PR TITLE
refactor(pdf-viewer): route reads through new PdfService (PR-O2-3)

### DIFF
--- a/src/js/services/pdf/pdf-service.js
+++ b/src/js/services/pdf/pdf-service.js
@@ -1,0 +1,49 @@
+// src/js/services/pdf/pdf-service.js
+
+import { FirestoreService } from '../_firebase/firestore-service.js';
+import { StorageService } from '../_firebase/storage-service.js';
+
+/**
+ * PdfService — Scanned-PDF Reads
+ *
+ * Thin domain wrapper for the grandma's-cookbook page-image PDF viewer
+ * (and any future scanned-PDF features). Centralizes the Firestore
+ * page-index read and the Storage page-image URL resolution so lib
+ * components don't import `_firebase/*` services directly.
+ *
+ * Public API:
+ *   - getPageIndex(collection, fileName)
+ *   - getPageImageUrl(path)
+ */
+export class PdfService {
+  /**
+   * Fetch a scanned PDF's page-index manifest (typically maps
+   * recipe ids / category labels to page numbers).
+   *
+   * @param {string} collection - Firestore collection holding the manifest.
+   * @param {string} fileName - Document id within that collection.
+   * @returns {Promise<Object|null>} Manifest data, or null when missing.
+   */
+  static async getPageIndex(collection, fileName) {
+    if (!collection || !fileName) {
+      throw new Error('PdfService.getPageIndex: collection and fileName are required');
+    }
+    return await FirestoreService.getDocument(collection, fileName);
+  }
+
+  /**
+   * Resolve a download URL for a scanned-PDF page image stored in
+   * Firebase Storage (e.g. `grandmas_cookbook/original/page.42.jpg`).
+   *
+   * @param {string} path - Storage path of the page image.
+   * @returns {Promise<string>}
+   */
+  static async getPageImageUrl(path) {
+    if (!path) {
+      throw new Error('PdfService.getPageImageUrl: path is required');
+    }
+    return await StorageService.getFileUrl(path);
+  }
+}
+
+export const pdfService = PdfService;

--- a/src/lib/utilities/pdf_viewer/pdf_viewer.js
+++ b/src/lib/utilities/pdf_viewer/pdf_viewer.js
@@ -1,9 +1,4 @@
-import {
-  getFirestoreInstance,
-  getStorageInstance,
-} from '../../../js/services/_firebase/firebase-service.js';
-import { doc, getDoc } from 'firebase/firestore';
-import { ref, getDownloadURL } from 'firebase/storage';
+import { PdfService } from '../../../js/services/pdf/pdf-service.js';
 
 class PDFViewer extends HTMLElement {
   constructor() {
@@ -73,15 +68,9 @@ class PDFViewer extends HTMLElement {
 
   async fetchPageIndex() {
     try {
-      const db = getFirestoreInstance();
-      if (!db) {
-        console.error('Firestore not initialized');
-        return {};
-      }
-      const [collectionName, fileName] = this.getAttribute('page-index').split('/'); // Split the attribute value
-      const pageIndexRef = doc(db, collectionName, fileName);
-      const pageIndexDocSnap = await getDoc(pageIndexRef);
-      return pageIndexDocSnap.exists() ? pageIndexDocSnap.data() : {};
+      const [collectionName, fileName] = this.getAttribute('page-index').split('/');
+      const data = await PdfService.getPageIndex(collectionName, fileName);
+      return data || {};
     } catch (error) {
       console.error('Error fetching page index:', error);
       return {};
@@ -542,19 +531,9 @@ class PDFViewer extends HTMLElement {
     img.alt = `Page ${pageNumber}`;
 
     try {
-      const storage = getStorageInstance();
-      if (!storage) {
-        console.error('Storage not initialized');
-        return;
-      }
-
-      // Construct reference to the file
       // pdfPath usually has form "grandmas_cookbook/original/"
-      // We need to ensure we don't have double slashes if pdfPath ends with /
       const path = `${this.pdfPath}page.${pageNumber}.jpg`;
-      const imageRef = ref(storage, path);
-
-      const url = await getDownloadURL(imageRef);
+      const url = await PdfService.getPageImageUrl(path);
 
       img.src = url;
 

--- a/tests/js/services/pdf-service.test.mjs
+++ b/tests/js/services/pdf-service.test.mjs
@@ -1,0 +1,85 @@
+import { jest } from '@jest/globals';
+
+import '../../common/mocks/firebase-firestore.mock.js';
+import '../../common/mocks/firebase-storage.mock.js';
+import '../../common/mocks/firebase-service.mock.js';
+
+let PdfService;
+
+const firestoreMocks = {
+  getDocument: jest.fn(),
+};
+
+const storageMocks = {
+  getFileUrl: jest.fn(),
+};
+
+jest.unstable_mockModule('src/js/services/_firebase/firestore-service.js', () => ({
+  FirestoreService: firestoreMocks,
+}));
+jest.unstable_mockModule('src/js/services/_firebase/storage-service.js', () => ({
+  StorageService: storageMocks,
+}));
+
+beforeEach(async () => {
+  jest.resetModules();
+  Object.values(firestoreMocks).forEach((m) => m.mockReset?.());
+  Object.values(storageMocks).forEach((m) => m.mockReset?.());
+  ({ PdfService } = await import('src/js/services/pdf/pdf-service.js'));
+});
+
+describe('PdfService', () => {
+  describe('getPageIndex', () => {
+    it('returns the manifest document data when present', async () => {
+      const manifest = { categories: { desserts: { pages: [12, 13] } } };
+      firestoreMocks.getDocument.mockResolvedValueOnce(manifest);
+
+      const result = await PdfService.getPageIndex('grandmas_cookbook', 'page-index');
+
+      expect(firestoreMocks.getDocument).toHaveBeenCalledWith('grandmas_cookbook', 'page-index');
+      expect(result).toBe(manifest);
+    });
+
+    it('returns null when the manifest doc is missing', async () => {
+      firestoreMocks.getDocument.mockResolvedValueOnce(null);
+      await expect(PdfService.getPageIndex('grandmas_cookbook', 'missing')).resolves.toBeNull();
+    });
+
+    it('throws when collection or fileName is missing', async () => {
+      await expect(PdfService.getPageIndex('', 'file')).rejects.toThrow(
+        'collection and fileName are required',
+      );
+      await expect(PdfService.getPageIndex('col', '')).rejects.toThrow(
+        'collection and fileName are required',
+      );
+      expect(firestoreMocks.getDocument).not.toHaveBeenCalled();
+    });
+
+    it('propagates Firestore errors', async () => {
+      firestoreMocks.getDocument.mockRejectedValueOnce(new Error('permission denied'));
+      await expect(PdfService.getPageIndex('col', 'file')).rejects.toThrow('permission denied');
+    });
+  });
+
+  describe('getPageImageUrl', () => {
+    it('returns the Storage download URL for the given path', async () => {
+      storageMocks.getFileUrl.mockResolvedValueOnce('https://storage/page.42.jpg');
+      const result = await PdfService.getPageImageUrl('grandmas_cookbook/original/page.42.jpg');
+      expect(storageMocks.getFileUrl).toHaveBeenCalledWith(
+        'grandmas_cookbook/original/page.42.jpg',
+      );
+      expect(result).toBe('https://storage/page.42.jpg');
+    });
+
+    it('throws when path is missing', async () => {
+      await expect(PdfService.getPageImageUrl('')).rejects.toThrow('path is required');
+      await expect(PdfService.getPageImageUrl(null)).rejects.toThrow('path is required');
+      expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
+    });
+
+    it('propagates Storage errors', async () => {
+      storageMocks.getFileUrl.mockRejectedValueOnce(new Error('not found'));
+      await expect(PdfService.getPageImageUrl('p')).rejects.toThrow('not found');
+    });
+  });
+});


### PR DESCRIPTION
Third (last) cleanup PR. With this merged, the strict \`no-restricted-imports\` rule (PR-O2-4) will pass without exemptions.

## What changed (3 files, +139/−26)

### New: \`src/js/services/pdf/pdf-service.js\`

A thin domain service for the scanned-PDF viewer (grandma's cookbook). Two methods:

\`\`\`
PdfService.getPageIndex(collection, fileName)  // Firestore manifest read
PdfService.getPageImageUrl(path)               // Storage URL resolve
\`\`\`

Why not \`DocumentService\`: "Document" collides with the Firestore-document mental model in a Firebase codebase. Why not \`CookbookService\`: the whole project is "the cookbook" — too generic. \`PdfService\` is unambiguous and matches what the feature actually is (scanned PDFs with page-image storage + a Firestore-backed page index).

### \`src/lib/utilities/pdf_viewer/pdf_viewer.js\`

- Dropped imports of \`firebase-service\` (\`getFirestoreInstance\` / \`getStorageInstance\`), \`firebase/firestore\` (\`doc\`, \`getDoc\`), \`firebase/storage\` (\`ref\`, \`getDownloadURL\`).
- Single \`PdfService\` import in their place.
- Two call sites migrated (\`fetchPageIndex\` and the page-image loader). Behavior preserved — the same Firestore doc is read and the same Storage URL is resolved.
- Removed the manual instance-presence guards (\`if (!db)\` / \`if (!storage)\`) — the underlying services handle their own initialization.

### \`tests/js/services/pdf-service.test.mjs\`

New test file, 7 cases:
- \`getPageIndex\`: returns manifest data; null on missing doc; throws on missing args; propagates Firestore errors.
- \`getPageImageUrl\`: returns Storage URL; throws on missing path; propagates Storage errors.

## Verify

- \`npm test\` → 29 suites / 543 tests pass (+7 new for the service).
- \`npm run lint\` → 0 errors.
- \`npx prettier --check\` → clean.
- \`npm run build\` → ✓.

**Violation audit**: \`grep\` for firebase/* and \`_firebase/*-service\` imports outside \`src/js/services/**\` now returns **0 hits**. The codebase is ready for PR-O2-4 (the rule itself) to pass without exemptions.

## Behavioral changes

**Effectively none.** The two functional changes are subtle and intentional:

1. **\`fetchPageIndex\`** now returns \`{}\` when \`PdfService.getPageIndex\` returns \`null\` (missing doc). Previously the code did \`pageIndexDocSnap.exists() ? data() : {}\` — same observable result.
2. **Image loader** no longer logs "Storage not initialized" if Storage isn't ready — it just lets \`StorageService.getFileUrl\` throw, which is then caught by \`img.onerror\` or surfaces as a network error in dev tools. \`StorageService\` handles init internally, so this guard wasn't reachable in practice.

## User flow to test

1. \`git checkout refactor/o2-cleanup-pdf-viewer && npm run dev\`
2. Navigate to \`/grandmas-cooking\`.
3. **PDF viewer loads**:
   - Page-index manifest fetched (the categories dropdown populates correctly).
   - Page images render as you navigate pages.
4. **Page navigation**:
   - Use the page picker or next/prev → each new page loads its image.
   - Picking a category → jumps to the right page.
5. **Search by recipe / category** (if the UI supports it): the index lookup works.
6. **Edge case**: open the viewer with a bad \`page-index\` attribute (no matching Firestore doc) — should fall back gracefully (categories list empty, but no JS crash).

## Series

- **O2-1** (merged) — drop dead firebase/storage import in recipe_import_modal.js
- **O2-2** (merged) — service-stamp creationTime; drop firebase/firestore from propose component
- **THIS PR (O2-3)** — introduce PdfService; migrate pdf_viewer.js
- **O2-4** (next) — add the strict \`no-restricted-imports\` ESLint rule; closes #215

Refs #211.