### PR TITLE
chore(eslint): strict no-restricted-imports rule for service-layer boundary (PR-O2-4)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,37 @@ export default [
           patterns: [{ group: ['firebase/compat/*'], message: 'Do not use compat API' }],
         },
       ],
-      // Add more rules as needed
+    },
+  },
+  // Strict service-layer boundary: lib/, page/, and other non-service src/ code
+  // must go through a domain service. Direct imports of _firebase/* services
+  // or raw firebase/{firestore,storage,auth} SDKs are forbidden here. The
+  // exception is src/js/services/** itself, which is the only place those
+  // SDKs are allowed.
+  {
+    files: ['src/**/*.{js,mjs}'],
+    ignores: ['src/js/services/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['firebase/compat/*'],
+              message: 'Do not use compat API.',
+            },
+            {
+              group: ['firebase/firestore', 'firebase/storage', 'firebase/auth'],
+              message: 'Raw Firebase SDKs are only allowed inside src/js/services/**.',
+            },
+            {
+              group: ['**/_firebase/firestore-service*', '**/_firebase/storage-service*'],
+              message:
+                'Use a domain service (RecipeService, RecipeImageService, MediaInstructionService, PdfService, UserService, etc.) instead of importing _firebase/* directly.',
+            },
+          ],
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
**Final PR of the service-layer refactor umbrella.** Adds the ESLint rule that locks in the boundary established by Q1a–Q4 + O2-1/2/3.

## What changed (1 file, +31/−1)

Adds a strict \`no-restricted-imports\` config block scoped to \`src/**/*.{js,mjs}\` with \`src/js/services/**\` excluded. The block forbids:

| Pattern | Why |
|---|---|
| \`firebase/firestore\`, \`firebase/storage\`, \`firebase/auth\` | Raw SDKs only inside \`src/js/services/**\`. |
| \`**/_firebase/firestore-service*\`, \`**/_firebase/storage-service*\` | Lib components and pages must go through a domain service (RecipeService, RecipeImageService, MediaInstructionService, PdfService, UserService, etc.). |
| \`firebase/compat/*\` | Already banned globally — restated here so the strict block's pattern list is self-contained. |

The pre-existing top-level rule (banning **default** imports of firebase/auth/firestore/storage everywhere — including tests, functions/) is preserved as the first config block.

## Verify

- \`npm run lint\` → **0 errors**. The pre-existing warning in \`functions/recipe-transfer.js\` (outside src/) is unchanged.
- \`npm test\` → 29 suites / 543 tests pass.
- \`npx prettier --check\` → clean.
- \`npm run build\` → ✓.

### Negative test

Temporarily added \`import { doc } from 'firebase/firestore';\` to \`src/lib/utilities/pdf_viewer/pdf_viewer.js\`. Lint immediately errored:

\`\`\`
src/lib/utilities/pdf_viewer/pdf_viewer.js
  570:1  error  'firebase/firestore' import is restricted from being used by a pattern.
                Raw Firebase SDKs are only allowed inside src/js/services/**  no-restricted-imports
\`\`\`

Reverted and confirmed lint clean. The rule is functional.

### Config audit

\`eslint --print-config\` on representative files confirms:

- \`src/lib/utilities/pdf_viewer/pdf_viewer.js\` (a lib file) → strict block applies with 3 strict patterns.
- \`src/js/services/recipes/recipe-service.js\` (a service file) → strict block does NOT apply; only the original default-import bans remain.

## Behavioral changes

**None.** This is config-only — no runtime change.

## User flow to test

Sanity-only — runtime is unchanged. The relevant verification is that:

1. Lint still passes (\`npm run lint\` → 0 errors). ✓
2. The app still runs end-to-end. Smoke any one of the flows tested in Q1a–O2-3 (e.g. propose a recipe, open the cookbook PDF viewer, browse home page).

If you want to see the rule fire, run:
\`\`\`
echo "import { doc } from 'firebase/firestore';" >> src/lib/utilities/pdf_viewer/pdf_viewer.js
npm run lint
git checkout src/lib/utilities/pdf_viewer/pdf_viewer.js
\`\`\`

## Series complete

- O2-1 (merged) — drop dead firebase/storage import in recipe_import_modal.js
- O2-2 (merged) — service-stamp creationTime; drop firebase/firestore from propose component
- O2-3 (merged) — introduce PdfService; migrate pdf_viewer.js
- **THIS PR (O2-4)** — strict ESLint rule, no exemptions

After merge, \`refactor/service-layer\` is ready to merge into \`development\`.

Closes #215.
Refs #211.