### PR TITLE
fix(tests): wait for async handleClick in auth-avatar visual tests

### DIFF
--- a/tests/visuals/components/auth-avatar/auth-avatar.spec.js
+++ b/tests/visuals/components/auth-avatar/auth-avatar.spec.js
@@ -106,6 +106,11 @@ test.describe('Auth Avatar Visuals', () => {
     const avatar = page.locator('auth-avatar');
     await avatar.click();
 
+    // handleClick is async — it awaits loadAuthComponents() before calling
+    // openModal/showAuthForms. Wait for the side-effects rather than reading
+    // window flags synchronously after the click event dispatches.
+    await page.waitForFunction(() => window.modalOpened && window.authFormsShown);
+
     const result = await page.evaluate(() => ({
       modalOpened: window.modalOpened,
       authFormsShown: window.authFormsShown,
@@ -140,6 +145,8 @@ test.describe('Auth Avatar Visuals', () => {
 
     const avatar = page.locator('auth-avatar');
     await avatar.click();
+
+    await page.waitForFunction(() => window.modalOpened && window.userProfileShown);
 
     const result = await page.evaluate(() => ({
       modalOpened: window.modalOpened,


### PR DESCRIPTION
## Summary
- After PR #195, `AuthAvatar.handleClick` is async (awaits `loadAuthComponents()` before calling `openModal`/`showAuthForms`). Playwright's `await avatar.click()` returns when the click event dispatches, not when the async handler resolves — so two visual tests were reading `window.modalOpened` while it was still in the microtask queue.
- Add `page.waitForFunction(...)` after the click in both failing tests so they wait for the mocked side-effects to land.

## Test plan
- [x] `npx playwright test tests/visuals/components/auth-avatar/` — 5/5 pass locally
- [x] Pre-commit hook passes (format + lint + jest + playwright + build)

Closes #260.