### PR TITLE
chore(games): bump memory game to 3 rows in both modals

### DIFF
--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -268,7 +268,7 @@ class AiImageEnhanceModal extends HTMLElement {
       if (loadingText) loadingText.textContent = 'מכין את המטבח... תפוס את המרכיבים!';
     } else {
       this._gameWrapper = new GameWrapper(container, CookingMemoryGame, {
-        rows: 2,
+        rows: 3,
         successMessage: 'כל הכבוד! הזיכרון שלך חד!',
       });
       if (loadingText) loadingText.textContent = 'זה עשוי לקחת מספר שניות... הנה משחק קטן בינתיים!';

--- a/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
+++ b/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
@@ -558,7 +558,7 @@ class RecipeImportModal extends HTMLElement {
             'מכין את המטבח... תפוס את המרכיבים!';
         } else {
           this.gameWrapper = new GameWrapper(gameContainer, CookingMemoryGame, {
-            rows: 2,
+            rows: 3,
             successMessage: 'כל הכבוד! הזיכרון שלך חד!',
           });
           this.shadowRoot.getElementById('loading-text').textContent =


### PR DESCRIPTION
## Summary
- Bump `CookingMemoryGame` from 2 rows × 4 cols (4 pairs) to 3 rows × 4 cols (6 pairs) in both consumers.
- Emoji pool in `memory_game.js` has 8 emojis, so 6 pairs is well within bounds.

## Changes
- `src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js`: `rows: 2` → `rows: 3`
- `src/lib/recipes/recipe_import_modal/recipe_import_modal.js`: `rows: 2` → `rows: 3`

## Test plan
- [ ] Trigger AI image enhance — memory game appears with 3 rows × 4 cols, no layout/overflow regression in the modal.
- [ ] Trigger recipe import (image or URL) — memory game appears with 3 rows × 4 cols, no layout/overflow regression.
- [ ] Burger stacker game still appears in both modals when randomly picked.
- [x] `npm run format` / `npm run lint` / `npm run test` (543/543) / `npm run build` — all green.

Fixes #258

Part of the #263 mini-games umbrella. Phase 1 of 3 (next: #259 `GameWrapper.random()` registry).