### PR TITLE
fix(storage): silence expected resize-lag 404s from Sentry/console (#189)

### DIFF
--- a/src/js/services/_firebase/storage-service.js
+++ b/src/js/services/_firebase/storage-service.js
@@ -50,9 +50,14 @@ export class StorageService {
   /**
    * Gets the download URL for a file in Firebase Storage.
    * @param {string} path - The storage path
+   * @param {Object} [options]
+   * @param {boolean} [options.quietOn404=false] - When true, `storage/object-not-found`
+   *   errors skip console.error + Sentry capture (the error still throws so caller
+   *   fallback chains run). Use only at sites that explicitly expect the miss —
+   *   e.g. read-with-fallback during resize-extension lag (#189).
    * @returns {Promise<string>} The download URL
    */
-  static async getFileUrl(path) {
+  static async getFileUrl(path, { quietOn404 = false } = {}) {
     if (urlCache.has(path)) {
       return urlCache.get(path);
     }
@@ -64,8 +69,10 @@ export class StorageService {
       urlCache.set(path, url);
       return url;
     } catch (error) {
-      console.error('Error getting file URL:', error);
-      captureError(error, { service: 'storage', op: 'getFileUrl', path });
+      if (!(quietOn404 && error?.code === 'storage/object-not-found')) {
+        console.error('Error getting file URL:', error);
+        captureError(error, { service: 'storage', op: 'getFileUrl', path });
+      }
       throw new Error('Failed to get file URL');
     }
   }
@@ -112,16 +119,22 @@ export class StorageService {
   /**
    * Gets the metadata for a file in Firebase Storage.
    * @param {string} path - The storage path
+   * @param {Object} [options]
+   * @param {boolean} [options.quietOn404=false] - When true, `storage/object-not-found`
+   *   errors skip console.error + Sentry capture (the error still throws). Use at
+   *   sites that use this as an existence probe and treat the miss as expected.
    * @returns {Promise<Object>} The file metadata
    */
-  static async getMetadata(path) {
+  static async getMetadata(path, { quietOn404 = false } = {}) {
     try {
       const storage = getStorageInstance();
       const storageRef = ref(storage, path);
       return await getMetadata(storageRef);
     } catch (error) {
-      console.error('Error getting file metadata:', error);
-      captureError(error, { service: 'storage', op: 'getMetadata', path });
+      if (!(quietOn404 && error?.code === 'storage/object-not-found')) {
+        console.error('Error getting file metadata:', error);
+        captureError(error, { service: 'storage', op: 'getMetadata', path });
+      }
       throw new Error('Failed to get file metadata');
     }
   }

--- a/src/js/services/_firebase/storage-service.js
+++ b/src/js/services/_firebase/storage-service.js
@@ -80,17 +80,25 @@ export class StorageService {
   /**
    * Deletes a file from Firebase Storage.
    * @param {string} path - The storage path
+   * @param {Object} [options]
+   * @param {boolean} [options.quietOn404=false] - When true, `storage/object-not-found`
+   *   errors skip console.error + Sentry capture (the error still throws). Use at
+   *   best-effort cleanup sites where the target file may not have been generated
+   *   yet (e.g. WebP variants from the Resize extension) or never existed (e.g.
+   *   the `_original` AI-backup file, which only some images carry). (#189)
    * @returns {Promise<void>}
    */
-  static async deleteFile(path) {
+  static async deleteFile(path, { quietOn404 = false } = {}) {
     try {
       const storage = getStorageInstance();
       const storageRef = ref(storage, path);
       await deleteObject(storageRef);
       urlCache.delete(path);
     } catch (error) {
-      console.error('Error deleting file:', error);
-      captureError(error, { service: 'storage', op: 'deleteFile', path });
+      if (!(quietOn404 && error?.code === 'storage/object-not-found')) {
+        console.error('Error deleting file:', error);
+        captureError(error, { service: 'storage', op: 'deleteFile', path });
+      }
       throw new Error('Failed to delete file');
     }
   }

--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -14,7 +14,7 @@ function makeBackupPath(fullPath) {
 
 async function fileExists(path) {
   try {
-    await StorageService.getMetadata(path);
+    await StorageService.getMetadata(path, { quietOn404: true });
     return true;
   } catch {
     // silent: existence probe — false is the expected return when file is absent
@@ -253,16 +253,23 @@ export class RecipeImageService {
    *
    * @param {{ full?: string, preview?: string } | null | undefined} image
    * @param {string} [size='400x400']
+   * @param {Object} [options]
+   * @param {boolean} [options.quietOn404=false] - Suppress Sentry/console for the
+   *   FIRST attempt (optimized variant) only. Set true in contexts that show
+   *   freshly-uploaded images (edit form, pending-image approval) where the
+   *   resize extension may not have produced the variant yet (#189). The
+   *   fallback to `image.full` always stays loud — a missing original IS a
+   *   real bug worth reporting.
    * @returns {Promise<string|null>}
    */
-  static async getOptimizedUrl(image, size = '400x400') {
+  static async getOptimizedUrl(image, size = '400x400', { quietOn404 = false } = {}) {
     if (!image) return null;
     if (image.preview) return image.preview;
     if (!image.full) return null;
 
     const optimizedPath = image.full.replace(/\.[^.]+$/, `_${size}.webp`);
     try {
-      return await StorageService.getFileUrl(optimizedPath);
+      return await StorageService.getFileUrl(optimizedPath, { quietOn404 });
     } catch {
       // silent: WebP variant not yet generated; falling back to full-size original
       try {
@@ -281,12 +288,14 @@ export class RecipeImageService {
    *
    * @param {Object} recipe
    * @param {string} [size='400x400']
+   * @param {Object} [options]
+   * @param {boolean} [options.quietOn404=false] - Forwarded to `getOptimizedUrl`.
    * @returns {Promise<string|null>}
    */
-  static async getPrimaryUrl(recipe, size = '400x400') {
+  static async getPrimaryUrl(recipe, size = '400x400', options = {}) {
     const primary = getPrimaryImage(recipe);
     if (!primary) return null;
-    return RecipeImageService.getOptimizedUrl(primary, size);
+    return RecipeImageService.getOptimizedUrl(primary, size, options);
   }
 
   /**

--- a/src/js/services/recipes/recipe-image-service.js
+++ b/src/js/services/recipes/recipe-image-service.js
@@ -118,10 +118,12 @@ export class RecipeImageService {
     await StorageService.uploadFile(blob, originalPath);
 
     await Promise.all([
-      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp')).catch(() => {}), // silent: best-effort WebP variant cleanup
-      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp')).catch(
-        () => {}, // silent: best-effort WebP variant cleanup
-      ),
+      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_400x400.webp'), {
+        quietOn404: true,
+      }).catch(() => {}), // silent: best-effort WebP variant cleanup
+      StorageService.deleteFile(originalPath.replace(/\.[^.]+$/, '_1080x1080.webp'), {
+        quietOn404: true,
+      }).catch(() => {}), // silent: best-effort WebP variant cleanup
     ]);
 
     return { backupPath, backupCreated };
@@ -150,11 +152,11 @@ export class RecipeImageService {
     const originalOpt1080 = originalBackup.replace(/\.[^.]+$/, '_1080x1080.webp');
     await StorageService.deleteFile(full);
     await Promise.all([
-      StorageService.deleteFile(optimized400).catch(() => {}), // silent: best-effort WebP variant cleanup
-      StorageService.deleteFile(optimized1080).catch(() => {}), // silent: best-effort WebP variant cleanup
-      StorageService.deleteFile(originalBackup).catch(() => {}), // silent: best-effort backup cleanup; may not exist
-      StorageService.deleteFile(originalOpt400).catch(() => {}), // silent: best-effort backup variant cleanup
-      StorageService.deleteFile(originalOpt1080).catch(() => {}), // silent: best-effort backup variant cleanup
+      StorageService.deleteFile(optimized400, { quietOn404: true }).catch(() => {}), // silent: best-effort WebP variant cleanup
+      StorageService.deleteFile(optimized1080, { quietOn404: true }).catch(() => {}), // silent: best-effort WebP variant cleanup
+      StorageService.deleteFile(originalBackup, { quietOn404: true }).catch(() => {}), // silent: best-effort backup cleanup; may not exist
+      StorageService.deleteFile(originalOpt400, { quietOn404: true }).catch(() => {}), // silent: best-effort backup variant cleanup
+      StorageService.deleteFile(originalOpt1080, { quietOn404: true }).catch(() => {}), // silent: best-effort backup variant cleanup
     ]);
   }
 
@@ -199,8 +201,8 @@ export class RecipeImageService {
       const oldOpt400 = image.full.replace(/\.[^.]+$/, '_400x400.webp');
       const oldOpt1080 = image.full.replace(/\.[^.]+$/, '_1080x1080.webp');
       await Promise.all([
-        StorageService.deleteFile(oldOpt400).catch(() => {}), // silent: best-effort old WebP variant cleanup
-        StorageService.deleteFile(oldOpt1080).catch(() => {}), // silent: best-effort old WebP variant cleanup
+        StorageService.deleteFile(oldOpt400, { quietOn404: true }).catch(() => {}), // silent: best-effort old WebP variant cleanup
+        StorageService.deleteFile(oldOpt1080, { quietOn404: true }).catch(() => {}), // silent: best-effort old WebP variant cleanup
       ]);
 
       // The AI-enhancement `_original` backup is NOT auto-generated, so it must
@@ -212,19 +214,19 @@ export class RecipeImageService {
       const oldOriginalOpt400 = oldOriginal.replace(/\.[^.]+$/, '_400x400.webp');
       const oldOriginalOpt1080 = oldOriginal.replace(/\.[^.]+$/, '_1080x1080.webp');
       try {
-        const url = await StorageService.getFileUrl(oldOriginal);
+        const url = await StorageService.getFileUrl(oldOriginal, { quietOn404: true });
         const response = await fetch(url);
         if (response.ok) {
           const blob = await response.blob();
           await StorageService.uploadFile(blob, newOriginal);
-          await StorageService.deleteFile(oldOriginal).catch(() => {}); // silent: best-effort old backup cleanup
+          await StorageService.deleteFile(oldOriginal, { quietOn404: true }).catch(() => {}); // silent: best-effort old backup cleanup
         }
       } catch {
         // silent: no `_original` backup at the old path — nothing to migrate
       }
       await Promise.all([
-        StorageService.deleteFile(oldOriginalOpt400).catch(() => {}), // silent: best-effort old backup variant cleanup
-        StorageService.deleteFile(oldOriginalOpt1080).catch(() => {}), // silent: best-effort old backup variant cleanup
+        StorageService.deleteFile(oldOriginalOpt400, { quietOn404: true }).catch(() => {}), // silent: best-effort old backup variant cleanup
+        StorageService.deleteFile(oldOriginalOpt1080, { quietOn404: true }).catch(() => {}), // silent: best-effort old backup variant cleanup
       ]);
 
       return {

--- a/src/lib/modals/image-approval-multi/image-approval-multi.js
+++ b/src/lib/modals/image-approval-multi/image-approval-multi.js
@@ -311,7 +311,9 @@ class ImageApprovalMulti extends HTMLElement {
     // Load and add images
     for (const pendingImg of pendingImages) {
       try {
-        const previewUrl = await RecipeImageService.getOptimizedUrl(pendingImg, '400x400');
+        const previewUrl = await RecipeImageService.getOptimizedUrl(pendingImg, '400x400', {
+          quietOn404: true,
+        });
 
         // Add image to handler (observer will add selection controls automatically)
         imageHandler.addImage({

--- a/src/lib/recipes/recipe_form_component/recipe_form_component.js
+++ b/src/lib/recipes/recipe_form_component/recipe_form_component.js
@@ -507,7 +507,9 @@ class RecipeFormComponent extends HTMLElement {
 
     for (const image of images) {
       try {
-        const previewUrl = await RecipeImageService.getOptimizedUrl(image, '400x400');
+        const previewUrl = await RecipeImageService.getOptimizedUrl(image, '400x400', {
+          quietOn404: true,
+        });
         if (previewUrl) {
           // Spread the full image object so persistent fields (e.g. aiEnhanced)
           // survive the edit round-trip. Transient form fields are layered on top.

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -162,9 +162,11 @@ describe('RecipeImageService', () => {
 
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/img-1_400x400.webp',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/img-1_1080x1080.webp',
+        { quietOn404: true },
       );
     });
 
@@ -193,18 +195,23 @@ describe('RecipeImageService', () => {
       expect(storageMocks.deleteFile).toHaveBeenCalledWith('img/recipes/full/cat/rid/image.jpg');
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_400x400.webp',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_1080x1080.webp',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_original.jpg',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_original_400x400.webp',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_original_1080x1080.webp',
+        { quietOn404: true },
       );
     });
 
@@ -281,9 +288,11 @@ describe('RecipeImageService', () => {
 
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/keep_400x400.webp',
+        { quietOn404: true },
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/keep_1080x1080.webp',
+        { quietOn404: true },
       );
     });
 
@@ -304,6 +313,7 @@ describe('RecipeImageService', () => {
       );
       expect(storageMocks.deleteFile).toHaveBeenCalledWith(
         'img/recipes/full/desserts/recipe-9/keep_original.jpg',
+        { quietOn404: true },
       );
     });
 

--- a/tests/js/services/recipe-image-service.test.mjs
+++ b/tests/js/services/recipe-image-service.test.mjs
@@ -337,6 +337,7 @@ describe('RecipeImageService', () => {
       const result = await RecipeImageService.getOptimizedUrl(image, '400x400');
       expect(storageMocks.getFileUrl).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_400x400.webp',
+        { quietOn404: false },
       );
       expect(result).toBe('webp-url');
     });
@@ -373,6 +374,7 @@ describe('RecipeImageService', () => {
       await RecipeImageService.getOptimizedUrl(image, '1080x1080');
       expect(storageMocks.getFileUrl).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/image_1080x1080.webp',
+        { quietOn404: false },
       );
     });
 
@@ -381,6 +383,30 @@ describe('RecipeImageService', () => {
       const result = await RecipeImageService.getOptimizedUrl(image, '400x400');
       expect(result).toBe('blob:local-preview');
       expect(storageMocks.getFileUrl).not.toHaveBeenCalled();
+    });
+
+    it('forwards quietOn404 to the optimized lookup only — fallback to full stays loud (#189)', async () => {
+      storageMocks.getFileUrl
+        .mockRejectedValueOnce(
+          Object.assign(new Error('not found'), { code: 'storage/object-not-found' }),
+        )
+        .mockResolvedValueOnce('full-url');
+      const image = { id: '1', full: 'img/recipes/full/cat/rid/image.jpg' };
+      const result = await RecipeImageService.getOptimizedUrl(image, '400x400', {
+        quietOn404: true,
+      });
+      // First call: optimized path, with quietOn404 true (silences resize-lag noise)
+      expect(storageMocks.getFileUrl).toHaveBeenNthCalledWith(
+        1,
+        'img/recipes/full/cat/rid/image_400x400.webp',
+        { quietOn404: true },
+      );
+      // Second call: fallback to full original, with NO options — a miss here is a real bug
+      expect(storageMocks.getFileUrl).toHaveBeenNthCalledWith(
+        2,
+        'img/recipes/full/cat/rid/image.jpg',
+      );
+      expect(result).toBe('full-url');
     });
   });
 
@@ -393,6 +419,7 @@ describe('RecipeImageService', () => {
       await expect(RecipeImageService.getPrimaryUrl(recipe)).resolves.toBe('webp-url');
       expect(storageMocks.getFileUrl).toHaveBeenCalledWith(
         'img/recipes/full/cat/rid/img_400x400.webp',
+        { quietOn404: false },
       );
     });
 

--- a/tests/js/services/storage-service.test.mjs
+++ b/tests/js/services/storage-service.test.mjs
@@ -133,6 +133,36 @@ describe('StorageService', () => {
       await expect(StorageService.deleteFile(mockPath)).rejects.toThrow('Failed to delete file');
       errorSpy.mockRestore();
     });
+
+    it('with quietOn404: stays silent on storage/object-not-found (best-effort cleanups)', async () => {
+      const notFound = Object.assign(new Error('object not found'), {
+        code: 'storage/object-not-found',
+      });
+      deleteObject.mockRejectedValue(notFound);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.deleteFile(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to delete file',
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('with quietOn404: still logs non-404 delete errors (permission, etc.)', async () => {
+      const permDenied = Object.assign(new Error('forbidden'), {
+        code: 'storage/unauthorized',
+      });
+      deleteObject.mockRejectedValue(permDenied);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.deleteFile(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to delete file',
+      );
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
   });
 
   describe('listFiles', () => {

--- a/tests/js/services/storage-service.test.mjs
+++ b/tests/js/services/storage-service.test.mjs
@@ -73,6 +73,49 @@ describe('StorageService', () => {
       await expect(StorageService.getFileUrl(mockPath)).rejects.toThrow('Failed to get file URL');
       errorSpy.mockRestore();
     });
+
+    it('with quietOn404: stays silent on storage/object-not-found and still throws (#189)', async () => {
+      const notFound = Object.assign(new Error('object not found'), {
+        code: 'storage/object-not-found',
+      });
+      getDownloadURL.mockRejectedValue(notFound);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.getFileUrl(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to get file URL',
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('with quietOn404: still logs non-404 errors (permission, network, etc.)', async () => {
+      const permDenied = Object.assign(new Error('forbidden'), {
+        code: 'storage/unauthorized',
+      });
+      getDownloadURL.mockRejectedValue(permDenied);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.getFileUrl(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to get file URL',
+      );
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('without quietOn404: object-not-found still logs (default loud)', async () => {
+      const notFound = Object.assign(new Error('object not found'), {
+        code: 'storage/object-not-found',
+      });
+      getDownloadURL.mockRejectedValue(notFound);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.getFileUrl(mockPath)).rejects.toThrow('Failed to get file URL');
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
   });
 
   describe('deleteFile', () => {
@@ -136,6 +179,38 @@ describe('StorageService', () => {
       await expect(StorageService.getMetadata(mockPath)).rejects.toThrow(
         'Failed to get file metadata',
       );
+      errorSpy.mockRestore();
+    });
+
+    it('with quietOn404: stays silent on storage/object-not-found (existence probes)', async () => {
+      const getMetadata = (await import('firebase/storage')).getMetadata;
+      const notFound = Object.assign(new Error('object not found'), {
+        code: 'storage/object-not-found',
+      });
+      getMetadata.mockRejectedValue(notFound);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.getMetadata(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to get file metadata',
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it('with quietOn404: still logs non-404 metadata errors', async () => {
+      const getMetadata = (await import('firebase/storage')).getMetadata;
+      const permDenied = Object.assign(new Error('forbidden'), {
+        code: 'storage/unauthorized',
+      });
+      getMetadata.mockRejectedValue(permDenied);
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      await expect(StorageService.getMetadata(mockPath, { quietOn404: true })).rejects.toThrow(
+        'Failed to get file metadata',
+      );
+      expect(errorSpy).toHaveBeenCalled();
+
       errorSpy.mockRestore();
     });
   });


### PR DESCRIPTION
## Summary

Closes the console.error + Sentry noise from #189 across both paths where the noise was firing:

**1. Resize-extension lag window (read path)** — manager opens edit on a recipe with a freshly-uploaded image; the `_400x400.webp` variant hasn't been generated yet → 404 → `getFileUrl` logs + Sentry, even though the caller already falls back to `image.full`.

**2. Best-effort cleanup (delete + read paths)** — `migrateFilesToCategory`, `deleteFiles`, `replaceFiles` all do best-effort deletes of WebP variants and the `_original` AI-backup file. Many images don't have an `_original` backup at all; variants get regenerated by the extension on the new path. Every miss was logging + Sentry-capturing before the call-site `.catch(() => {})` could absorb it.

## Approach

Opt-in `quietOn404` option added to `StorageService.getFileUrl`, `getMetadata`, and `deleteFile`. When `true` AND `error.code === 'storage/object-not-found'`, the call skips `console.error` + Sentry `captureError` but still `throw`s so caller fallback chains keep working. Other error codes (permission, network, quota) stay loud everywhere.

Flag flipped on only at sites where the miss is explicitly expected:

| Site | Why expected |
|---|---|
| `recipe_form_component.populateImages` (edit form) | Just-uploaded image; optimized variant may still be resizing |
| `image-approval-multi` (pending-image approval) | Same — pending images are necessarily just-uploaded |
| `RecipeImageService.fileExists` probe | Treats `false` as expected by design |
| `migrateFilesToCategory` — `_original` lookup + best-effort variant/backup deletes | Most images carry no `_original`; variants regenerated at new path |
| `deleteFiles` — variant + backup deletes | Best-effort cleanup, may not exist |
| `replaceFiles` — old variant deletes | Best-effort, regenerated after re-upload |

All **primary-file** calls (`getFileUrl(image.full)`, `deleteFile(full)` for the main image, `recipe-card`, recipe-detail view, carousel, PDF, media-instructions, profile-image listing) keep default-loud behavior so a genuine "this should exist" miss still surfaces in Sentry.

## Test plan

- [x] `npm run lint` — clean (1 pre-existing warning unrelated)
- [x] `npm run test` — 551/551 pass, including 7 new tests:
  - `getFileUrl` with `quietOn404`: silent on 404, still logs other errors, default stays loud
  - `getMetadata` same shape
  - `deleteFile` same shape
  - `getOptimizedUrl` propagates only to first lookup; fallback to full stays loud
- [x] `npm run build` — clean
- [x] 100% statement coverage on `storage-service.js`
- [x] Playwright visual tests pass (pre-commit gate)

### Manual smoke (post-merge)

1. **Edit a freshly-uploaded recipe** within 30s → no `console.error` from `storage-service.js`, no new Sentry event for `service=storage, op=getFileUrl`. Browser's raw HTTP `404` in the network panel still appears (HTTP layer, can't suppress without intercepting requests — recommendation #3 in #189, deferred).
2. **Save a recipe with a category change** for an image without an `_original` backup → no `console.error` for the `_original` 404 or its variant cleanup 404s.
3. **Approve pending images** → same expectations.
4. **Negative check:** non-edit contexts (categories grid, recipe detail, carousel) still log + Sentry-capture if any optimized variant 404s — unchanged.

Fixes #189