### PR TITLE
feat(games): bake loading -> ready state into GameWrapper

### DIFF
--- a/src/lib/games/game_wrapper.css
+++ b/src/lib/games/game_wrapper.css
@@ -15,6 +15,102 @@
   /* Consistent rounded corners */
 }
 
+.game-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+}
+
+.game-status-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--ink-3, rgba(31, 29, 24, 0.55));
+  font-size: 13px;
+}
+
+.game-status-loading[hidden] {
+  display: none;
+}
+
+.game-status-ready {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.game-status-ready[hidden] {
+  display: none;
+}
+
+.game-loading-dots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.game-loading-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--primary, #6a994e);
+  animation: game-loading-bounce 1.2s ease-in-out infinite;
+}
+
+.game-loading-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.game-loading-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes game-loading-bounce {
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+
+.game-ready-icon {
+  font-size: 18px;
+}
+
+.game-ready-text {
+  color: var(--ink, #1f1d18);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.game-ready-btn {
+  border: none;
+  background: var(--primary, #6a994e);
+  color: white;
+  padding: 6px 14px;
+  border-radius: var(--r-pill, 999px);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    transform var(--dur-1, 160ms) var(--ease, ease),
+    box-shadow var(--dur-1, 160ms) var(--ease, ease);
+}
+
+.game-ready-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-1, 0 2px 4px rgba(0, 0, 0, 0.1));
+}
+
 .game-header {
   display: flex;
   justify-content: center;

--- a/src/lib/games/game_wrapper.js
+++ b/src/lib/games/game_wrapper.js
@@ -24,12 +24,12 @@ const REGISTRY = [
 export class GameWrapper {
   static random(container, overrides = {}) {
     const pick = REGISTRY[Math.floor(Math.random() * REGISTRY.length)];
-    const wrapper = new GameWrapper(container, pick.GameClass, {
+    return new GameWrapper(container, pick.GameClass, {
       ...pick.defaultConfig,
       ...overrides,
       successMessage: pick.successMessage,
+      loadingText: pick.loadingText,
     });
-    return { wrapper, loadingText: pick.loadingText };
   }
 
   constructor(container, GameClass, config = {}) {
@@ -40,6 +40,7 @@ export class GameWrapper {
     this.startTime = null;
     this.timerInterval = null;
     this.hasStarted = false;
+    this._asyncReadyShown = false;
   }
 
   init() {
@@ -53,17 +54,41 @@ export class GameWrapper {
       onGameOver: (reason) => this.onGameOver(reason),
     });
 
+    if (this._asyncReadyShown) this._applyAsyncReady();
+
     this.game.start();
   }
 
   renderWrapper() {
+    const { asyncReady, loadingText } = this.config;
+    const statusBlock = asyncReady
+      ? `
+        <div class="game-status">
+          <div class="game-status-loading">
+            <div class="game-loading-dots">
+              <div class="game-loading-dot"></div>
+              <div class="game-loading-dot"></div>
+              <div class="game-loading-dot"></div>
+            </div>
+            <span class="game-loading-text"></span>
+          </div>
+          <div class="game-status-ready" hidden>
+            <span class="game-ready-icon">✨</span>
+            <span class="game-ready-text"></span>
+            <button class="game-ready-btn"></button>
+          </div>
+        </div>
+      `
+      : '';
+
     this.container.innerHTML = `
       <div class="game-wrapper">
+        ${statusBlock}
         <div class="game-header">
           <div class="timer">⏱️ <span id="game-timer">00:00</span></div>
         </div>
         <div class="game-content"></div>
-        
+
         <div class="game-overlay" style="display: none;">
           <div class="overlay-content">
             <div class="overlay-icon">🏆</div>
@@ -76,8 +101,34 @@ export class GameWrapper {
       </div>
     `;
 
+    if (asyncReady) {
+      const loadingTextEl = this.container.querySelector('.game-loading-text');
+      const readyTextEl = this.container.querySelector('.game-ready-text');
+      const readyBtnEl = this.container.querySelector('.game-ready-btn');
+      if (loadingTextEl) loadingTextEl.textContent = loadingText || '';
+      if (readyTextEl) readyTextEl.textContent = asyncReady.text || '';
+      if (readyBtnEl) {
+        readyBtnEl.textContent = asyncReady.button || '';
+        if (typeof asyncReady.onDismiss === 'function') {
+          readyBtnEl.onclick = () => asyncReady.onDismiss();
+        }
+      }
+    }
+
     const btn = this.container.querySelector('.overlay-btn');
     if (btn) btn.onclick = () => this.restart();
+  }
+
+  markAsyncReady() {
+    this._asyncReadyShown = true;
+    this._applyAsyncReady();
+  }
+
+  _applyAsyncReady() {
+    const loadingRow = this.container.querySelector('.game-status-loading');
+    const readyRow = this.container.querySelector('.game-status-ready');
+    if (loadingRow) loadingRow.hidden = true;
+    if (readyRow) readyRow.hidden = false;
   }
 
   startTimer() {

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -225,39 +225,29 @@ class AiImageEnhanceModal extends HTMLElement {
     const compare = this.shadowRoot.querySelector('.compare');
     const advanced = this.shadowRoot.querySelector('.advanced');
     const actions = this.shadowRoot.querySelector('.actions');
-    const status = this.shadowRoot.querySelector('.loading-status-row');
-    const ready = this.shadowRoot.getElementById('enhance-ready');
     if (loadingView) loadingView.hidden = !isLoading;
     if (compare) compare.style.display = isLoading ? 'none' : '';
     if (advanced) advanced.style.display = isLoading ? 'none' : '';
     if (actions) actions.style.display = isLoading ? 'none' : '';
 
     if (isLoading) {
-      // Reset to "in progress" appearance — status row visible, ready overlay hidden.
-      if (status) status.style.display = '';
-      if (ready) ready.hidden = true;
       this._startGame();
     } else {
       this._destroyGame();
     }
   }
 
-  _showEnhanceReady() {
-    const status = this.shadowRoot.querySelector('.loading-status-row');
-    const ready = this.shadowRoot.getElementById('enhance-ready');
-    if (status) status.style.display = 'none';
-    if (ready) ready.hidden = false;
-  }
-
   _startGame() {
     const container = this.shadowRoot.getElementById('game-container');
-    const loadingTextEl = this.shadowRoot.getElementById('loading-text');
     if (!container || this._gameWrapper) return;
 
-    const { wrapper, loadingText } = GameWrapper.random(container);
-    this._gameWrapper = wrapper;
-    if (loadingTextEl) loadingTextEl.textContent = loadingText;
-
+    this._gameWrapper = GameWrapper.random(container, {
+      asyncReady: {
+        text: 'התמונה המשופרת מוכנה!',
+        button: 'צפה בתוצאה',
+        onDismiss: () => this._setEnhanceLoading(false),
+      },
+    });
     this._gameWrapper.init();
   }
 
@@ -431,8 +421,8 @@ class AiImageEnhanceModal extends HTMLElement {
       this._updatePaneHints();
       this._setStatus('התמונה שופרה. ניתן לשמור או לבטל.');
       // Keep the game alive — switch the loading row to a "ready" badge.
-      // The user dismisses it via "view-result-btn" when they want to leave the game.
-      this._showEnhanceReady();
+      // The user dismisses it via the wrapper's button when they want to leave the game.
+      this._gameWrapper?.markAsyncReady();
     } catch (error) {
       console.error('Image enhancement failed:', error);
       // Restore the placeholder so the after pane stops looking like it's loading.
@@ -559,9 +549,6 @@ class AiImageEnhanceModal extends HTMLElement {
     sr.getElementById('enhance-btn').addEventListener('click', () => this._enhance());
     sr.getElementById('save-btn').addEventListener('click', () => this._save());
     sr.getElementById('discard-btn').addEventListener('click', () => this._discard());
-    sr.getElementById('view-result-btn').addEventListener('click', () =>
-      this._setEnhanceLoading(false),
-    );
     sr.getElementById('before-pane').addEventListener('click', () => {
       if (this._beforeUrl) this._openViewer('before');
     });
@@ -851,58 +838,6 @@ class AiImageEnhanceModal extends HTMLElement {
           display: none;
         }
 
-        .loading-status-row {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 10px;
-          color: var(--ink-3, rgba(31, 29, 24, 0.55));
-          font-size: 13px;
-        }
-
-        .enhance-ready {
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          gap: 12px;
-          flex-wrap: wrap;
-        }
-
-        .enhance-ready[hidden] {
-          display: none;
-        }
-
-        .ready-icon {
-          font-size: 18px;
-        }
-
-        .ready-text {
-          color: var(--ink, #1f1d18);
-          font-size: 14px;
-          font-weight: 500;
-        }
-
-        .loading-dots {
-          display: inline-flex;
-          gap: 4px;
-        }
-
-        .loading-dot {
-          width: 6px;
-          height: 6px;
-          border-radius: 50%;
-          background: var(--primary, #6a994e);
-          animation: loading-bounce 1.2s ease-in-out infinite;
-        }
-
-        .loading-dot:nth-child(2) { animation-delay: 0.15s; }
-        .loading-dot:nth-child(3) { animation-delay: 0.3s; }
-
-        @keyframes loading-bounce {
-          0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
-          30% { transform: translateY(-4px); opacity: 1; }
-        }
-
         .game-container {
           width: 100%;
           max-width: 100%;
@@ -967,19 +902,6 @@ class AiImageEnhanceModal extends HTMLElement {
         </div>
 
         <div id="enhance-loading" class="enhance-loading" hidden>
-          <div class="loading-status-row">
-            <div class="loading-dots">
-              <div class="loading-dot"></div>
-              <div class="loading-dot"></div>
-              <div class="loading-dot"></div>
-            </div>
-            <span id="loading-text">זה עשוי לקחת מספר שניות... הנה משחק קטן בינתיים!</span>
-          </div>
-          <div id="enhance-ready" class="enhance-ready" hidden>
-            <span class="ready-icon">✨</span>
-            <span class="ready-text">התמונה המשופרת מוכנה!</span>
-            <button id="view-result-btn" class="action primary">צפה בתוצאה</button>
-          </div>
           <div id="game-container" class="game-container"></div>
         </div>
 

--- a/src/lib/recipes/recipe_import_modal/recipe_import_modal.css
+++ b/src/lib/recipes/recipe_import_modal/recipe_import_modal.css
@@ -328,52 +328,7 @@
   box-sizing: border-box;
 }
 
-.loading-status-row {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  justify-content: center;
-  width: 100%;
-}
-
-@keyframes bounce {
-  0%,
-  80%,
-  100% {
-    transform: scale(0);
-    opacity: 0.5;
-  }
-
-  40% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-.loading-dots {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.loading-dot {
-  width: 10px;
-  height: 10px;
-  background-color: var(--primary, #6a994e);
-  border-radius: 50%;
-  animation: bounce 1.4s infinite ease-in-out both;
-}
-
-.loading-dot:nth-child(1) {
-  animation-delay: -0.32s;
-}
-
-.loading-dot:nth-child(2) {
-  animation-delay: -0.16s;
-}
-
-/* ---- Error / success states ---- */
+/* ---- Error state ---- */
 
 .error-container {
   text-align: center;
@@ -434,27 +389,6 @@
   color: var(--secondary, #bc4749);
 }
 
-.success-overlay {
-  text-align: center;
-  animation: slideUp 0.5s ease;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-
-.success-badge {
-  background: transparent;
-  color: var(--primary-dark, #386641);
-  padding: 5px;
-  font-size: 1.3rem;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 /* ---- Footer buttons ---- */
 
 .modal-footer {
@@ -502,18 +436,6 @@
 }
 
 /* ---- Animations ---- */
-
-@keyframes slideUp {
-  from {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
 
 @keyframes slideDown {
   from {

--- a/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
+++ b/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
@@ -88,20 +88,6 @@ class RecipeImportModal extends HTMLElement {
 
             <!-- Loading State -->
             <div id="loading-view" class="loading-container" style="display: none;">
-              <div class="loading-status-row" id="loading-status">
-                 <div class="loading-dots">
-                    <div class="loading-dot"></div>
-                    <div class="loading-dot"></div>
-                    <div class="loading-dot"></div>
-                 </div>
-                 <p id="loading-text" style="margin: 0;">מנתח את המתכון... זה עשוי לקחת מספר שניות</p>
-              </div>
-              
-              <div id="success-overlay" class="success-overlay" style="display: none;">
-                  <div class="success-badge">המתכון מוכן!</div>
-                  <button class="btn btn-primary" id="view-recipe-btn">צפה במתכון</button>
-              </div>
-
               <!-- Inline Error (Non-blocking) -->
               <div id="inline-error-container" class="inline-error" style="display: none;">
                   <span id="inline-error-text">שגיאה</span>
@@ -218,10 +204,6 @@ class RecipeImportModal extends HTMLElement {
         this.extractRecipeFromUrl();
       }
     });
-
-    // View Recipe (Success State)
-    const viewRecipeBtn = this.shadowRoot.getElementById('view-recipe-btn');
-    viewRecipeBtn.addEventListener('click', () => this.finishImport());
 
     // Try Again
     tryAgainBtn.addEventListener('click', () => this.reset());
@@ -424,7 +406,6 @@ class RecipeImportModal extends HTMLElement {
       this.shadowRoot.getElementById('loading-view').style.display = 'none';
       this.shadowRoot.getElementById('error-view').style.display = 'none';
       this.shadowRoot.getElementById('url-view').style.display = 'none';
-      this.shadowRoot.getElementById('success-overlay').style.display = 'none';
       // Reset Inline Error
       this.shadowRoot.getElementById('inline-error-container').style.display = 'none';
 
@@ -445,13 +426,6 @@ class RecipeImportModal extends HTMLElement {
         tabImage.classList.add('active');
         tabUrl.classList.remove('active');
       }
-
-      // Reset loading state internals
-      const loadingStatus = this.shadowRoot.getElementById('loading-status');
-      if (loadingStatus) loadingStatus.style.display = 'flex';
-
-      this.shadowRoot.getElementById('loading-text').textContent =
-        'זה עשוי לקחת מספר שניות... הנה משחק קטן בינתיים!';
     }
   }
 
@@ -535,13 +509,16 @@ class RecipeImportModal extends HTMLElement {
 
       // Ensure inline error is hidden when starting new loading
       this.shadowRoot.getElementById('inline-error-container').style.display = 'none';
-      this.shadowRoot.getElementById('loading-status').style.display = 'flex';
 
       // Start Game Wrapper
       if (!this.gameWrapper && gameContainer) {
-        const { wrapper, loadingText } = GameWrapper.random(gameContainer);
-        this.gameWrapper = wrapper;
-        this.shadowRoot.getElementById('loading-text').textContent = loadingText;
+        this.gameWrapper = GameWrapper.random(gameContainer, {
+          asyncReady: {
+            text: 'המתכון מוכן!',
+            button: 'צפה במתכון',
+            onDismiss: () => this.finishImport(),
+          },
+        });
         this.gameWrapper.init();
       }
     } else {
@@ -563,7 +540,6 @@ class RecipeImportModal extends HTMLElement {
     // Non-blocking Inline Error Handling
     const inlineErrorContainer = this.shadowRoot.getElementById('inline-error-container');
     const inlineErrorText = this.shadowRoot.getElementById('inline-error-text');
-    const loadingStatus = this.shadowRoot.getElementById('loading-status');
     const loadingView = this.shadowRoot.getElementById('loading-view');
 
     // Determine if we're in URL or image mode
@@ -591,9 +567,7 @@ class RecipeImportModal extends HTMLElement {
       displayMessage = 'השירות אינו זמין כעת (404).';
     }
 
-    // Hide status, Show Error, KEEP GAME RUNNING
-    if (loadingStatus) loadingStatus.style.display = 'none';
-
+    // Show Error inline, KEEP GAME RUNNING
     if (inlineErrorContainer) {
       inlineErrorContainer.style.display = 'flex';
       inlineErrorText.textContent = displayMessage;
@@ -613,20 +587,7 @@ class RecipeImportModal extends HTMLElement {
 
   showSuccessState(data) {
     this.extractedData = data;
-
-    // Hide loading dots row
-    const loadingStatus = this.shadowRoot.getElementById('loading-status');
-    const loadingText = this.shadowRoot.getElementById('loading-text');
-    const successOverlay = this.shadowRoot.getElementById('success-overlay');
-
-    if (loadingStatus) loadingStatus.style.display = 'none';
-
-    // Optional: could reuse loadingText for success message, but we used overlay instead.
-    // We already have "Recipe Ready" in the badge.
-    // If we want to show text:
-    // loadingText.textContent = 'הניתוח הושלם! אתה יכול להמשיך לשחק או לצפות במתכון.';
-
-    successOverlay.style.display = 'flex';
+    this.gameWrapper?.markAsyncReady();
   }
 
   finishImport() {


### PR DESCRIPTION
## Summary

Both consumers (`ai-image-enhance-modal.js`, `recipe_import_modal.js`) had the same inline state machine: a "loading dots + text" row while the async task ran, swapped for a "done!" badge + dismiss button on success. Lift it into `GameWrapper` so callers only declare the ready-state copy and a dismiss callback.

## API

```js
const wrapper = GameWrapper.random(container, {
  asyncReady: {
    text: 'התמונה המשופרת מוכנה!',
    button: 'צפה בתוצאה',
    onDismiss: () => { /* caller cleanup */ },
  },
});
wrapper.init();
// ...async work resolves...
wrapper.markAsyncReady();
```

When `asyncReady` is omitted (e.g. the standalone games page from #265), no status row renders — game plays solo.

## Notable design choices

- **`random()` return shape change** — was `{ wrapper, loadingText }` (Phase 2), now just `wrapper`. The wrapper renders the per-game `loadingText` itself, so callers don't need it. Breaking, but only 2 callers exist and both are migrated in this PR.
- **`_asyncReadyShown` flag** preserves the ready state across `restart()` — if the user plays again after the badge has shown, the badge keeps showing on the new game.
- **CSS namespacing** — new classes are prefixed `.game-*` (`.game-status`, `.game-loading-dot`, `.game-ready-btn`, etc.) to avoid collision with consumer styles inside shadow DOM.
- **Visual unification** — recipe-import's previously larger success badge (1.3rem bold green text) is replaced by the more compact ai-image-enhance variant (✨ icon + 14px text + pill button). UX intent is preserved; pixel parity isn't.

## Changes

- `src/lib/games/game_wrapper.js` — `asyncReady` config, `markAsyncReady()`, render conditional status row, wire dismiss callback. Static `random()` signature simplified.
- `src/lib/games/game_wrapper.css` — new namespaced `.game-status*` styles + `@keyframes game-loading-bounce`.
- `src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js` — drop inline status-row HTML, drop `_showEnhanceReady()`, drop `view-result-btn` listener, replace its dismiss path with `asyncReady.onDismiss`. Drop ~50 lines of inline CSS.
- `src/lib/recipes/recipe_import_modal/recipe_import_modal.js` — drop `#loading-status` and `#success-overlay` HTML, drop `view-recipe-btn` listener, simplify `showSuccessState()` to one line, drop loading-text reset in `reset()`.
- `src/lib/recipes/recipe_import_modal/recipe_import_modal.css` — drop `.loading-dots`, `.loading-dot`, `.loading-status-row`, `@keyframes bounce`, `.success-overlay`, `.success-badge`, orphaned `@keyframes slideUp`.

**Net: +169 / −217 (48-line reduction).**

## Test plan

- [ ] **AI image enhance** — open modal, trigger enhance, see game start with loading-dots row + loading text. When enhancement completes, row swaps to ✨ + "התמונה המשופרת מוכנה!" + "צפה בתוצאה" button. Game keeps running. Click button → result revealed. Game completion/game-over/restart still work.
- [ ] **Recipe import (image + URL)** — same smoke flow, with "המתכון מוכן!" + "צפה במתכון". Inline error path during loading still works (game keeps running, error shows below).
- [ ] **Restart after async-ready** — start enhance, let game end via completion, async finishes during overlay, click "play again" — ready badge should be visible on the new game (state preserved).
- [x] `npm run lint` — 0 errors.
- [x] `npm run test` — 543/543 passing.
- [x] `npm run build` — green.
- [x] Pre-commit hook — all checks passed (including Playwright visual specs).

Fixes #264

Phase 3 of 3 for #263 mini-games umbrella. Closes out the original refactor scope; #265 (standalone games page) and #266 (more games) remain.