### PR TITLE
feat(auth): enable fullscreen-mobile for sign-in and user-profile modal

### DIFF
--- a/src/lib/auth/auth-controller.js
+++ b/src/lib/auth/auth-controller.js
@@ -51,7 +51,7 @@ class AuthController extends HTMLElement {
           display: contents;
         }
       </style>
-      <custom-modal height="auto" width="520px">
+      <custom-modal height="auto" width="520px" fullscreen-mobile>
         <slot></slot>
       </custom-modal>
     `;


### PR DESCRIPTION
## Summary
- Add `fullscreen-mobile` to the `<custom-modal>` in `auth-controller.js`.
- `auth-controller` already renders an `<custom-modal>` that hosts both the sign-in flow and the user-profile flow (auth-content swaps modes inside the same instance), so a single attribute covers both.
- `setAuthWidth` (520px) and `setProfileWidth` (640px) keep working on desktop; at ≤768px the `:host([fullscreen-mobile]) .modal-content` rule overrides width with higher CSS specificity, so dynamic width-switching is transparently neutralized on mobile.

Second of two sub-PRs against `feature/274-fullscreen-mobile-modals`. Once this is merged in, the umbrella PR will go feature → development with `Fixes #274`.

Refs #274

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 548/548 passing
- [ ] Manual smoke at ≤768px (DevTools mobile emulation):
  - [ ] Sign-in flow: tap sign-in trigger → modal edge-to-edge → switch sign-in ↔ sign-up tabs → forgot-password → back
  - [ ] User profile: tap avatar while signed-in → modal edge-to-edge → switch details / avatar / security tabs
  - [ ] Close via X and ESC both work
- [ ] Desktop (>768px): both flows look identical to before (centered, 520px / 640px)