### PR TITLE
feat(mobile): enable full screen for modals #274

### DIFF
--- a/src/lib/auth/auth-controller.js
+++ b/src/lib/auth/auth-controller.js
@@ -51,7 +51,7 @@ class AuthController extends HTMLElement {
           display: contents;
         }
       </style>
-      <custom-modal height="auto" width="520px">
+      <custom-modal height="auto" width="520px" fullscreen-mobile>
         <slot></slot>
       </custom-modal>
     `;

--- a/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
+++ b/src/lib/media/ai-image-enhancer/ai-image-enhance-modal.js
@@ -881,7 +881,7 @@ class AiImageEnhanceModal extends HTMLElement {
         }
       </style>
 
-      <custom-modal id="custom-modal" width="640px">
+      <custom-modal id="custom-modal" width="640px" fullscreen-mobile>
         <h2 id="modal-title" class="title"></h2>
 
         <div class="compare">

--- a/src/lib/media/image-proposal-modal/image-proposal-modal.js
+++ b/src/lib/media/image-proposal-modal/image-proposal-modal.js
@@ -125,7 +125,7 @@ class ImageProposalModal extends HTMLElement {
       </style>
 
       <loading-spinner overlay border-radius="10px" size="60px" color="#ffffff">
-        <custom-modal width="300px">
+        <custom-modal width="300px" fullscreen-mobile>
           <div class="proposal-modal">
             <div class="proposal-content">
               <div class="proposal-header">

--- a/src/lib/modals/image-approval-multi/image-approval-multi.js
+++ b/src/lib/modals/image-approval-multi/image-approval-multi.js
@@ -84,7 +84,7 @@ class ImageApprovalMulti extends HTMLElement {
     this.shadowRoot.innerHTML = `
       <style>${this.styles()}</style>
       <loading-spinner overlay border-radius="10px" size="60px" color="#ffffff">
-        <custom-modal width="90vw" height="auto">
+        <custom-modal width="90vw" height="auto" fullscreen-mobile>
           <div class="approval-container">
             <h2>אישור תמונות</h2>
 

--- a/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
+++ b/src/lib/recipes/recipe_import_modal/recipe_import_modal.js
@@ -41,7 +41,7 @@ class RecipeImportModal extends HTMLElement {
         ${styles}
         ${GAME_STYLES}
       </style>
-      <custom-modal id="import-modal" width="600px">
+      <custom-modal id="import-modal" width="600px" fullscreen-mobile>
           <div class="modal-body-content">
             <h2 class="modal-title">ייבא מתכון</h2>
 

--- a/src/lib/recipes/recipe_preview_modal/edit_preview_recipe.js
+++ b/src/lib/recipes/recipe_preview_modal/edit_preview_recipe.js
@@ -205,7 +205,7 @@ class EditPreviewRecipe extends HTMLElement {
     const isPreview = this.mode === 'preview';
     return `
       <div class="recipe-preview-modal">
-        <custom-modal height="90vh" width="60vw">
+        <custom-modal height="90vh" width="60vw" fullscreen-mobile>
           <div class="edit-modal-wrap">
             <div class="modal-body">
               ${

--- a/src/lib/recipes/recipe_preview_modal/recipe_preview_modal.js
+++ b/src/lib/recipes/recipe_preview_modal/recipe_preview_modal.js
@@ -156,7 +156,7 @@ class RecipePreviewModal extends HTMLElement {
   template() {
     return `
       <div class="recipe-preview-modal">
-        <custom-modal height="90vh" width="90vw">
+        <custom-modal height="90vh" width="90vw" fullscreen-mobile>
           <loading-spinner overlay border-radius="10px" style="z-index:1000; display:none;" id="modal-spinner"></loading-spinner>
           <div class="error-message"></div>
           <div class="modal-content">

--- a/src/lib/utilities/modal/modal.js
+++ b/src/lib/utilities/modal/modal.js
@@ -50,6 +50,9 @@
  * @attr {string} width - Sets the width of the modal.
  * @attr {string} height - Sets the height of the modal.
  * @attr {string} background-color - Sets the background color of the modal.
+ * @attr {boolean} fullscreen-mobile - When present, the modal renders edge-to-edge
+ *   (100vw x 100dvh, no border, no radius) at viewports ≤768px. Desktop layout
+ *   is unaffected.
  */
 
 export class Modal extends HTMLElement {
@@ -106,6 +109,25 @@ export class Modal extends HTMLElement {
         :host {
           --modal-outer-padding: 4px;
           --modal-max-width: 100vw;
+        }
+
+        :host([fullscreen-mobile]) {
+          --modal-outer-padding: 0;
+          --modal-max-width: 100vw;
+        }
+
+        :host([fullscreen-mobile]) .modal-content {
+          width: 100vw;
+          max-width: 100vw;
+          height: 100dvh;
+          max-height: 100dvh;
+          border: 0;
+          border-radius: 0;
+          transform: translateY(24px);
+        }
+
+        :host([fullscreen-mobile]) .modal.open .modal-content {
+          transform: none;
         }
       }
 

--- a/tests/lib/utilities/modal.test.js
+++ b/tests/lib/utilities/modal.test.js
@@ -1,0 +1,45 @@
+import 'src/lib/utilities/modal/modal.js';
+
+describe('custom-modal', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('element registers and attaches a shadow root', () => {
+    const el = document.createElement('custom-modal');
+    document.body.appendChild(el);
+    expect(el).toBeInstanceOf(HTMLElement);
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  test('without fullscreen-mobile attribute, host has no such attribute', () => {
+    const el = document.createElement('custom-modal');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('fullscreen-mobile')).toBe(false);
+  });
+
+  test('fullscreen-mobile attribute is exposed on the host', () => {
+    const el = document.createElement('custom-modal');
+    el.setAttribute('fullscreen-mobile', '');
+    document.body.appendChild(el);
+    expect(el.hasAttribute('fullscreen-mobile')).toBe(true);
+  });
+
+  test('shadow root styles contain the :host([fullscreen-mobile]) rule inside the mobile media query', () => {
+    const el = document.createElement('custom-modal');
+    document.body.appendChild(el);
+    const css = el.shadowRoot.querySelector('style').textContent;
+    expect(css).toMatch(/@media \(max-width:\s*768px\)/);
+    expect(css).toMatch(/:host\(\[fullscreen-mobile\]\)\s*\.modal-content/);
+    expect(css).toMatch(/100dvh/);
+  });
+
+  test('open() and close() toggle isOpen', async () => {
+    const el = document.createElement('custom-modal');
+    document.body.appendChild(el);
+    el.open();
+    expect(el.isOpen).toBe(true);
+    await el.close();
+    expect(el.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Enables an edge-to-edge full-screen experience for content-rich modals on mobile (≤768px). Desktop layout is unaffected.

- Adds an opt-in `fullscreen-mobile` boolean attribute to the shared `<custom-modal>` base (`src/lib/utilities/modal/modal.js`). When present, the modal renders `100vw × 100dvh` with no border, no border-radius, and no backdrop padding at ≤768px.
- Pure-CSS implementation via `:host([fullscreen-mobile])` inside the existing `@media (max-width: 768px)` block; no `observedAttributes` needed.
- Applies the attribute to seven content-rich modals + the auth modal:
  - Recipe preview (`recipe_preview_modal`)
  - Edit recipe (`edit_preview_recipe`)
  - Recipe import (`recipe_import_modal`)
  - AI image enhance (`ai-image-enhance-modal`)
  - Image proposal (`image-proposal-modal`)
  - Image approval multi (`image-approval-multi`)
  - Auth: sign-in + user profile (`auth-controller`)
- Intentionally **skipped** (kept centered): `confirmation_modal`, `message-modal`, `filter_modal` — error/success/tight-action surfaces don't benefit from fullscreen.
- Adds unit tests for `<custom-modal>` covering attribute reflection and the presence of the mobile CSS rules.

### Sub-PRs merged into this feature branch
- #287 — `feat(modal): add fullscreen-mobile attribute to shared modal base`
- #289 — `feat(auth): enable fullscreen-mobile for sign-in and user-profile modal`

Fixes #274

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 548/548 passing (5 new cases for `<custom-modal>`)
- [x] `npm run build` — clean
- [ ] Manual smoke at ≤768px (DevTools mobile emulation): each affected modal opens edge-to-edge
  - [ ] Recipe import (`/dashboard`)
  - [ ] Recipe preview (open a recipe card)
  - [ ] Edit preview (preview → edit)
  - [ ] AI image enhance (recipe form)
  - [ ] Image proposal (propose-images flow)
  - [ ] Image approval multi (dashboard queue)
  - [ ] Sign-in flow (sign-in / sign-up / forgot-password)
  - [ ] User profile (details / avatar / security tabs)
- [ ] At ≤768px, confirm confirmation, message, and filter modals stay **centered** (not fullscreen)
- [ ] Close via X and ESC works for every fullscreen modal
- [ ] Desktop (>768px): all modals look identical to before