### PR TITLE
refactor(app-drawer): own backdrop styles; migrate my-meal drawer

### DIFF
--- a/src/app/pages/my-meal-page.html
+++ b/src/app/pages/my-meal-page.html
@@ -29,7 +29,12 @@
     </div>
   </div>
 
-  <div id="ingredients-drawer" class="ingredients-drawer">
+  <app-drawer
+    id="ingredients-drawer"
+    drawer-class="ingredients-drawer"
+    active-class="open"
+    position="end"
+  >
     <div class="drawer-header">
       <h2>רשימת מצרכים</h2>
       <div class="header-actions">
@@ -98,7 +103,6 @@
     <div id="ingredients-list-container" class="ingredients-list-container">
       <!-- Ingredients list will be populated here -->
     </div>
-  </div>
-  <div id="drawer-backdrop" class="drawer-backdrop"></div>
+  </app-drawer>
   <confirmation-modal id="confirmation-modal"></confirmation-modal>
 </div>

--- a/src/app/pages/my-meal-page.js
+++ b/src/app/pages/my-meal-page.js
@@ -9,6 +9,7 @@ import {
 import { AppConfig } from '../../js/config/app-config.js';
 import { icons } from '../../js/icons.js';
 import '../../lib/modals/confirmation_modal/confirmation_modal.js';
+import '../../lib/utilities/app-drawer/app-drawer.js';
 import '../../styles/pages/my-meal-page.css';
 
 export default {
@@ -35,7 +36,6 @@ export default {
       meal: null,
       recipes: {}, // Cache for recipe data
       activeTabId: null,
-      drawerOpen: false,
       ingredientsView: 'all', // 'all' or 'current'
       unselectedIngredients: new Set(),
     };
@@ -138,7 +138,7 @@ export default {
     }
 
     // Update ingredients list if drawer is open
-    if (this.state.drawerOpen) {
+    if (this.drawer && this.drawer.isOpen) {
       this.renderIngredientsList();
     }
   },
@@ -285,7 +285,7 @@ export default {
 
     component.addEventListener('servings-changed', (e) => {
       this.updateRecipeState(recipeId, { servings: e.detail.servings });
-      if (this.state.drawerOpen) this.renderIngredientsList();
+      if (this.drawer && this.drawer.isOpen) this.renderIngredientsList();
     });
 
     container.appendChild(component);
@@ -327,7 +327,7 @@ export default {
 
   setupIngredientsDrawer() {
     const drawer = this.container.querySelector('#ingredients-drawer');
-    const backdrop = this.container.querySelector('#drawer-backdrop');
+    this.drawer = drawer;
     const toggleBtn = this.container.querySelector('#toggle-ingredients-btn');
     const closeBtn = this.container.querySelector('#close-drawer-btn');
     const viewAllBtn = this.container.querySelector('#view-all-ingredients');
@@ -343,17 +343,7 @@ export default {
       shareBtn.classList.remove('hidden');
     }
 
-    const toggleDrawer = () => {
-      this.state.drawerOpen = !this.state.drawerOpen;
-      if (this.state.drawerOpen) {
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        this.renderIngredientsList();
-      } else {
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-      }
-    };
+    drawer.addEventListener('app-drawer-open', () => this.renderIngredientsList());
 
     const getIngredientsText = () => {
       const recipeIds =
@@ -444,9 +434,8 @@ export default {
       }
     });
 
-    toggleBtn.addEventListener('click', toggleDrawer);
-    closeBtn.addEventListener('click', toggleDrawer);
-    backdrop.addEventListener('click', toggleDrawer);
+    toggleBtn.addEventListener('click', () => drawer.toggle());
+    closeBtn.addEventListener('click', () => drawer.close());
 
     viewAllBtn.addEventListener('click', () => {
       this.state.ingredientsView = 'all';

--- a/src/lib/utilities/app-drawer/app-drawer.css
+++ b/src/lib/utilities/app-drawer/app-drawer.css
@@ -1,0 +1,16 @@
+.app-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 29, 24, 0.4);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  opacity: 0;
+  visibility: hidden;
+  transition: all var(--dur-3) var(--ease-out);
+  z-index: var(--z-backdrop);
+}
+
+.app-drawer-backdrop.app-drawer-backdrop--open {
+  opacity: 1;
+  visibility: visible;
+}

--- a/src/lib/utilities/app-drawer/app-drawer.js
+++ b/src/lib/utilities/app-drawer/app-drawer.js
@@ -1,3 +1,5 @@
+import './app-drawer.css';
+
 /**
  * App Drawer Component
  * @class
@@ -5,9 +7,14 @@
  *
  * @description
  * A reusable light-DOM drawer/sidebar element. It owns lifecycle (open/close,
- * scroll lock, backdrop, Escape key) but is "headless" w.r.t. styling — the
- * consumer supplies the class names applied to the drawer host, the backdrop,
- * and the active state, so that any existing CSS keeps working unchanged.
+ * scroll lock, backdrop, Escape key) and ships default backdrop styling. The
+ * consumer supplies class names for the drawer host and active state; the
+ * `backdrop-class` is optional and layers on top of the component default.
+ *
+ * The backdrop element always receives the base class `app-drawer-backdrop`
+ * and, when open, the state class `app-drawer-backdrop--open` (in addition
+ * to any consumer-supplied `backdrop-class` and `active-class`). Consumers
+ * that want a non-default backdrop appearance can target their own class.
  *
  * The backdrop is created as a sibling appended to <body> so the drawer's own
  * `overflow: hidden` cannot clip it.
@@ -61,6 +68,7 @@ class AppDrawer extends HTMLElement {
     }
 
     this._backdrop = document.createElement('div');
+    this._backdrop.classList.add('app-drawer-backdrop');
     const backdropClass = this.getAttribute('backdrop-class');
     if (backdropClass) {
       backdropClass
@@ -95,7 +103,7 @@ class AppDrawer extends HTMLElement {
     if (this.isOpen) return;
     const active = this._activeClass();
     this.classList.add(active);
-    if (this._backdrop) this._backdrop.classList.add(active);
+    if (this._backdrop) this._backdrop.classList.add(active, 'app-drawer-backdrop--open');
 
     if (this._boolAttr('lock-scroll', true)) {
       document.body.style.overflow = 'hidden';
@@ -110,7 +118,7 @@ class AppDrawer extends HTMLElement {
     if (!this.isOpen) return;
     const active = this._activeClass();
     this.classList.remove(active);
-    if (this._backdrop) this._backdrop.classList.remove(active);
+    if (this._backdrop) this._backdrop.classList.remove(active, 'app-drawer-backdrop--open');
 
     if (this._lockedScroll) {
       document.body.style.overflow = '';

--- a/src/styles/components/header.css
+++ b/src/styles/components/header.css
@@ -631,26 +631,7 @@ header .hamburger::after {
     gap: 10px;
   }
 
-  /* Backdrop */
-  .mobile-nav-backdrop {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background: rgba(31, 29, 24, 0.4);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    opacity: 0;
-    visibility: hidden;
-    transition: all var(--dur-3) var(--ease-out);
-    z-index: var(--z-backdrop);
-  }
-
-  .mobile-nav-backdrop.active {
-    opacity: 1;
-    visibility: visible;
-  }
+  /* Backdrop styles are provided by <app-drawer> (app-drawer.css). */
 }
 
 /*------------------------------------*\

--- a/src/styles/components/pdf-toc-drawer.css
+++ b/src/styles/components/pdf-toc-drawer.css
@@ -1,12 +1,8 @@
 /* PDF viewer table-of-contents drawer (mobile only). The <app-drawer>
-   host gets the .pdf-toc-drawer class via its drawer-class attribute,
-   and the backdrop sibling gets .pdf-toc-drawer__backdrop. */
+   host gets the .pdf-toc-drawer class via its drawer-class attribute.
+   Backdrop styling is provided by <app-drawer> (app-drawer.css). */
 
 .pdf-toc-drawer {
-  display: none;
-}
-
-.pdf-toc-drawer__backdrop {
   display: none;
 }
 
@@ -30,24 +26,6 @@
 
   .pdf-toc-drawer.active {
     transform: translate3d(0, 0, 0);
-  }
-
-  .pdf-toc-drawer__backdrop {
-    display: block;
-    position: fixed;
-    inset: 0;
-    background: rgba(31, 29, 24, 0.4);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    opacity: 0;
-    visibility: hidden;
-    transition: all var(--dur-3, 520ms) var(--ease-out, cubic-bezier(0.16, 1, 0.3, 1));
-    z-index: var(--z-backdrop, 1010);
-  }
-
-  .pdf-toc-drawer__backdrop.active {
-    opacity: 1;
-    visibility: visible;
   }
 
   .pdf-toc-drawer__head {

--- a/src/styles/components/spa.css
+++ b/src/styles/components/spa.css
@@ -64,7 +64,7 @@ footer {
   align-items: center;
   justify-content: center;
   background: rgba(250, 246, 236, 0.9);
-  z-index: var(--z-modal);
+  z-index: var(--z-page-overlay);
   transition: opacity 0.15s ease;
 }
 

--- a/src/styles/pages/my-meal-page.css
+++ b/src/styles/pages/my-meal-page.css
@@ -154,7 +154,7 @@
   box-shadow: -4px 0 24px rgba(31, 29, 24, 0.12);
   z-index: var(--z-drawer);
   transform: translateX(100%);
-  transition: transform var(--dur-2, 260ms) var(--ease-out, ease);
+  transition: transform var(--dur-3) var(--ease-out);
   display: flex;
   flex-direction: column;
 }
@@ -458,22 +458,7 @@
   text-decoration: line-through;
 }
 
-/* ---- Drawer backdrop ---- */
-
-.spa-content .my-meal-page .drawer-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(31, 29, 24, 0.45);
-  z-index: var(--z-backdrop);
-  display: none;
-}
-
-.spa-content .my-meal-page .drawer-backdrop.open {
-  display: block;
-}
+/* Drawer backdrop styles are provided by <app-drawer> (app-drawer.css). */
 
 /* ---- Empty state ---- */
 


### PR DESCRIPTION
## Summary

- **Shared backdrop styles in `<app-drawer>`**: new `app-drawer.css` carries the backdrop appearance (position, blur, fade, z-index). Component auto-applies `app-drawer-backdrop` + `app-drawer-backdrop--open` alongside any consumer-supplied classes — defaults work out of the box, overrides still layer on top.
- **Dedupe**: deleted the now-redundant `.mobile-nav-backdrop` block (header.css) and the two `.pdf-toc-drawer__backdrop` blocks (pdf-toc-drawer.css). Both drawers pick up the component default with byte-equivalent output.
- **Migrate my-meal ingredients drawer to `<app-drawer>`**: drops the hand-rolled toggle/backdrop wiring + `drawerOpen` state. Gains ESC-to-close, body scroll lock, and focus return for free. Animation duration aligned to `--dur-3` to match nav/PDF.
- **Fix: page-loading spinner z-index** (`spa.css`): `.page-loading` was using `--z-modal` (2000), which incorrectly outranked `--z-drawer` (1020). Switched to `--z-page-overlay` (200) — the token named for exactly this case. Pre-existing bug, surfaced while verifying the drawer migration.

## Why

The my-meal page shipped its own drawer mechanics (state, backdrop, ESC handler not present, no scroll lock, no focus return) while two existing consumers already used `<app-drawer>`. The shared component is the right home for these defaults; migrating gets three a11y/UX wins for my-meal and removes three near-identical copies of the same backdrop CSS.

## Test plan

- [x] `npm run format` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing warning, unrelated)
- [x] `npm run test` — 543/543 pass, 29/29 suites
- [x] `npm run build` — succeeds
- [x] Playwright visual tests (via pre-commit hook) — pass
- [ ] **Manual smoke on mobile viewport:**
  - [ ] `/my-meal`: open drawer via ingredients button, close via X / backdrop click / ESC; body should not scroll while open; focus returns to the ingredients button on close
  - [ ] `/my-meal`: navigate to the page while drawer is open on another page (or trigger a slow load); the page-loading spinner should sit *behind* the drawer, not over it
  - [ ] Header: open mobile nav drawer, verify backdrop appearance unchanged (still uses default fade + blur)
  - [ ] `/grandmas-cooking` (PDF viewer): open TOC drawer on mobile, verify backdrop appearance unchanged