### PR TITLE
fix(games): knife — portrait recommendation + modal close-button isolation

### DIFF
--- a/src/lib/games/game_wrapper.css
+++ b/src/lib/games/game_wrapper.css
@@ -267,6 +267,10 @@
   height: 100%;
   flex: 1;
   justify-content: center;
+  /* Trap overlays painted inside the wrapper (rotate-prompt, game start
+     screen, win/lose overlay) so their z-index can't escape and cover the
+     modal's close button. */
+  isolation: isolate;
 }
 
 #games-page-modal .game-wrapper .game-content {

--- a/src/lib/games/game_wrapper.js
+++ b/src/lib/games/game_wrapper.js
@@ -59,6 +59,8 @@ const REGISTRY = [
     defaultConfig: { toSlice: 30, maxStrikes: 3 },
     successMessage: 'כל הכבוד! חיתוך מושלם',
     loadingText: 'משחיזים את הסכינים... חכה רגע!',
+    // Fruits arc up from the bottom — recommend portrait on phones.
+    preferredOrientation: 'portrait',
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds `preferredOrientation: 'portrait'` to the knife registry entry so the rotate-prompt overlay asks landscape-phone users to rotate, matching burger.
- Adds `isolation: isolate` to `#games-page-modal .game-wrapper` so in-wrapper overlays (rotate-prompt, start screen, win/lose) stack within the wrapper and can't paint over the modal's close button.

These two commits were made after PR #297's head was last pushed, so they didn't make it into the #297 squash on development. This PR backfills them.

Refs #266.

## Test plan
- [ ] On a landscape phone (DevTools 740×360 works), open /games → אמנות הסכין → rotate-prompt overlay appears with "סובב את המסך לאורך"
- [ ] Modal × is clickable in landscape (not covered by the rotate-prompt or the start screen)
- [ ] Rotate to portrait → prompt hides, game plays normally
- [ ] Other games (burger landscape rotate-prompt, pizza portrait rotate-prompt, memory) still behave the same