### PR TITLE
fix(router): localize router error message to Hebrew

### DIFF
--- a/src/app/core/page-manager.js
+++ b/src/app/core/page-manager.js
@@ -241,13 +241,13 @@ export class PageManager {
     console.error('Page load error:', error);
 
     this.contentContainer.innerHTML = `
-      <div class="page-error">
+      <div class="page-error" dir="rtl">
         <div class="error-card">
-          <h2>Page Load Error</h2>
-          <p>Sorry, there was an error loading this page.</p>
+          <h2>שגיאה בטעינת הדף</h2>
+          <p>אירעה שגיאה בטעינת הדף. אנא נסו שוב.</p>
           <div class="error-details" id="error-details"></div>
           <button class="reload-button" id="reload-button">
-            Reload Page
+            טען מחדש
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Translates the router/page-load error UI in `PageManager.handlePageLoadError` from English to Hebrew (heading, body, reload button)
- Adds `dir="rtl"` to the `.page-error` container so layout matches the rest of the Hebrew UI
- Raw `error.message` is still shown verbatim for debugging

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run format` (prettier check) — clean
- [x] `npm test` — 548/548 passed
- [x] Pre-commit hook (format + lint + tests + playwright + build) — all green
- [ ] Manual: trigger a route handler throw and confirm the Hebrew error UI renders RTL with the reload button still functional