### PR TITLE
Add live demo callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Hebrew recipe sharing application built to preserve and share family culinary traditions.
 
+> **Live demo:** [cookbook.roiguri.com](https://cookbook.roiguri.com)
+
 > **Project Context:**
 > This project represents my **first deep dive into full-stack web development**.
 > It was built with a deliberate educational goal: to master the fundamentals of web development (DOM manipulation, state management, routing) by building them from scratch using **Vanilla JavaScript** and **Web Components**, rather than relying on frameworks like React or Angular from the start.


### PR DESCRIPTION
Adds a single-line live demo blockquote immediately after the opening paragraph, so visitors see the clickable link to [cookbook.roiguri.com](https://cookbook.roiguri.com) before reading anything else — making it easy to try the app without scrolling.

No other content changes; the portfolio-style structure of the README is preserved.