### PR TITLE
refactor(recipe-import): extract reusable video-extraction core #294

### DIFF
--- a/functions/utils/gemini/extractors/_video-core.js
+++ b/functions/utils/gemini/extractors/_video-core.js
@@ -1,0 +1,82 @@
+const { createClient } = require('../client');
+const { RECIPE_SCHEMA, validateRecipeData } = require('../recipe-schema');
+
+const VIDEO_EXTRACTION_PROMPT = `Extract the complete recipe from this cooking video.
+
+The video may include:
+- Spoken narration describing ingredients, quantities, and steps (Hebrew or English).
+- On-screen text or graphics listing ingredients, measurements, or step titles.
+- Visual demonstration of technique (use it to infer steps that aren't spoken aloud).
+- Title/description metadata that may name the dish or list ingredients.
+
+CRITICAL RULES FOR STRUCTURE:
+1. SYNTHESIZE ACROSS SOURCES: Combine spoken audio, on-screen text, and visual cues into a single coherent recipe. Prefer on-screen quantities over guesses from visuals.
+2. ANALYZE STRUCTURE: Look for named sections (e.g. "For the sauce", "Preparation", "Baking") in either audio or on-screen text.
+3. FORCE SECTIONS: If named sections exist for ingredients, use 'ingredientSections' and set 'ingredients' to null.
+4. FORCE STAGES: If named sections exist for instructions, use 'stages' and set 'instructions' to null.
+5. EXCLUSIVITY: Never populate both flat lists and sections.
+
+REQUIRED METADATA (always populate):
+- category: Choose the BEST matching value from the enum based on the dish type.
+- difficulty: Assess complexity based on number of ingredients, steps, and techniques.
+- mainIngredient: Identify the primary/central ingredient (in Hebrew).
+
+Data Formatting:
+- Ingredients: Split into item, amount, unit. amount MUST be a number — convert fractions/mixed to decimals (½ → 0.5, ⅓ → 0.333, 1 ½ → 1.5). Use null when the video gives a range ("2-3"), "to taste", or no clear quantity; keep item/unit.
+- Instructions: Split into logical steps; one technique per step.
+- Language: Translate ALL text to Hebrew, regardless of the spoken language in the video.
+
+If the video does not contain a recognizable recipe (no ingredients OR no preparation steps), return a response with name set to null.`;
+
+/**
+ * Runs Gemini recipe extraction over a prepared video media part and returns
+ * the validated recipe data. Platform-agnostic: the caller supplies the media
+ * part — a `fileData` ref (e.g. a YouTube `fileUri` Gemini fetches itself) or
+ * `inlineData` bytes (e.g. an Instagram/TikTok reel we downloaded). The prompt,
+ * model, schema, validation, and error handling are shared across all sources.
+ *
+ * @param {Object} mediaPart - A Gemini content part: `{ fileData: { fileUri, mimeType } }`
+ *   or `{ inlineData: { data, mimeType } }`.
+ * @returns {Promise<Object>} The extracted, validated recipe data.
+ */
+async function extractRecipeFromVideoParts(mediaPart) {
+  const client = createClient();
+
+  try {
+    const response = await client.models.generateContent({
+      model: 'gemini-2.5-flash',
+      contents: [
+        {
+          parts: [mediaPart, { text: VIDEO_EXTRACTION_PROMPT }],
+        },
+      ],
+      config: {
+        responseMimeType: 'application/json',
+        responseSchema: RECIPE_SCHEMA,
+      },
+    });
+
+    const responseText = response.text;
+    if (!responseText) {
+      throw new Error('Could not extract valid recipe data - empty response from video');
+    }
+
+    const data = JSON.parse(responseText);
+
+    if (!validateRecipeData(data)) {
+      throw new Error(
+        'Could not extract valid recipe data from this video. The video may not contain a recipe, may be private, or may be unavailable.',
+      );
+    }
+
+    return data;
+  } catch (error) {
+    console.error('Error calling Gemini API for video:', error);
+    if (error.message && error.message.includes('Could not extract')) {
+      throw error;
+    }
+    throw new Error('Failed to extract recipe from video');
+  }
+}
+
+module.exports = { extractRecipeFromVideoParts, VIDEO_EXTRACTION_PROMPT };

--- a/functions/utils/gemini/extractors/youtube.js
+++ b/functions/utils/gemini/extractors/youtube.js
@@ -1,5 +1,4 @@
-const { createClient } = require('../client');
-const { RECIPE_SCHEMA, validateRecipeData } = require('../recipe-schema');
+const { extractRecipeFromVideoParts } = require('./_video-core');
 
 /**
  * Parses a YouTube URL into `{ videoId, normalizedUrl }`. Returns `null` for
@@ -37,37 +36,11 @@ function parseYouTubeUrl(input) {
   return { videoId, normalizedUrl: `https://www.youtube.com/watch?v=${videoId}` };
 }
 
-const VIDEO_EXTRACTION_PROMPT = `Extract the complete recipe from this cooking video.
-
-The video may include:
-- Spoken narration describing ingredients, quantities, and steps (Hebrew or English).
-- On-screen text or graphics listing ingredients, measurements, or step titles.
-- Visual demonstration of technique (use it to infer steps that aren't spoken aloud).
-- Title/description metadata that may name the dish or list ingredients.
-
-CRITICAL RULES FOR STRUCTURE:
-1. SYNTHESIZE ACROSS SOURCES: Combine spoken audio, on-screen text, and visual cues into a single coherent recipe. Prefer on-screen quantities over guesses from visuals.
-2. ANALYZE STRUCTURE: Look for named sections (e.g. "For the sauce", "Preparation", "Baking") in either audio or on-screen text.
-3. FORCE SECTIONS: If named sections exist for ingredients, use 'ingredientSections' and set 'ingredients' to null.
-4. FORCE STAGES: If named sections exist for instructions, use 'stages' and set 'instructions' to null.
-5. EXCLUSIVITY: Never populate both flat lists and sections.
-
-REQUIRED METADATA (always populate):
-- category: Choose the BEST matching value from the enum based on the dish type.
-- difficulty: Assess complexity based on number of ingredients, steps, and techniques.
-- mainIngredient: Identify the primary/central ingredient (in Hebrew).
-
-Data Formatting:
-- Ingredients: Split into item, amount, unit. amount MUST be a number — convert fractions/mixed to decimals (½ → 0.5, ⅓ → 0.333, 1 ½ → 1.5). Use null when the video gives a range ("2-3"), "to taste", or no clear quantity; keep item/unit.
-- Instructions: Split into logical steps; one technique per step.
-- Language: Translate ALL text to Hebrew, regardless of the spoken language in the video.
-
-If the video does not contain a recognizable recipe (no ingredients OR no preparation steps), return a response with name set to null.`;
-
 /**
- * Extracts recipe data from a YouTube video using Gemini's fileData input.
- * The model receives the video frames + audio + transcript; we ask for
- * structured JSON output against the shared RECIPE_SCHEMA.
+ * Extracts recipe data from a YouTube video. The normalized watch URL is handed
+ * to Gemini as a `fileData` ref — Gemini fetches and processes the video itself
+ * (frames + audio + transcript). The shared video core owns the prompt, schema,
+ * and validation.
  *
  * @param {string} url - A YouTube watch / Shorts / youtu.be URL.
  * @returns {Promise<Object>} The extracted recipe data.
@@ -78,46 +51,9 @@ async function extractRecipeFromVideo(url) {
     throw new Error('Could not extract: input is not a valid YouTube URL');
   }
 
-  const client = createClient();
-
-  try {
-    const response = await client.models.generateContent({
-      model: 'gemini-2.5-flash',
-      contents: [
-        {
-          parts: [
-            { fileData: { fileUri: parsed.normalizedUrl, mimeType: 'video/mp4' } },
-            { text: VIDEO_EXTRACTION_PROMPT },
-          ],
-        },
-      ],
-      config: {
-        responseMimeType: 'application/json',
-        responseSchema: RECIPE_SCHEMA,
-      },
-    });
-
-    const responseText = response.text;
-    if (!responseText) {
-      throw new Error('Could not extract valid recipe data - empty response from video');
-    }
-
-    const data = JSON.parse(responseText);
-
-    if (!validateRecipeData(data)) {
-      throw new Error(
-        'Could not extract valid recipe data from this video. The video may not contain a recipe, may be private, or may be unavailable.',
-      );
-    }
-
-    return data;
-  } catch (error) {
-    console.error('Error calling Gemini API for video:', error);
-    if (error.message && error.message.includes('Could not extract')) {
-      throw error;
-    }
-    throw new Error('Failed to extract recipe from video');
-  }
+  return extractRecipeFromVideoParts({
+    fileData: { fileUri: parsed.normalizedUrl, mimeType: 'video/mp4' },
+  });
 }
 
 module.exports = { extractRecipeFromVideo, parseYouTubeUrl };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -149,7 +149,11 @@ const config = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)', '**/?(*.)+(spec|test).mjs'],
+  testMatch: [
+    '**/?(*.)+(spec|test).[tj]s?(x)',
+    '**/?(*.)+(spec|test).mjs',
+    '**/?(*.)+(spec|test).cjs',
+  ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: [

--- a/tests/js/functions/video-extractor.test.cjs
+++ b/tests/js/functions/video-extractor.test.cjs
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for the YouTube extractor and the shared video-extraction
+ * core it delegates to. The Gemini SDK and the secret param are mocked so no
+ * network or real credential is needed — these lock the behavior that Part 2
+ * (Instagram) will reuse.
+ *
+ * Written as CommonJS (.cjs) because the code under test is CommonJS Cloud
+ * Functions code; classic `jest.mock` intercepts its `require()` chain and
+ * avoids loading the ESM-only `@google/genai` SDK at all.
+ */
+
+const mockGenerateContent = jest.fn();
+
+// `virtual` because these packages live in functions/node_modules and aren't
+// resolvable from the test's location — we never load the real modules anyway.
+jest.mock(
+  '@google/genai',
+  () => ({
+    GoogleGenAI: class {
+      constructor() {
+        this.models = { generateContent: mockGenerateContent };
+      }
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'firebase-functions/params',
+  () => ({
+    defineSecret: () => ({ value: () => 'test-key' }),
+  }),
+  { virtual: true },
+);
+
+const {
+  extractRecipeFromVideo,
+  parseYouTubeUrl,
+} = require('../../../functions/utils/gemini/extractors/youtube');
+
+const VALID_RECIPE = {
+  name: 'עוגת שוקולד',
+  ingredients: [{ item: 'קמח', amount: 2, unit: 'כוסות' }],
+  instructions: ['ערבבו את החומרים', 'אפו 30 דקות'],
+};
+
+beforeEach(() => {
+  // The validation-failure paths log via console.error; keep test output clean.
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('parseYouTubeUrl', () => {
+  it('normalizes watch / youtu.be / shorts URLs to a canonical watch URL', () => {
+    expect(parseYouTubeUrl('https://www.youtube.com/watch?v=abcdefghijk').normalizedUrl).toBe(
+      'https://www.youtube.com/watch?v=abcdefghijk',
+    );
+    expect(parseYouTubeUrl('https://youtu.be/abcdefghijk').videoId).toBe('abcdefghijk');
+    expect(parseYouTubeUrl('https://www.youtube.com/shorts/abcdefghijk').videoId).toBe(
+      'abcdefghijk',
+    );
+  });
+
+  it('rejects non-YouTube and malformed input', () => {
+    expect(parseYouTubeUrl('https://example.com/watch?v=abcdefghijk')).toBeNull();
+    expect(parseYouTubeUrl('not a url')).toBeNull();
+    expect(parseYouTubeUrl(null)).toBeNull();
+  });
+});
+
+describe('extractRecipeFromVideo', () => {
+  it('sends the normalized URL as a fileData part and returns validated data', async () => {
+    mockGenerateContent.mockResolvedValue({ text: JSON.stringify(VALID_RECIPE) });
+
+    const result = await extractRecipeFromVideo('https://youtu.be/abcdefghijk');
+
+    expect(result).toEqual(VALID_RECIPE);
+    const call = mockGenerateContent.mock.calls[0][0];
+    expect(call.model).toBe('gemini-2.5-flash');
+    const parts = call.contents[0].parts;
+    expect(parts[0]).toEqual({
+      fileData: { fileUri: 'https://www.youtube.com/watch?v=abcdefghijk', mimeType: 'video/mp4' },
+    });
+    expect(parts[1].text).toContain('Extract the complete recipe');
+    expect(call.config.responseMimeType).toBe('application/json');
+  });
+
+  it('throws on an invalid URL without calling Gemini', async () => {
+    await expect(extractRecipeFromVideo('https://example.com')).rejects.toThrow(
+      'not a valid YouTube URL',
+    );
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+  });
+
+  it('throws when the model returns an empty response', async () => {
+    mockGenerateContent.mockResolvedValue({ text: '' });
+    await expect(extractRecipeFromVideo('https://youtu.be/abcdefghijk')).rejects.toThrow(
+      'Could not extract',
+    );
+  });
+
+  it('throws when the model returns data without a recognizable recipe', async () => {
+    mockGenerateContent.mockResolvedValue({ text: JSON.stringify({ name: null }) });
+    await expect(extractRecipeFromVideo('https://youtu.be/abcdefghijk')).rejects.toThrow(
+      'Could not extract',
+    );
+  });
+});


### PR DESCRIPTION
## What

Part 1 of adding Instagram/TikTok support to recipe import: a pure, behavior-preserving refactor that extracts a **platform-agnostic video-extraction core** out of the YouTube-specific extractor, plus the first unit tests for the `functions/` extractors.

No user-facing behavior changes. YouTube import works exactly as before.

## Changes

- **New `functions/utils/gemini/extractors/_video-core.js`** — owns the shared `VIDEO_EXTRACTION_PROMPT`, the Gemini `generateContent` call, schema, validation, and error handling. Exposes `extractRecipeFromVideoParts(mediaPart)`, which accepts either a `fileData` ref (YouTube — Gemini fetches the video) **or** `inlineData` bytes (the Instagram/TikTok path coming in Part 2).
- **`functions/utils/gemini/extractors/youtube.js`** — slimmed to `parseYouTubeUrl` + a thin `extractRecipeFromVideo` that builds the `fileData` part and delegates. Public exports/signatures unchanged, so `gemini-service.js` and `functions/index.js` need no edits.
- **New `tests/js/functions/video-extractor.test.cjs`** — 6 regression tests (URL normalization/rejection, happy path asserting the exact part sent to Gemini, invalid URL, empty response, no-recipe). First tests to cover the `functions/` extractors.
- **`jest.config.mjs`** — added `.cjs` to `testMatch` so CommonJS Cloud Functions code can be tested with classic `jest.mock`, cleanly mocking the ESM-only `@google/genai` SDK without loading it.

## Verification

- New tests: 6/6 pass · ~97% coverage on the new core
- Full suite: 601/601 pass (38 suites), no regressions
- Lint: 0 errors · Build: ✓
- Pre-commit hook (format/eslint/tests/playwright/build): ✓

## Why this seam

Part 2 (Instagram) adds `parseInstagramUrl` + a `resolve(url) → bytes` adapter (yt-dlp in the Cloud Function first, swappable to a home server over Tailscale later), then calls `extractRecipeFromVideoParts({ inlineData })` — reusing everything proven here.

Relates to #294.